### PR TITLE
Feature flag

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,4 +27,11 @@ class ApplicationController < ActionController::Base
     # :user is the scope we are authenticating
     store_location_for(:user, request.fullpath)
   end
+
+  def ensure_sdr_updatable
+    return if Settings.allow_sdr_content_changes
+
+    flash[:warning] = 'Creating/Updating SDR content (i.e. collections or works) is not yet available.'
+    redirect_to :root
+  end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -4,6 +4,7 @@
 # Handles CRUD for Collections
 class CollectionsController < ApplicationController
   before_action :authenticate_user!
+  before_action :ensure_sdr_updatable
   verify_authorized
 
   def new

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -3,6 +3,7 @@
 
 class WorksController < ApplicationController
   before_action :authenticate_user!, except: [:show]
+  before_action :ensure_sdr_updatable
 
   def new
     @collection = Collection.find(params[:collection_id])

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,7 +9,8 @@ require("@rails/activestorage").start()
 require("channels")
 import 'controllers'
 
-// import 'bootstrap'
+import 'popper.js'
+import 'bootstrap'
 require.context('../images', true)
 import 'stylesheets/main'
 

--- a/app/javascript/stylesheets/alert.scss
+++ b/app/javascript/stylesheets/alert.scss
@@ -1,0 +1,11 @@
+// Dismissible alerts
+
+// Expand the left padding and account for the close button's positioning.
+.alert-dismissible {
+  padding-left: $alert-dismissible-padding-r;
+
+  // Move alert button close link position to left
+  .btn-close {
+    left: 0;
+  }
+}

--- a/app/javascript/stylesheets/main.scss
+++ b/app/javascript/stylesheets/main.scss
@@ -18,3 +18,4 @@ $primary: $stanford-cardinal;
 
 @import 'editor';
 @import 'dashboard';
+@import 'alert';

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,6 +38,8 @@
       </nav>
     </header>
 
+    <%= render 'shared/flashes' %>
+
     <%= yield %>
 
     <footer class="stanford-footer p-3 p-md-5 mt-5 bg-light text-center text-sm-left">

--- a/app/views/shared/_flashes.html.erb
+++ b/app/views/shared/_flashes.html.erb
@@ -1,0 +1,34 @@
+<% if [flash[:success], flash[:notice], flash[:multi_line_notice], flash[:warning], flash[:error]].any? %>
+  <div class="flashes">
+    <% if flash[:success] %>
+      <div class="alert alert-success alert-dismissible" role="alert">
+        <button type="button" class="btn-close" data-dismiss="alert" aria-label="Close"></button>
+        <%= flash[:success] %>
+      </div>
+    <% end %>
+    <% if flash[:notice] %>
+      <div class="alert alert-info alert-dismissible" role="alert">
+        <button type="button" class="btn-close" data-dismiss="alert" aria-label="Close"></button>
+        <%= flash[:notice] %>
+      </div>
+    <% end %>
+    <% if flash[:multi_line_notice] %>
+      <div class="alert alert-info alert-dismissible" role="alert">
+        <button type="button" class="btn-close" data-dismiss="alert" aria-label="Close"></button>
+        <%= flash[:multi_line_notice].join("<br/>").html_safe %>
+      </div>
+    <% end %>
+    <% if flash[:warning] %>
+      <div class="alert alert-warning alert-dismissible" role="alert">
+        <button type="button" class="btn-close" data-dismiss="alert" aria-label="Close"></button>
+        <%= flash[:warning] %>
+      </div>
+    <% end %>
+    <% if flash[:error] %>
+      <div class="alert alert-danger alert-dismissible" role="alert">
+        <button type="button" class="btn-close" data-dismiss="alert" aria-label="Close"></button>
+        <%= flash[:error] %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,3 +16,6 @@ remote_user_headers:
 
 h2:
   hydrus_apo: 'druid:zx485kb6348'
+
+# feature flag
+allow_sdr_content_changes: false

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/webpacker": "5.2.1",
     "bootstrap": "^5.0.0-alpha1",
     "dropzone": "^5.7.2",
+    "popper.js": "^1.16.1",
     "stimulus": "^1.1.1",
     "turbolinks": "^5.2.0"
   },

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Create a new collection and deposit to it', js: true do
 
   before do
     sign_in user
+    allow(Settings).to receive(:allow_sdr_content_changes).and_return(true)
   end
 
   context 'when successful deposit' do

--- a/spec/features/user_return_location_spec.rb
+++ b/spec/features/user_return_location_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'User return location' do
 
   before do
     sign_in user
+    allow(Settings).to receive(:allow_sdr_content_changes).and_return(true)
   end
 
   context 'when in session' do

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Welcome page' do
   context 'when authenticated' do
     before do
       sign_in user
+      allow(Settings).to receive(:allow_sdr_content_changes).and_return(true)
     end
 
     it 'displays logout link' do

--- a/spec/requests/works_spec.rb
+++ b/spec/requests/works_spec.rb
@@ -5,6 +5,11 @@ require 'rails_helper'
 
 RSpec.describe 'Works requests' do
   let(:work) { create(:work) }
+  let(:collection) { create(:collection) }
+
+  before do
+    allow(Settings).to receive(:allow_sdr_content_changes).and_return(true)
+  end
 
   context 'with unauthenticated user' do
     before do
@@ -32,11 +37,30 @@ RSpec.describe 'Works requests' do
     end
 
     describe 'new work form' do
-      let(:collection) { create(:collection) }
-
       it 'renders the form' do
         get "/collections/#{collection.id}/works/new"
         expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when Settings.allow_sdr_content_changes is' do
+      let(:alert_text) { 'Creating/Updating SDR content (i.e. collections or works) is not yet available.' }
+
+      # rubocop:disable RSpec/ExampleLength
+      it 'false, it redirects and displays alert' do
+        allow(Settings).to receive(:allow_sdr_content_changes).and_return(false)
+        get "/collections/#{collection.id}/works/new"
+        expect(response).to redirect_to(:root)
+        follow_redirect!
+        expect(response).to be_successful
+        expect(response.body).to include alert_text
+      end
+      # rubocop:enable RSpec/ExampleLength
+
+      it 'true, it does NOT display alert' do
+        get "/collections/#{collection.id}/works/new"
+        expect(response).to be_successful
+        expect(response.body).not_to include alert_text
       end
     end
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -5188,6 +5188,11 @@ pnp-webpack-plugin@^1.6.4:
   dependencies:
     ts-pnp "^1.1.6"
 
+popper.js@^1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
+
 portfinder@^1.0.26:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"


### PR DESCRIPTION
## Why was this change made?

Fixes #103 

This feature flag will allow deployment to production early without risk to existing SDR content.  (Think:  before the PO has signed off)

Flag defaults to NOT ALLOWING content to be updated - this makes for more work in tests, but avoids possibly messing up in prod ...  I can reverse the default if desired.

If you try to create a collection or a work, you will be redirected to the dashboard with the alert message shown:

![image](https://user-images.githubusercontent.com/96775/96650612-045f5000-12e8-11eb-829b-1583c90ea81e.png)


^^ NOTE that the close button for the alert text is on the LEFT.  This is how the access team seems to do it, which is good if the window is wide and/or if the alert text is short.  The last commit is the simple stylesheet change I made for this.

## How was this change tested?

on my laptop and I also wrote some request specs for it.


## Which documentation and/or configurations were updated?



