### PR TITLE
Add weekly update hook to regenerate and commit Sorbet signatures

### DIFF
--- a/.autoupdate/postupdate
+++ b/.autoupdate/postupdate
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This script runs as part of weekly dependency updates, making use of a new
+# hooks system to allow for app-specific update behavior without changing the
+# central auto-update infrastructure.
+#
+# See:
+# https://github.com/sul-dlss/access-update-scripts/blob/81d786378c37b547486e83d174dbbb7e3c93e277/autupdate.sh#L34
+
+bundle install
+SRB_YES=1 bundle exec srb rbi update
+bundle exec rake rails_rbi:all
+bundle exec srb rbi hidden-definitions
+bundle exec srb rbi suggest-typed
+git add sorbet && git commit -m 'Update type-checking signatures'


### PR DESCRIPTION
Connects to #231

## Why was this change made?

To automate type-checking updates as part of weekly dep updates.

## How was this change tested?

It wasn't.

## Which documentation and/or configurations were updated?

None

