### PR TITLE
Correct typo in name of work created field

### DIFF
--- a/app/components/dates_component.html.erb
+++ b/app/components/dates_component.html.erb
@@ -1,9 +1,9 @@
 <section>
   <header>Date content was created</header>
   <div class="mb-3 row">
-    <%= form.label :created_etdf, 'Date created', class: 'col-sm-2 col-form-label' %>
+    <%= form.label :created_edtf, 'Date created', class: 'col-sm-2 col-form-label' %>
     <div class="col-sm-10">
-      <%= form.text_field :created_etdf, class: "form-control", required: true %>
+      <%= form.text_field :created_edtf, class: "form-control", required: true %>
     </div>
   </div>
 </section>

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -28,7 +28,7 @@ class WorksController < ApplicationController
 
   def work_params
     params.require(:work).permit(:title, :work_type, :subtype, :contact_email,
-                                 :created_etdf, :abstract, :citation, :access, :license, :agree_to_terms,
+                                 :created_edtf, :abstract, :citation, :access, :license, :agree_to_terms,
                                  files: [])
   end
 end

--- a/db/migrate/20201013170323_simplify_columns_in_notifications.rb
+++ b/db/migrate/20201013170323_simplify_columns_in_notifications.rb
@@ -1,5 +1,3 @@
-# typed: true
-
 class SimplifyColumnsInNotifications < ActiveRecord::Migration[6.0]
   def change
     remove_column :notifications, :recipient_id, :integer

--- a/db/migrate/20201014223440_rename_work_created_field.rb
+++ b/db/migrate/20201014223440_rename_work_created_field.rb
@@ -1,0 +1,5 @@
+class RenameWorkCreatedField < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :works, :created_etdf, :created_edtf
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_13_170323) do
+ActiveRecord::Schema.define(version: 2020_10_14_223440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -117,7 +117,7 @@ ActiveRecord::Schema.define(version: 2020_10_13_170323) do
     t.string "work_type", null: false
     t.string "subtype", null: false
     t.string "contact_email", null: false
-    t.string "created_etdf", null: false
+    t.string "created_edtf", null: false
     t.text "abstract", null: false
     t.string "citation", null: false
     t.string "access", null: false

--- a/sorbet/rails-rbi/models/work.rbi
+++ b/sorbet/rails-rbi/models/work.rbi
@@ -72,13 +72,13 @@ module Work::GeneratedAttributeMethods
   def created_at?; end
 
   sig { returns(String) }
-  def created_etdf; end
+  def created_edtf; end
 
   sig { params(value: T.any(String, Symbol)).void }
-  def created_etdf=(value); end
+  def created_edtf=(value); end
 
   sig { returns(T::Boolean) }
-  def created_etdf?; end
+  def created_edtf?; end
 
   sig { returns(T.nilable(String)) }
   def druid; end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     work_type { 'Book' }
     subtype { 'Non-fiction' }
     contact_email { 'io@io.io' }
-    created_etdf { '1900' }
+    created_edtf { '1900' }
     abstract { 'test abstract' }
     citation { 'test citation' }
     access { 'stanford' }

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Create a new work', js: true do
 
       expect(page).to have_content('title = My Title')
       expect(page).to have_content("contact_email = #{user.email}")
-      expect(page).to have_content('created_etdf = 01/01/2020')
+      expect(page).to have_content('created_edtf = 01/01/2020')
       expect(page).to have_content('abstract = Whatever')
       expect(page).to have_content('citation = Whatever')
       expect(page).to have_content('license = Copyleft')


### PR DESCRIPTION
Draft because I'd like https://github.com/sul-dlss/happy-heron/pull/135 merged first.

## Why was this change made?

`created_etdf` should be `created_edtf` (EDTF == extended date-time format).

## How was this change tested?

CI

## Which documentation and/or configurations were updated?

none

