### PR TITLE
Install capistrano and add QA environment

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,0 +1,38 @@
+# Load DSL and set up stages
+require "capistrano/setup"
+
+# Include default deployment tasks
+require "capistrano/deploy"
+
+# Load the SCM plugin appropriate to your project:
+#
+# require "capistrano/scm/hg"
+# install_plugin Capistrano::SCM::Hg
+# or
+# require "capistrano/scm/svn"
+# install_plugin Capistrano::SCM::Svn
+# or
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
+
+# Include tasks from other gems included in your Gemfile
+#
+# For documentation on these, see for example:
+#
+#   https://github.com/capistrano/rvm
+#   https://github.com/capistrano/rbenv
+#   https://github.com/capistrano/chruby
+#   https://github.com/capistrano/bundler
+#   https://github.com/capistrano/rails
+#   https://github.com/capistrano/passenger
+#
+require "capistrano/bundler"
+require "capistrano/rvm"
+# require "capistrano/rbenv"
+# require "capistrano/chruby"
+require "capistrano/rails"
+# require "capistrano/passenger"
+require 'dlss/capistrano'
+
+# Load custom tasks from `lib/capistrano/tasks` if you have any defined
+Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,10 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 
+gem 'motion', github: 'unabridged/motion' #'~> 0.4.2'
+gem 'pg'
+gem 'view_component', '~> 2.18'
+
 group :development, :test do
   gem 'byebug'
   gem 'rspec-rails'
@@ -51,8 +55,9 @@ group :test do
   gem 'webdrivers'
 end
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
-
-gem 'motion', github: 'unabridged/motion' #'~> 0.4.2'
-gem 'view_component', '~> 2.18'
+group :deployment do
+  gem 'capistrano-passenger', require: false
+  gem 'capistrano-rails', require: false
+  gem 'capistrano-rvm', require: false
+  gem 'dlss-capistrano', '~> 3.6', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,11 +68,38 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
+    airbrussh (1.4.0)
+      sshkit (>= 1.6.1, != 1.7.0)
     bindex (0.8.1)
     bootsnap (1.4.8)
       msgpack (~> 1.0)
     builder (3.2.4)
+    bundler-audit (0.7.0.1)
+      bundler (>= 1.2.0, < 3)
+      thor (>= 0.18, < 2)
     byebug (11.1.3)
+    capistrano (3.14.1)
+      airbrussh (>= 1.0.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    capistrano-bundle_audit (0.3.0)
+      bundler-audit (~> 0.5)
+      capistrano (~> 3.0)
+      capistrano-bundler (~> 1.4)
+    capistrano-bundler (1.6.0)
+      capistrano (~> 3.1)
+    capistrano-one_time_key (0.1.0)
+      capistrano (~> 3.0)
+    capistrano-passenger (0.2.0)
+      capistrano (~> 3.0)
+    capistrano-rails (1.6.1)
+      capistrano (~> 3.1)
+      capistrano-bundler (>= 1.1, < 3)
+    capistrano-rvm (0.1.2)
+      capistrano (~> 3.0)
+      sshkit (~> 1.2)
+    capistrano-shared_configs (0.2.2)
     capybara (3.33.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -85,6 +112,11 @@ GEM
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     diff-lcs (1.4.4)
+    dlss-capistrano (3.9.0)
+      capistrano (~> 3.0)
+      capistrano-bundle_audit (>= 0.3.0)
+      capistrano-one_time_key
+      capistrano-shared_configs
     erubi (1.9.0)
     ffi (1.13.1)
     globalid (0.4.2)
@@ -110,12 +142,16 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.2)
     msgpack (1.3.3)
+    net-scp (3.0.0)
+      net-ssh (>= 2.6.5, < 7.0.0)
+    net-ssh (6.1.0)
     nio4r (2.5.3)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
+    pg (1.2.3)
     public_suffix (4.0.6)
     puma (4.3.6)
       nio4r (~> 2.0)
@@ -203,6 +239,9 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
+    sshkit (1.21.0)
+      net-scp (>= 1.1.2)
+      net-ssh (>= 2.8.0)
     thor (1.0.1)
     thread_safe (0.3.6)
     turbolinks (5.2.1)
@@ -240,10 +279,15 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
+  capistrano-passenger
+  capistrano-rails
+  capistrano-rvm
   capybara (>= 2.15)
+  dlss-capistrano (~> 3.6)
   jbuilder (~> 2.7)
   listen (~> 3.2)
   motion!
+  pg
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)
   rspec-rails
