### PR TITLE
Configure new rubocop cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,6 +54,8 @@ Lint/EmptyFile: # (new in 0.90)
   Enabled: true
 Lint/FloatComparison: # (new in 0.89)
   Enabled: true
+Lint/HashCompareByIdentity: # (new in 0.93)
+  Enabled: true
 Lint/IdentityComparison: # (new in 0.91)
   Enabled: true
 Lint/MixedRegexpCaptureTypes: # (new in 0.85)
@@ -61,6 +63,8 @@ Lint/MixedRegexpCaptureTypes: # (new in 0.85)
 Lint/OutOfRangeRegexpRef: # (new in 0.89)
   Enabled: true
 Lint/RaiseException: # (new in 0.81)
+  Enabled: true
+Lint/RedundantSafeNavigation: # (new in 0.93)
   Enabled: true
 Lint/SelfAssignment: # (new in 0.89)
   Enabled: true
@@ -81,6 +85,8 @@ Style/AccessorGrouping: # (new in 0.87)
 Style/BisectedAttrAccessor: # (new in 0.87)
   Enabled: true
 Style/CaseLikeIf: # (new in 0.88)
+  Enabled: true
+Style/ClassEqualityComparison: # (new in 0.93)
   Enabled: true
 Style/CombinableLoops: # (new in 0.90)
   Enabled: true
@@ -174,3 +180,5 @@ Rails/WhereNot: # (new in 2.8)
   Enabled: true
 RSpec/MultipleExpectations:
   Enabled: false
+RSpec/StubbedMock: # (new in 1.44)
+  Enabled: true


### PR DESCRIPTION
## Why was this change made?
I don't like seeing warnings.


## How was this change tested?



## Which documentation and/or configurations were updated?



