### PR TITLE
Use consistent function naming scheme in JS

### DIFF
--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -1,7 +1,7 @@
 <div class="contributor row inner-container">
   <div class="col-md-12">
     <%= button_tag class: 'btn btn-sm float-right', aria: { label: 'Remove' },
-        data: { action: "click->nested-form#remove_association" } do %>
+        data: { action: "click->nested-form#removeAssociation" } do %>
       <span class="far fa-trash-alt"></span>
     <% end %>
   </div>

--- a/app/components/works/contributors_component.html.erb
+++ b/app/components/works/contributors_component.html.erb
@@ -13,7 +13,7 @@
   <% end %>
 
   <div data-target="nested-form.add_item">
-    <%= button_tag '+ Add another author/contributor', class: "btn btn-outline-primary", data: { action: "nested-form#add_association" } %>
+    <%= button_tag '+ Add another author/contributor', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
   </div>
 
 </section>

--- a/app/components/works/related_work_component.html.erb
+++ b/app/components/works/related_work_component.html.erb
@@ -14,6 +14,6 @@
   <% end %>
 
   <div data-target="nested-form.add_item">
-    <%= button_tag '+ Add another related work', class: "btn btn-outline-primary", data: { action: "nested-form#add_association" } %>
+    <%= button_tag '+ Add another related work', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
   </div>
 </div>

--- a/app/components/works/related_work_row_component.html.erb
+++ b/app/components/works/related_work_row_component.html.erb
@@ -8,7 +8,7 @@
 
   <div class="col-md-1">
     <%= button_tag class: 'btn btn-sm float-right', aria: { label: 'Remove' },
-        data: { action: "click->nested-form#remove_association" } do %>
+        data: { action: "click->nested-form#removeAssociation" } do %>
       <span class="far fa-trash-alt"></span>
     <% end %>
   </div>

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -3,13 +3,13 @@ import { Controller } from "stimulus"
 export default class extends Controller {
   static targets = ["add_item", "template"]
 
-  add_association(event) {
+  addAssociation(event) {
     event.preventDefault()
     const content = this.templateTarget.innerHTML.replace(/TEMPLATE_RECORD/g, new Date().valueOf())
     this.add_itemTarget.insertAdjacentHTML('beforebegin', content)
   }
 
-  remove_association(event) {
+  removeAssociation(event) {
     event.preventDefault()
     const item = event.target.closest(".inner-container")
     item.querySelector("input[name*='_destroy']").value = 1

--- a/sorbet/rails-rbi/typed_params.rbi
+++ b/sorbet/rails-rbi/typed_params.rbi
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 module TypedParams
   extend T::Generic
 


### PR DESCRIPTION
## Why was this change made?

To be consistent with other JS controllers in the app, and to use the language-specific naming convention.

## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None
