### PR TITLE
Run specs in a random order without monkeypatches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,7 @@
 # Ignore bundler config.
 /.bundle
 
-# Ignore the default SQLite database.
-/db/*.sqlite3
-/db/*.sqlite3-journal
-/db/*.sqlite3-*
+spec/examples.txt
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -152,30 +152,30 @@ RSpec.describe 'Collections requests' do
         end
       end
     end
-  end
 
-  context 'when Settings.allow_sdr_content_changes is' do
-    let(:alert_text) { 'Creating/Updating SDR content (i.e. collections or works) is not yet available.' }
+    context 'when Settings.allow_sdr_content_changes is' do
+      let(:alert_text) { 'Creating/Updating SDR content (i.e. collections or works) is not yet available.' }
 
-    describe 'false' do
-      before do
-        allow(Settings).to receive(:allow_sdr_content_changes).and_return(false)
+      describe 'false' do
+        before do
+          allow(Settings).to receive(:allow_sdr_content_changes).and_return(false)
+        end
+
+        it 'redirects and displays alert' do
+          get '/collections/new'
+          expect(response).to redirect_to(:root)
+          follow_redirect!
+          expect(response).to be_successful
+          expect(response.body).to include alert_text
+        end
       end
 
-      it 'redirects and displays alert' do
-        get '/collections/new'
-        expect(response).to redirect_to(:root)
-        follow_redirect!
-        expect(response).to be_successful
-        expect(response.body).to include alert_text
-      end
-    end
-
-    describe 'true' do
-      it 'does NOT display alert' do
-        get '/collections/new'
-        expect(response).to be_successful
-        expect(response.body).not_to include alert_text
+      describe 'true' do
+        it 'does NOT display alert' do
+          get '/collections/new'
+          expect(response).to be_successful
+          expect(response.body).not_to include alert_text
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,41 +60,39 @@ RSpec.configure do |config|
     config.default_formatter = 'doc'
   end
 
-  # The settings below are suggested to provide a good initial experience
-  # with RSpec, but feel free to customize to your heart's content.
-  #   # This allows you to limit a spec run to individual examples or groups
-  #   # you care about by tagging them with `:focus` metadata. When nothing
-  #   # is tagged with `:focus`, all examples get run. RSpec also provides
-  #   # aliases for `it`, `describe`, and `context` that include `:focus`
-  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  #   config.filter_run_when_matching :focus
-  #
-  #   # Allows RSpec to persist some state between runs in order to support
-  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
-  #   # you configure your source control system to ignore this file.
-  #   config.example_status_persistence_file_path = "spec/examples.txt"
-  #
-  #   # Limits the available syntax to the non-monkey patched syntax that is
-  #   # recommended. For more details, see:
-  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  #   config.disable_monkey_patching!
-  #
-  #   # Print the 10 slowest examples and example groups at the
-  #   # end of the spec run, to help surface which specs are running
-  #   # particularly slow.
-  #   config.profile_examples = 10
-  #
-  #   # Run specs in random order to surface order dependencies. If you find an
-  #   # order dependency and want to debug it, you can fix the order by providing
-  #   # the seed, which is printed after each run.
-  #   #     --seed 1234
-  #   config.order = :random
-  #
-  #   # Seed global randomization in this process using the `--seed` CLI option.
-  #   # Setting this allows you to use `--seed` to deterministically reproduce
-  #   # test failures related to randomization by passing the same `--seed` value
-  #   # as the one that triggered the failure.
-  #   Kernel.srand config.seed
+  # This allows you to limit a spec run to individual examples or groups
+  # you care about by tagging them with `:focus` metadata. When nothing
+  # is tagged with `:focus`, all examples get run. RSpec also provides
+  # aliases for `it`, `describe`, and `context` that include `:focus`
+  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  config.filter_run_when_matching :focus
+
+  # Allows RSpec to persist some state between runs in order to support
+  # the `--only-failures` and `--next-failure` CLI options. We recommend
+  # you configure your source control system to ignore this file.
+  config.example_status_persistence_file_path = 'spec/examples.txt'
+
+  # Limits the available syntax to the non-monkey patched syntax that is
+  # recommended. For more details, see:
+  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  config.disable_monkey_patching!
+
+  # Print the 10 slowest examples and example groups at the
+  # end of the spec run, to help surface which specs are running
+  # particularly slow.
+  config.profile_examples = 10
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
 end


### PR DESCRIPTION
## Why was this change made?
Running specs in a random order can help us find deficiencies in the suite.


## How was this change tested?



## Which documentation and/or configurations were updated?



