### PR TITLE
Pass an empty structural data model so the object can be registered

### DIFF
--- a/app/jobs/deposit_job.rb
+++ b/app/jobs/deposit_job.rb
@@ -55,6 +55,9 @@ class DepositJob < ApplicationJob
       identification: {
         sourceId: "hydrus:#{work.id}" # TODO: what should this be?
       },
+      structural: {
+        contains: []
+      },
       label: work.title,
       type: Cocina::Models::Vocab.object, # TODO: use something based on worktype
       version: 0


### PR DESCRIPTION

## Why was this change made?

Fixes #166 
This avoids a bug in sdr-client: https://github.com/sul-dlss/sdr-client/issues/134


## How was this change tested?



## Which documentation and/or configurations were updated?



