### PR TITLE
Set extract_css: false

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -17,7 +17,7 @@ default: &default
   cache_manifest: false
 
   # Extract and emit a css file
-  extract_css: true
+  extract_css: false
 
   static_assets_extensions:
     - .jpg


### PR DESCRIPTION

## Why was this change made?
So that webpacker can find application.css

Avoids:
```
  4) Collections requests with authenticated user when collection fails to save renders the page again
     Failure/Error: <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>

     ActionView::Template::Error:
       Webpacker can't find application.css in /Users/jcoyne85/workspace/sul-dlss/happy-heron/public/packs-test/manifest.json. Possible causes:
       1. You want to set webpacker.yml value of compile to true for your environment
          unless you are using the `webpack -w` or the webpack-dev-server.
       2. webpack has not yet re-run to reflect updates.
       3. You have misconfigured Webpacker's config/webpacker.yml file.
       4. Your webpack configuration is not creating a manifest.
```


## How was this change tested?



## Which documentation and/or configurations were updated?



