### PR TITLE
Splits out checking deposit status into separate job.

### DIFF
--- a/app/jobs/base_deposit_job.rb
+++ b/app/jobs/base_deposit_job.rb
@@ -1,0 +1,21 @@
+# typed: false
+# frozen_string_literal: true
+
+# Base class for Deposit jobs.
+class BaseDepositJob < ApplicationJob
+  extend T::Sig
+
+  protected
+
+  # This allows a login using credentials from the config gem.
+  class LoginFromSettings
+    def self.run
+      { email: Settings.sdr_api.email, password: Settings.sdr_api.password }
+    end
+  end
+
+  sig { returns(Dry::Monads::Result) }
+  def login
+    SdrClient::Login.run(url: Settings.sdr_api.url, login_service: LoginFromSettings)
+  end
+end

--- a/app/jobs/deposit_status_job.rb
+++ b/app/jobs/deposit_status_job.rb
@@ -1,0 +1,46 @@
+# typed: false
+# frozen_string_literal: true
+
+# Wait for a deposit into SDR API.
+class DepositStatusJob < BaseDepositJob
+  queue_as :default
+
+  sig { params(work: Work, job_id: Integer).void }
+  def perform(work:, job_id:)
+    result = status(job_id: job_id)
+    # This will force a recheck of status.
+    raise "No result yet for job #{job_id}" if result.nil?
+
+    if result.success?
+      work.druid = result.value!
+      work.deposit!
+    else
+      Honeybadger.notify("Job #{job_id} for work #{work.id} failed with: #{result.failure}")
+    end
+  end
+
+  private
+
+  sig { params(job_id: Integer).returns(T.nilable(Dry::Monads::Result)) }
+  def status(job_id:)
+    login_result = login
+    return login_result unless login_result.success?
+
+    result = SdrClient::BackgroundJobResults.show(url: Settings.sdr_api.url, job_id: job_id)
+    if result[:status] != 'complete'
+      nil
+    elsif result[:output][:errors].present?
+
+      Dry::Monads::Failure(error_msg_for(result[:output][:errors]))
+    else
+      Dry::Monads::Success(result[:output][:druid])
+    end
+  end
+
+  def error_msg_for(errors)
+    error = errors.first
+    error_msg = error[:title]
+    error_msg += ": #{error[:message]}" if error[:message]
+    error_msg
+  end
+end

--- a/spec/jobs/deposit_status_job_spec.rb
+++ b/spec/jobs/deposit_status_job_spec.rb
@@ -1,0 +1,49 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DepositStatusJob do
+  include Dry::Monads[:result]
+
+  let(:client) { instance_double(Dor::Services::Client, objects: objects) }
+  let(:druid) { 'druid:bc123df4567' }
+  let(:work) { create(:work) }
+  let(:result) { Success() }
+  let(:job_id) { 1234 }
+
+  before do
+    allow(SdrClient::Login).to receive(:run).and_return(result)
+    allow(SdrClient::BackgroundJobResults).to receive(:show).and_return(background_result)
+    allow(Honeybadger).to receive(:notify)
+  end
+
+  context 'when the job is successful' do
+    let(:background_result) { { status: 'complete', output: { druid: druid } } }
+
+    it 'updates the work' do
+      described_class.perform_now(work: work, job_id: job_id)
+      expect(work.druid).to eq druid
+      expect(work.state_name).to eq :deposited
+    end
+  end
+
+  context 'when the job is not successful' do
+    let(:background_result) { { status: 'complete', output: { errors: [{ title: 'something went wrong' }] } } }
+
+    it 'notifies' do
+      described_class.perform_now(work: work, job_id: job_id)
+      expect(work.druid).to be_nil
+      expect(work.state_name).to eq :first_draft
+      expect(Honeybadger).to have_received(:notify)
+    end
+  end
+
+  context 'when the job is not completed' do
+    let(:background_result) { { status: 'incomplete' } }
+
+    it 'raises' do
+      expect { described_class.perform_now(work: work, job_id: job_id) }.to raise_error('No result yet for job 1234')
+    end
+  end
+end


### PR DESCRIPTION
closes #202

## Why was this change made?
* Avoid retrying failed deposits.
* Allow waiting for deposit to retry with backoff.

## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


