### PR TITLE
Convert keywords component validation to remote form

### DIFF
--- a/app/components/works/keywords_component.html.erb
+++ b/app/components/works/keywords_component.html.erb
@@ -1,5 +1,5 @@
-<div class="keywords" data-controller="keywords" data-action="focusout->keywords#close">
-  <div class="keywords-container <%= 'is-invalid' if errors.present? %>" data-target="keywords.container" data-action="click->keywords#open">
+<div class="keywords" data-controller="keywords" data-action="focusout->keywords#close" data-target="progress.keywordsField">
+  <div class="keywords-container data-target="keywords.container" data-action="click->keywords#open">
     <span class="selection" role="combobox" aria-haspopup="true" aria-expanded="true" tabindex="-1"
       aria-disabled="false" aria-owns="keyword-results">
       <ul class="rendered" id="keyword-container" data-target="keywords.addItem">
@@ -25,9 +25,7 @@
       </span>
     </span>
   </div>
-  <% if errors.present? %>
-    <div class="invalid-feedback"><%= errors %></div>
-  <% end %>
+  <div class="invalid-feedback"></div>
 <%# -- TODO for autocomplete
   <div class="keywords-container keywords-container-open" data-target="keywords.container">
     <span class="keywords-dropdown select2-dropdown--above">

--- a/app/components/works/keywords_component.html.erb
+++ b/app/components/works/keywords_component.html.erb
@@ -1,5 +1,5 @@
 <div class="keywords" data-controller="keywords" data-action="focusout->keywords#close" data-target="progress.keywordsField">
-  <div class="keywords-container data-target="keywords.container" data-action="click->keywords#open">
+  <div class="keywords-container" data-target="keywords.container" data-action="click->keywords#open">
     <span class="selection" role="combobox" aria-haspopup="true" aria-expanded="true" tabindex="-1"
       aria-disabled="false" aria-owns="keyword-results">
       <ul class="rendered" id="keyword-container" data-target="keywords.addItem">

--- a/app/components/works/keywords_component.rb
+++ b/app/components/works/keywords_component.rb
@@ -9,9 +9,5 @@ module Works
     end
 
     attr_reader :form
-
-    def errors
-      helpers.safe_join form.object.errors[:keywords]
-    end
   end
 end

--- a/app/components/works/work_form_component.html.erb
+++ b/app/components/works/work_form_component.html.erb
@@ -1,8 +1,10 @@
 <div id="editor">
   <h1 class="row"><%= page_title %></h1>
   <%= form_with model: work_form, url: url,
-      local: true,
-      data: { controller: 'progress' },
+      data: {
+        controller: 'progress',
+        action: 'ajax:error->progress#displayErrors'
+      },
       html: { class: "needs-validation row #{'was-validated' if work_form.errors.present?}", novalidate: true, multipart: true } do |f| %>
     <%= f.hidden_field :work_type %>
     <%= render Works::DepositProgressComponent.new %>

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -28,7 +28,8 @@ class WorksController < ApplicationController
       DepositJob.perform_later(work) if params[:commit] == 'Deposit'
       redirect_to work
     else
-      render :new
+      # Send form errors to client in JSON format to be parsed and rendered there
+      render json: @form.errors, status: :bad_request
     end
   end
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -50,7 +50,8 @@ class WorksController < ApplicationController
       DepositJob.perform_later(work) if params[:commit] == 'Deposit'
       redirect_to work
     else
-      render :edit
+      # Send form errors to client in JSON format to be parsed and rendered there
+      render json: @form.errors, status: :bad_request
     end
   end
 

