### PR TITLE
.gitignore - add Gemfile.local and Gemfile.local.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ config/environments/*.local.yml
 
 # SimpleCov coverage artifacts
 /coverage
+
+# allow local gems
+/Gemfile.local
+/Gemfile.local.lock


### PR DESCRIPTION
## Why was this change made?

So Naomi can use pry locally and not drive Justin Coyne mad with pry being in the app everywhere.  He had the excellent suggestion of doing this:  https://github.com/gerrywastaken/Gemfile.local 

## How was this change tested?



## Which documentation and/or configurations were updated?