@@ -253,7 +297,6 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.4)
   turbolinks (~> 5)
-  tzinfo-data
   view_component (~> 2.18)
   web-console (>= 3.3.0)
   webdrivers

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,19 @@
-# SQLite. Versions 3.8.0 and up are supported.
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
+  database: "<%= ENV.fetch('DATABASE_NAME', 'h2') %>"
+  username: "<%= ENV.fetch('DATABASE_USERNAME', 'postgres') %>"
+  password: "<%= ENV.fetch('DATABASE_PASSWORD', 'postgres') %>"
+  host: "<%= ENV.fetch('DATABASE_HOSTNAME', 'localhost') %>"
+  port: "<%= ENV.fetch('DATABASE_PORT', 5432) %>"
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
 
 production:
   <<: *default
-  database: db/production.sqlite3

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,0 +1,45 @@
+set :application, "happy-heron"
+set :repo_url, 'ssh://git@github.com/sul-dlss/happy-heron.git'
+
+# Default branch is :master
+ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
+
+# Default deploy_to directory is /var/www/my_app_name
+set :deploy_to, "/opt/app/h2/#{fetch(:application)}"
+
+# Default value for :format is :airbrussh.
+# set :format, :airbrussh
+
+# You can configure the Airbrussh format using :format_options.
+# These are the defaults.
+# set :format_options, command_output: true, log_file: "log/capistrano.log", color: :auto, truncate: :auto
+
+# Default value for :log_level is :debug
+set :log_level, :info
+
+# Default value for :pty is false
+# set :pty, true
+
+# Default value for :linked_files is []
+append :linked_files, "config/database.yml", "config/secrets.yml"
+
+# Default value for linked_dirs is []
+append :linked_dirs, "log", "config/settings", "tmp/pids", "tmp/sockets", "public/system"
+
+# Default value for default_env is {}
+# set :default_env, { path: "/opt/ruby/bin:$PATH" }
+
+# Default value for local_user is ENV['USER']
+# set :local_user, -> { `git config user.name`.chomp }
+
+# Default value for keep_releases is 5
+# set :keep_releases, 5
+
+# Uncomment the following to require manually verifying the host key before first deploy.
+# set :ssh_options, verify_host_key: :secure
+
+# Set Rails env to production in all Cap environments
+set :rails_env, 'production'
+
+# update shared_configs before restarting app
+before 'deploy:restart', 'shared_configs:update'

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+server 'sul-h2-qa.stanford.edu', user: 'h2', roles: %w[web app db]
+
+Capistrano::OneTimeKey.generate_one_time_key!

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,11 +12,14 @@
 
 ActiveRecord::Schema.define(version: 2020_09_13_005756) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,10 +37,10 @@ ActiveRecord::Schema.define(version: 2020_09_13_005756) do
   end
 
   create_table "contributors", force: :cascade do |t|
-    t.integer "work_id", null: false
+    t.bigint "work_id", null: false
     t.string "first_name", null: false
     t.string "last_name", null: false
-    t.integer "role_term_id", null: false
+    t.bigint "role_term_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["role_term_id"], name: "index_contributors_on_role_term_id"
@@ -45,7 +48,7 @@ ActiveRecord::Schema.define(version: 2020_09_13_005756) do
   end
 
   create_table "related_links", force: :cascade do |t|
-    t.integer "work_id", null: false
+    t.bigint "work_id", null: false
     t.string "link_title"
     t.string "url", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -54,7 +57,7 @@ ActiveRecord::Schema.define(version: 2020_09_13_005756) do
   end
 
   create_table "related_works", force: :cascade do |t|
-    t.integer "work_id", null: false
+    t.bigint "work_id", null: false
     t.string "citation", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.6'
+
+services:
+  db:
+    image: postgres
+    environment:
+      POSTGRES_DB: h2
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+volumes:
+  postgres-data:


### PR DESCRIPTION
Connects to #6
Fixes #18 

## Why was this change made?

To install capistrano and begin testing passenger in standalone mode.

## How was this change tested?

It was deployed to QA.

## Which documentation and/or configurations were updated?

Shared_configs set up for QA.