--- a/app/javascript/controllers/keywords_controller.js
+++ b/app/javascript/controllers/keywords_controller.js
@@ -19,6 +19,8 @@ export default class extends Controller {
 
     this.searchTarget.value = ''
     this.addItemTarget.insertAdjacentHTML('beforeend', content)
+    // Remove error indications when keyword(s) added
+    this.containerTarget.classList.remove('is-invalid')
   }
 
   removeAssociation(event) {

--- a/app/javascript/controllers/progress_controller.js
+++ b/app/javascript/controllers/progress_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "stimulus";
 
 export default class extends Controller {
-  static targets = ["title", "titleField", "file", "fileField"];
+  static targets = ["title", "titleField", "file", "fileField", "keywordsField"];
 
   connect() {
     // TODO see what of the things are already valid
@@ -21,7 +21,18 @@ export default class extends Controller {
     if (stepName === 'file') {
       isComplete = document.querySelectorAll('[type=hidden][name="work[files][]"]').length > 0
     }
-
     step.classList.toggle('active', isComplete)
+  }
+
+  displayErrors(event) {
+    const [data, _status, _xhr] = event.detail;
+
+    for (const [fieldName, errorList] of Object.entries(data)) {
+      const target = this.targets.find(`${fieldName}Field`)
+      const container = target.querySelector(`.${fieldName}-container`)
+      container.classList.toggle('is-invalid')
+      const feedback = target.querySelector('.invalid-feedback')
+      feedback.innerHTML += errorList.join(' ')
+    }
   }
 }

--- a/spec/components/works/keywords_component_spec.rb
+++ b/spec/components/works/keywords_component_spec.rb
@@ -14,15 +14,4 @@ RSpec.describe Works::KeywordsComponent do
       .to be_present
     expect(rendered.css('.keywords-container.is-invalid')).not_to be_present
   end
-
-  context 'when the keyword is not provided' do
-    before do
-      work_form.validate({})
-    end
-
-    it 'renders the component errors' do
-      expect(rendered.css('.keywords-container.is-invalid')).to be_present
-      expect(rendered.css('.keywords-container.is-invalid ~ .invalid-feedback')).to be_present
-    end
-  end
 end

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -70,21 +70,27 @@ RSpec.describe 'Create a new collection and deposit to it', js: true do
       fill_in 'Abstract', with: 'Whatever'
       check 'Musical notation'
 
-      fill_in 'Citation', with: 'Whatever'
+      # fill_in 'Citation', with: 'Whatever'
       check 'I agree to the SDR Terms of Deposit'
 
       # Test remote form validation which only happens once client-side validation passes
       expect(page).not_to have_content('Please add at least one keyword')
       expect(page).not_to have_css('.keywords-container.is-invalid')
       expect(page).not_to have_css('.keywords-container.is-invalid ~ .invalid-feedback')
+
       click_button 'Deposit'
+
       expect(page).to have_content('Please add at least one keyword')
       expect(page).to have_css('.keywords-container.is-invalid')
       expect(page).to have_css('.keywords-container.is-invalid ~ .invalid-feedback')
-      # End of remote form validation
 
       fill_in 'Keywords', with: 'Springs'
       blur_from 'work_keywords'
+
+      expect(page).not_to have_content('Please add at least one keyword')
+      expect(page).not_to have_css('.keywords-container.is-invalid')
+      expect(page).not_to have_css('.keywords-container.is-invalid ~ .invalid-feedback')
+      # End of remote form validation
 
       fill_in 'Citation for this deposit (optional)', with: 'Whatever'
       check 'I agree to the SDR Terms of Deposit'

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe 'Create a new collection and deposit to it', js: true do
         "Created year must be between #{Settings.earliest_created_year} and #{Time.zone.today.year}"
       )
       fill_in 'Created year', with: ''
-      # End of validation testing, continue filling out deposit form
+      fill_in 'Publication year', with: ''
+      # End of client-side validation testing
 
       fill_in 'Title of deposit', with: 'My Title'
       fill_in 'Contact email', with: user.email
@@ -68,6 +69,19 @@ RSpec.describe 'Create a new collection and deposit to it', js: true do
 
       fill_in 'Abstract', with: 'Whatever'
       check 'Musical notation'
+
+      fill_in 'Citation', with: 'Whatever'
+      check 'I agree to the SDR Terms of Deposit'
+
+      # Test remote form validation which only happens once client-side validation passes
+      expect(page).not_to have_content('Please add at least one keyword')
+      expect(page).not_to have_css('.keywords-container.is-invalid')
+      expect(page).not_to have_css('.keywords-container.is-invalid ~ .invalid-feedback')
+      click_button 'Deposit'
+      expect(page).to have_content('Please add at least one keyword')
+      expect(page).to have_css('.keywords-container.is-invalid')
+      expect(page).to have_css('.keywords-container.is-invalid ~ .invalid-feedback')
+      # End of remote form validation
 
       fill_in 'Keywords', with: 'Springs'
       blur_from 'work_keywords'

--- a/spec/requests/works_spec.rb
+++ b/spec/requests/works_spec.rb
@@ -307,9 +307,10 @@ RSpec.describe 'Works requests' do
         }
       end
 
-      it 'displays the edit page' do
+      it 'returns a validation error in JSON format' do
         patch "/works/#{work.id}", params: { work: work_params }
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:bad_request)
+        expect(JSON.parse(response.body)['title']).to include("can't be blank")
       end
     end
   end


### PR DESCRIPTION
![Peek 2020-11-05 11-27](https://user-images.githubusercontent.com/131982/98288454-b8eda880-1f5b-11eb-951f-eb4d33122f81.gif)

## Why was this change made?

This is a spike for the team to be able to evaluate the two approaches: local forms vs remote forms. This PR switches from a local form to a remote form:

* local form: this is the standard rails form. when submitted, the request goes to the server and the server will send back to the client a rendered form (if errors) or redirect to a show page, typically
* remote form: this is the new default in rails. when submitted, turbolinks submits the form via XHR, the server does validation, and if validator errors are present, either a partial is rendered and sent or a JSON representation of errors are sent, and you use JS (Stimulus for us) to parse the errors and show them on the page.

Long story short? new-style rails convention prevents unnecessary page loads (more reactive/quicker user experience), providing a more modern user experience, at the cost of needing some JavaScript glue code. It's also arguably more API-oriented. 

## How was this change tested?

In browser and CI

## Which documentation and/or configurations were updated?

None.

