### PR TITLE
use fontawesome pencil icon

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -11,7 +11,11 @@
           <% @collections.each do |collection| %>
             <li>
               <div>
-                <header><%= collection.name %> <%= link_to '✏️', edit_collection_path(collection), aria: { label: "Edit #{collection.name}"} %></header>
+                <header><%= collection.name %>
+                  <%= link_to edit_collection_path(collection), aria: { label: "Edit #{collection.name}"} do %>
+                    <span class="fas fa-pencil-alt"></span>
+                  <% end %>
+                </header>
                 <%= button_tag '+ Deposit to this collection',
                       data: {
                         destination: new_collection_work_path(collection),


### PR DESCRIPTION
## Why was this change made?

Fixes #282 

Note from https://fontawesome.com/icons?d=gallery&q=pencil that `fa-pencil-alt` is being used.  Is this ok?  Is the size okay?  Does it need to be flipped so the point is on the lower right?  etc.

### Before

![image](https://user-images.githubusercontent.com/96775/98055551-9429f180-1df2-11eb-8320-237fb580c2a7.png)

### After

![image](https://user-images.githubusercontent.com/96775/98055573-9ee48680-1df2-11eb-8e88-cb8612042f0d.png)


## How was this change tested?

ran it locally

## Which documentation and/or configurations were updated?



