### PR TITLE
Deconflate groups and users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,13 +13,11 @@ class ApplicationController < ActionController::Base
 
   rescue_from ActionPolicy::Unauthorized, with: :deny_access
 
-  sig { returns(T.nilable(User)) }
-  def current_user
-    super.tap do |cur_user|
-      break unless cur_user
+  authorize :user_with_groups
 
-      cur_user.groups = ldap_groups
-    end
+  sig { returns(T.nilable(UserWithGroups)) }
+  def user_with_groups
+    UserWithGroups.new(user: current_user, groups: ldap_groups) if current_user
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,25 +11,7 @@ class User < ApplicationRecord
 
   has_many :notifications, dependent: :destroy
 
-  sig { params(groups: T.nilable(T::Array[String])).returns(T.nilable(T::Array[String])) }
-  attr_writer :groups
-
   devise :remote_user_authenticatable
-
-  sig { returns(T::Boolean) }
-  def administrator?
-    groups.include?(Settings.authorization_workgroup_names.administrators)
-  end
-
-  sig { returns(T::Boolean) }
-  def collection_creator?
-    groups.include?(Settings.authorization_workgroup_names.collection_creators)
-  end
-
-  sig { returns(T::Array[String]) }
-  def groups
-    @groups || []
-  end
 
   sig { returns(String) }
   def to_s

--- a/app/models/user_with_groups.rb
+++ b/app/models/user_with_groups.rb
@@ -1,0 +1,29 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Represents a user and their groups
+class UserWithGroups
+  extend T::Sig
+
+  sig { params(user: User, groups: T::Array[String]).void }
+  def initialize(user:, groups:)
+    @user = user
+    @groups = groups
+  end
+
+  sig { returns(User) }
+  attr_reader :user
+
+  sig { returns(T::Array[String]) }
+  attr_reader :groups
+
+  sig { returns(T::Boolean) }
+  def administrator?
+    groups.include?(Settings.authorization_workgroup_names.administrators)
+  end
+
+  sig { returns(T::Boolean) }
+  def collection_creator?
+    groups.include?(Settings.authorization_workgroup_names.collection_creators)
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -4,12 +4,7 @@
 # Base class for application policies
 class ApplicationPolicy < ActionPolicy::Base
   extend T::Sig
-  # Configure additional authorization contexts here
-  # (`user` is added by default).
-  #
-  #   authorize :account, optional: true
-  #
-  # Read more about authorization context: https://actionpolicy.evilmartians.io/#/authorization_context
+  authorize :user_with_groups
 
   # private
   #

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -4,7 +4,7 @@
 # Authorization policy for Collection objects
 class CollectionPolicy < ApplicationPolicy
   relation_scope do |relation|
-    relation.where(creator: user)
+    relation.where(creator: user_with_groups.user)
   end
 
   alias_rule :edit?, to: :update?
@@ -21,5 +21,5 @@ class CollectionPolicy < ApplicationPolicy
     true
   end
 
-  delegate :administrator?, :collection_creator?, to: :user
+  delegate :administrator?, :collection_creator?, to: :user_with_groups
 end

--- a/app/policies/dashboard_policy.rb
+++ b/app/policies/dashboard_policy.rb
@@ -8,5 +8,5 @@ class DashboardPolicy < ApplicationPolicy
     administrator? || collection_creator? # TODO: || has created any deposits
   end
 
-  delegate :administrator?, :collection_creator?, to: :user
+  delegate :administrator?, :collection_creator?, to: :user_with_groups
 end


### PR DESCRIPTION
No functional changes.

## Why was this change made?
A user is a persistence object, which has no concept of groups.


## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?



