### PR TITLE
Additional db check for data loss

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,13 +1,39 @@
-# typed: strict
+# typed: true
 # frozen_string_literal: true
 
 OkComputer.mount_at = 'status'
 OkComputer.check_in_parallel = true
 
+class TablesHaveDataCheck < OkComputer::Check
+  extend T::Sig
+  sig { returns(String) }
+  def check
+    msg = [
+      Collection
+    ].map { |klass| table_check(klass) }.join(' ')
+    mark_message msg
+  end
+
+  private
+
+  def table_check(klass)
+    # has at least 1 record
+    return "#{klass.name} has data." if klass.any?
+
+    mark_failure
+    "#{klass.name} has no data."
+  rescue => e # rubocop:disable Style/RescueStandardError
+    mark_failure
+    "#{e.class.name} received: #{e.message}."
+  end
+end
+
 # Required
 OkComputer::Registry.register 'ruby_version', OkComputer::RubyVersionCheck.new
 
 OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: Settings.redis_url)
+
+OkComputer::Registry.register 'feature-tables-have-data', TablesHaveDataCheck.new
 
 # Optional
 OkComputer::Registry.register 'background_jobs', OkComputer::SidekiqLatencyCheck.new('default', 25)


### PR DESCRIPTION
## Why was this change made?

Ops wants to have a check for data loss

  I opted to switch from strict typing here b/c sorbet complained `any?` wasn't a method on a `Class`
  for the sig I tried to write: `sig { params(klass: Class) .returns(String)  }` and wasn't sure how to 
  wire it up properly.

## How was this change tested?

Deployed to stage, verified a failing test with no collections in the db.

## Which documentation and/or configurations were updated?

DevOpsDocs pending

