### PR TITLE
Cache groups in the session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,11 +25,15 @@ class ApplicationController < ActionController::Base
   private
 
   sig { returns(T::Array[String]) }
+  # This looks first in the session for groups, and then to the headers.
+  # This allows the application session to outlive the shiboleth session
   def ldap_groups
-    raw_header = request.env[Settings.authorization_group_header]
-    raw_header = ENV['ROLES'] if Rails.env.development?
-    logger.debug("Roles are #{raw_header}")
-    raw_header&.split(';') || []
+    session['groups'] ||= begin
+      raw_header = request.env[Settings.authorization_group_header]
+      raw_header = ENV['ROLES'] if Rails.env.development?
+      logger.debug("Roles are #{raw_header}")
+      raw_header&.split(';') || []
+    end
   end
 
   def deny_access


### PR DESCRIPTION

## Why was this change made?

So that groups are available even if the shibboleth session expires.

Fixes #281

## How was this change tested?

Tested on staging.


## Which documentation and/or configurations were updated?



