### PR TITLE
Buttons must be in a container or they will stretch the full row

### DIFF
--- a/app/components/buttons_component.html.erb
+++ b/app/components/buttons_component.html.erb
@@ -1,1 +1,3 @@
-<%= form.submit 'Save as draft', class: 'btn btn-primary' %>
+<div>
+  <%= form.submit 'Save as draft', class: 'btn btn-primary' %>
+</div>


### PR DESCRIPTION


## Why was this change made?
Before
<img width="1371" alt="Screen Shot 2020-09-22 at 3 33 29 PM" src="https://user-images.githubusercontent.com/92044/93934799-4ac18f00-fce9-11ea-933c-3d22f969d760.png">

After
<img width="1370" alt="Screen Shot 2020-09-22 at 3 33 39 PM" src="https://user-images.githubusercontent.com/92044/93934827-53b26080-fce9-11ea-9f4b-9b940d0e1cba.png">


## How was this change tested?



## Which documentation and/or configurations were updated?



