### PR TITLE
embargo date input: adjust bootstrap column widths

### DIFF
--- a/app/components/works/embargo_component.html.erb
+++ b/app/components/works/embargo_component.html.erb
@@ -16,18 +16,18 @@
        <%= form.radio_button :release, 'embargo', class: 'form-check-input' %>
        <%= form.label :release_embargo, 'On this date' %>
      </div>
-     <div class="col-sm-3">
+     <div class="col-sm-9">
        <div class="row">
-         <div class="col">
+         <div class="col-sm-2">
            <label for="work_embargo_year" class="visually-hidden">Embargo year</label>
            <%= select_year Time.zone.today, { prefix: 'work', field_name: 'embargo_date(1i)', start_year: Time.zone.today.year, end_year: 3.years.from_now.year }, id: 'work_embargo_year', class: "form-control" %>
          </div>
-         <div class="col">
+         <div class="col-sm-3">
            <label for="work_embargo_month" class="visually-hidden">Embargo month</label>
            <%= select_month nil, { prefix: 'work', field_name: 'embargo_date(2i)', prompt: 'month'}, id: 'work_embargo_month', class: "form-control" %>
          </div>
 
-         <div class="col">
+         <div class="col-sm-2">
            <label for="work_embargo_day" class="visually-hidden">Embargo day</label>
            <%= select_day nil, { prefix: 'work', field_name: 'embargo_date(3i)', prompt: 'day'}, id: 'work_embargo_day', class: "form-control" %>
          </div>


### PR DESCRIPTION
Fixes #317

I'm not facile with bootstrap; it would be great if someone who was double checked this.   I did read about what the diff classes I was tweaking meant ...

## Why was this change made?

### Before

Firefox, 100% size:

![image](https://user-images.githubusercontent.com/96775/98308295-8c965400-1f7c-11eb-9978-e10d1502ad53.png)

### After

Firefox, 100% size

![image](https://user-images.githubusercontent.com/96775/98308339-a33cab00-1f7c-11eb-9600-5e1879547e92.png)

Firefox, 120% size

![image](https://user-images.githubusercontent.com/96775/98308367-b3ed2100-1f7c-11eb-85b9-e6f8ac27206c.png)



## How was this change tested?



## Which documentation and/or configurations were updated?



