### PR TITLE
make email validation more strict client/server side

### DIFF
--- a/app/components/collections/form_component.html.erb
+++ b/app/components/collections/form_component.html.erb
@@ -21,7 +21,7 @@
     <div class="mb-3 row">
       <%= form.label :contact_email, 'Contact email', class: 'col-sm-2 col-form-label' %>
       <div class="col-sm-10">
-        <%= form.email_field :contact_email, class: "form-control", required: true %>
+        <%= form.email_field :contact_email, class: "form-control", required: true, pattern: Devise.email_regexp.source %>
         <div class="invalid-feedback">You must provide a valid email address</div>
       </div>
     </div>

--- a/app/components/works/title_component.html.erb
+++ b/app/components/works/title_component.html.erb
@@ -14,7 +14,7 @@
    <div class="mb-3 row">
      <%= form.label :contact_email, 'Contact email', class: 'col-sm-2 col-form-label' %>
      <div class="col-sm-10">
-       <%= form.email_field :contact_email, class: "form-control", required: true %>
+       <%= form.email_field :contact_email, class: "form-control", required: true, pattern: Devise.email_regexp.source %>
        <div class="invalid-feedback">You must provide a valid email address</div>
      </div>
    </div>

--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -26,7 +26,8 @@ class CollectionForm < Reform::Form
     super
   end
 
-  validates :name, :description, :contact_email, :managers, :access, presence: true
+  validates :name, :description, :managers, :access, presence: true
+  validates :contact_email, presence: true, format: { with: Devise.email_regexp }
 
   private
 

--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -60,6 +60,7 @@ class WorkForm < Reform::Form
             allow_nil: true
   validates 'release', presence: true, inclusion: { in: %w[immediate embargo] }
   validates :keywords, length: { minimum: 1, message: 'Please add at least one keyword.' }
+  validates :contact_email, presence: true, format: { with: Devise.email_regexp }
 
   collection :contributors,
              populator: lambda { |fragment:, **|

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -7,7 +7,7 @@ class Collection < ApplicationRecord
   belongs_to :creator, class_name: 'User'
   has_and_belongs_to_many :depositors, class_name: 'User', join_table: 'depositors'
 
-  validates :contact_email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :contact_email, presence: true, format: { with: Devise.email_regexp }
   validates :description, presence: true
   validates :managers, presence: true
   validates :name, presence: true

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -15,7 +15,7 @@ class Work < ApplicationRecord
   has_many :keywords, dependent: :destroy
 
   validates :abstract, :access, :state, :title, presence: true
-  validates :contact_email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :contact_email, presence: true, format: { with: Devise.email_regexp }
   validates :created_edtf, :published_edtf, edtf: true
   validates :license, presence: true, inclusion: { in: License.license_list }
   validates :subtype, work_subtype: true

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -184,7 +184,7 @@ Devise.setup do |config|
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  config.email_regexp = /[a-z0-9._%+-]+@[a-z0-9-]+\.[a-z]{2,63}/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -185,6 +185,8 @@ Devise.setup do |config|
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
   config.email_regexp = /[a-z0-9._%+-]+@[a-z0-9-]+\.[a-z]{2,63}/
+  # NOTE: this regex was modified to enforce stricter validation of email addresses (of a pattern XXX@XX.XX)
+  #    and is used in all locations where an email address is validated (not just for devise).  Nov 2020
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this


### PR DESCRIPTION
## Why was this change made?

Fixes #332 

* create an email regex to require a pattern like this XXX@XXX.XX  (some characters ending with exactly one @ followed by some characters (e.g. a subdomain) followed by exactly one . followed by at least two characters (e.g. a top level domain)
* put this email regex in a single config location (just took over the Devise config)
* use this configured regex in all current locations where we validate email addresses (client or server side)
* add this validation to the Reform models as well (where they were not before) <-- not sure if this is needed?

## How was this change tested?

Localhost browser


## Which documentation and/or configurations were updated?



