### PR TITLE
spec_helper: default single spec file run to have doc output

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,16 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  # Many RSpec users commonly either run the entire suite or an individual
+  # file, and it's useful to allow more verbose output when running an
+  # individual spec file.
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = 'doc'
+  end
+
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
   #   # This allows you to limit a spec run to individual examples or groups
@@ -67,16 +77,6 @@ RSpec.configure do |config|
   #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
   #   config.disable_monkey_patching!
-  #
-  #   # Many RSpec users commonly either run the entire suite or an individual
-  #   # file, and it's useful to allow more verbose output when running an
-  #   # individual spec file.
-  #   if config.files_to_run.one?
-  #     # Use the documentation formatter for detailed output,
-  #     # unless a formatter has already been configured
-  #     # (e.g. via a command-line flag).
-  #     config.default_formatter = "doc"
-  #   end
   #
   #   # Print the 10 slowest examples and example groups at the
   #   # end of the spec run, to help surface which specs are running


### PR DESCRIPTION
## Why was this change made?

I find this kind of output super helpful when i'm working in a single spec file:

(except ... not the failures.  failures should never happen.  we're perfect coders.)

```
Coverage report generated for RSpec to /Users/ndushay/sul-dlss-github/happy-heron/coverage. 33 / 289 LOC (11.42%) covered.
SimpleCov failed with exit 1ndushay@m3dl-sm-03-mbph-3 happy-heron (main) $ bx rspec spec/requests/dashboard_request_spec.rb 

Dashboards
  shows links to create in a collection (FAILED - 1)
  when Settings.allow_sdr_content_changes is
    false
      displays allow_sdr_content_changes alert text (FAILED - 2)
    true
      does NOT display allow_sdr_content_changes alert text (FAILED - 3)

Failures:
```

## How was this change tested?



## Which documentation and/or configurations were updated?



