### PR TITLE
Correct request origin typos preventing ActionCable connections

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,8 +47,8 @@ Rails.application.configure do
   # initialization order, so we can't supply more specific URLs in
   # shared_configs here.
   config.action_cable.allowed_request_origins = [
-    %r{https://sul-h2.*\.stanford\.edu'},
-    %r{https://sdr.*\.stanford\.edu'}
+    %r{https://sul-h2.*\.stanford\.edu},
+    %r{https://sdr.*\.stanford\.edu}
   ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.


### PR DESCRIPTION


## Why was this change made?

To fix websockets in deployed environments.

## How was this change tested?

in -stage

## Which documentation and/or configurations were updated?

none

