### PR TITLE
Add passenger configuration to application

### DIFF
--- a/Passengerfile.json
+++ b/Passengerfile.json
@@ -1,0 +1,11 @@
+{
+  "unlimited_concurrency_paths": ["/cable"],
+  "environment": "production",
+  "user": "h2",
+  "daemonize": true,
+  "pid_file": "/opt/app/h2/happy-heron/current/tmp/pids/passenger.3000.pid",
+  "log_file": "/opt/app/h2/happy-heron/current/log/passenger.3000.log",
+  "instance_registry_dir": "/var/run/passenger-instreg",
+  "address": "127.0.0.1",
+  "data_buffer_dir": "/var/run/passenger-instreg"
+}


### PR DESCRIPTION

## Why was this change made?

Currently, puppet creates and manages this file in the `/opt/app/h2/happy-heron/current/` directory, which is a symlink. So if you redeploy the application and puppet has not yet re-created Passengerfile.json, then you cannot restart Passenger since it depends on that configuration being present.

Note that the contents of this file are identical to what's in puppet now, so when puppet overwrites the file, it should have no effect on the running application or any restarts.

## How was this change tested?

QA

## Which documentation and/or configurations were updated?

Added Passenger configuration

