### PR TITLE
Make hydrus APO a setting

### DIFF
--- a/app/services/request_generator.rb
+++ b/app/services/request_generator.rb
@@ -24,7 +24,7 @@ class RequestGenerator
   def generate
     {
       administrative: {
-        hasAdminPolicy: 'druid:pq757cd0790' # TODO: What should this be? this is the hydrus APO.
+        hasAdminPolicy: Settings.h2.hydrus_apo
       },
       identification: {
         sourceId: "hydrus:#{work.id}" # TODO: what should this be?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,3 +13,6 @@ redis_url: redis://localhost:6379/
 remote_user_headers:
   - REMOTE_USER
   - HTTP_X_REMOTE_USER
+
+h2:
+  hydrus_apo: 'druid:zx485kb6348'

--- a/spec/services/request_generator_spec.rb
+++ b/spec/services/request_generator_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RequestGenerator do
       label: 'Test title',
       version: 0,
       administrative: {
-        hasAdminPolicy: 'druid:pq757cd0790'
+        hasAdminPolicy: 'druid:zx485kb6348'
       },
       description: {
         title: [


### PR DESCRIPTION
## Why was this change made?
To allow the hydrus APO to vary by environment.


## How was this change tested?
Unit.


## Which documentation and/or configurations were updated?
Updated stage and prod shared_configs.

Note: I created an APO in QA. I'm not sure if it matters, but I'm not positive that I got it completely right.


