### PR TITLE
Simplify notifications table

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,6 +3,4 @@
 
 class Notification < ApplicationRecord
   belongs_to :user
-  belongs_to :recipient, class_name: 'User'
-  belongs_to :notifiable, polymorphic: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
             presence: true,
             uniqueness: { case_sensitive: false }
 
-  has_many :notifications, as: :recipient, dependent: :destroy
+  has_many :notifications, dependent: :destroy
 
   devise :remote_user_authenticatable
 end

--- a/db/migrate/20201013170323_simplify_columns_in_notifications.rb
+++ b/db/migrate/20201013170323_simplify_columns_in_notifications.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+class SimplifyColumnsInNotifications < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :notifications, :recipient_id, :integer
+    remove_column :notifications, :action, :text
+    remove_column :notifications, :notifiable_type, :string
+    remove_column :notifications, :notifiable_id, :integer
+
+    add_column :notifications, :opened_at, :datetime
+    add_column :notifications, :text, :string, null: false
+
+    add_index :notifications, :opened_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_09_194443) do
+ActiveRecord::Schema.define(version: 2020_10_13_170323) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,12 +68,11 @@ ActiveRecord::Schema.define(version: 2020_10_09_194443) do
 
   create_table "notifications", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.integer "recipient_id"
-    t.string "action"
-    t.string "notifiable_type"
-    t.integer "notifiable_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "opened_at"
+    t.string "text", null: false
+    t.index ["opened_at"], name: "index_notifications_on_opened_at"
     t.index ["user_id"], name: "index_notifications_on_user_id"
   end
 


### PR DESCRIPTION

## Why was this change made?

There were two deficiencies with the prior (copypasta) notifications table:

1. Without notification rows for a user, a user instance was not destroyable because notifiable_type was not defined;
2. We did not need the complexity in the prior table, specifically distinguishing between users and recipients, and also needing to support notifiable models.

I replaced these columns with two new ones: an `opened_at` date, which is `nil` by default, and will allow us to distinguish read from unread messages, and a `text` string to contain the notification message itself.


## How was this change tested?

CI and local testing in console

## Which documentation and/or configurations were updated?

none

