### PR TITLE
Spin up docker-compose

### DIFF
--- a/.autoupdate/postupdate
+++ b/.autoupdate/postupdate
@@ -7,9 +7,13 @@
 # See:
 # https://github.com/sul-dlss/access-update-scripts/blob/81d786378c37b547486e83d174dbbb7e3c93e277/autupdate.sh#L34
 
-bundle install
-SRB_YES=1 bundle exec srb rbi update
-bundle exec rake rails_rbi:all
-bundle exec srb rbi hidden-definitions
-bundle exec srb rbi suggest-typed
+# Database service must be running and DB must be created to allow sorbet-rails to generate RBIs
+docker-compose up -d db
+bin/bundle install
+bin/rails db:setup
+SRB_YES=1 bin/bundle exec srb rbi update
+bin/bundle exec rake rails_rbi:all
+bin/bundle exec srb rbi hidden-definitions
+bin/bundle exec srb rbi suggest-typed
+docker-compose down
 git add sorbet && git commit -m 'Update type-checking signatures'


### PR DESCRIPTION
And use binstubs to ensure build is using the right binaries for the application.

## Why was this change made?

To automate RBI updates as part of weekly updates.

## How was this change tested?

sul-ci-prod

## Which documentation and/or configurations were updated?

none

