### PR TITLE
Add additional options to embargo access form

### DIFF
--- a/app/components/works/embargo_component.html.erb
+++ b/app/components/works/embargo_component.html.erb
@@ -3,7 +3,7 @@
   <div class="mb-3 row">
     <%= form.label :access, 'Who can access?', class: 'col-sm-2 col-form-label' %>
     <div class="col-sm-10">
-      <%= form.select :access, ['stanford'], {}, class: "form-select" %>
+      <%= form.select :access, [['Select...', ''], ['Stanford Community', 'stanford'], ['Everyone', 'everyone']], {}, class: "form-select" %>
     </div>
   </div>
 </section>

--- a/app/components/works/embargo_component.html.erb
+++ b/app/components/works/embargo_component.html.erb
@@ -3,7 +3,7 @@
   <div class="mb-3 row">
     <%= form.label :access, 'Who can access?', class: 'col-sm-2 col-form-label' %>
     <div class="col-sm-10">
-      <%= form.select :access, [['Select...', ''], ['Stanford Community', 'stanford'], ['Everyone', 'everyone']], {}, class: "form-select" %>
+      <%= form.select :access, [['Select...', ''], ['Stanford Community', 'stanford'], ['Everyone', 'world']], {}, class: "form-select" %>
     </div>
   </div>
 </section>

--- a/app/components/works/embargo_component.html.erb
+++ b/app/components/works/embargo_component.html.erb
@@ -3,7 +3,7 @@
   <div class="mb-3 row">
     <%= form.label :access, 'Who can access?', class: 'col-sm-2 col-form-label' %>
     <div class="col-sm-10">
-      <%= form.select :access, [['Select...', ''], ['Stanford Community', 'stanford'], ['Everyone', 'world']], {}, class: "form-select" %>
+      <%= form.select :access, [['Stanford Community', 'stanford'], ['Everyone', 'world']], { selected: "", disabled: "", prompt: "Select..." }, class: "form-select" %>
     </div>
   </div>
 </section>


### PR DESCRIPTION

## Why was this change made?

Fixes #236 

Draft while I figure out testing and any relevant refactoring.

After:

<img width="1682" alt="Screen Shot 2020-10-28 at 4 11 27 PM" src="https://user-images.githubusercontent.com/2294288/97506518-592e4680-1938-11eb-8980-fa9a6614f3c7.png">

## How was this change tested?



## Which documentation and/or configurations were updated?



