### PR TITLE
Raise custom exception when deposit status not available

### DIFF
--- a/app/exceptions/try_again_later.rb
+++ b/app/exceptions/try_again_later.rb
@@ -1,0 +1,9 @@
+# typed: true
+# frozen_string_literal: true
+
+# Custom exception class to special-case exceptions raised in the
+# DepositStatusJob related to deposits not yet being done. We use these
+# exceptions to signal to Sidekiq to restart the job after incremental backoff.
+# The special-casing is helpful because it allows us to ignore these exceptions
+# in Honeybadger.
+class TryAgainLater < RuntimeError; end

--- a/app/jobs/deposit_status_job.rb
+++ b/app/jobs/deposit_status_job.rb
@@ -8,8 +8,8 @@ class DepositStatusJob < BaseDepositJob
   sig { params(work: Work, job_id: Integer).void }
   def perform(work:, job_id:)
     result = status(job_id: job_id)
-    # This will force a recheck of status.
-    raise "No result yet for job #{job_id}" if result.nil?
+    # This will force a recheck of status (and should be ignored by Honeybadger)
+    raise TryAgainLater, "No result yet for job #{job_id}" if result.nil?
 
     if result.success?
       work.druid = result.value!

--- a/sorbet/rails-rbi/typed_params.rbi
+++ b/sorbet/rails-rbi/typed_params.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 module TypedParams
   extend T::Generic
 

--- a/spec/jobs/deposit_status_job_spec.rb
+++ b/spec/jobs/deposit_status_job_spec.rb
@@ -44,8 +44,10 @@ RSpec.describe DepositStatusJob do
   context 'when the job is not completed' do
     let(:background_result) { { status: 'incomplete' } }
 
-    it 'raises' do
-      expect { described_class.perform_now(work: work, job_id: job_id) }.to raise_error('No result yet for job 1234')
+    it 'raises a custom exception (so it can be ignored by Honeybadger)' do
+      expect { described_class.perform_now(work: work, job_id: job_id) }.to raise_error(
+        TryAgainLater, 'No result yet for job 1234'
+      )
     end
   end
 end


### PR DESCRIPTION
Fixes #233


## Why was this change made?

This exception is used to trigger Sidekiq retries and is not useful for reporting to Honeybadger. By using a custom exception class, we can ignore it in HB config. 


## How was this change tested?

CI


## Which documentation and/or configurations were updated?

Corresponding shared_configs work has already been done.

