### PR TITLE
Require a user-supplied subtype for works of type 'other'

### DIFF
--- a/app/components/works/description_component.html.erb
+++ b/app/components/works/description_component.html.erb
@@ -8,6 +8,7 @@
     <%= form.label :abstract, 'Abstract', class: 'col-sm-2 col-form-label' %>
     <div class="col-sm-10">
       <%= form.text_area :abstract, class: "form-control", required: true %>
+      <div class="invalid-feedback">You must provide an abstract</div>
     </div>
   </div>
 
@@ -24,14 +25,22 @@
     </div>
   </div>
 
-  <div class="mb-5 row">
-    <% subtypes.each do |subtype| %>
-      <div class="col-sm-4">
-        <div class="form-check">
-          <%= form.check_box :subtype, { multiple: true, class: 'form-check-input' }, subtype, nil %>
-          <%= form.label "subtype_#{subtype.parameterize(separator: '_')}", subtype, class: 'form-check-label' %>
-        </div>
+  <div class="mb-3 row">
+    <% if other_type? %>
+      <%= form.label :subtype, 'Other', class: 'col-sm-2 col-form-label' %>
+      <div class="col-sm-10">
+        <%= form.text_field :subtype, class: 'form-control', required: true, multiple: true %>
+        <div class="invalid-feedback">You must provide a subtype for works of type 'Other'</div>
       </div>
+    <% else %>
+      <% subtypes.each do |subtype| %>
+        <div class="col-sm-4">
+          <div class="form-check">
+            <%= form.check_box :subtype, { multiple: true, class: 'form-check-input' }, subtype, nil %>
+            <%= form.label "subtype_#{subtype.parameterize(separator: '_')}", subtype, class: 'form-check-label' %>
+          </div>
+        </div>
+      <% end %>
     <% end %>
   </div>
 

--- a/app/components/works/description_component.rb
+++ b/app/components/works/description_component.rb
@@ -11,7 +11,15 @@ module Works
     attr_reader :form
 
     def subtypes
-      WorkType.subtypes_for(form.object.work_type)
+      WorkType.subtypes_for(work_type)
+    end
+
+    def work_type
+      form.object.work_type
+    end
+
+    def other_type?
+      work_type == 'other'
     end
   end
 end

--- a/app/components/works/work_type_modal_component.html.erb
+++ b/app/components/works/work_type_modal_component.html.erb
@@ -30,10 +30,13 @@
       </div>
     </template>
 
+    <template data-target="work-type.otherTemplate">
+      <div class="col-md-4">
+        <input type="text" name="subtype[]" id="subtype_other">
+      </div>
+    </template>
 
-    <div class="row" data-target="work-type.area" hidden>
-      <h5>Which of the following terms further describe your deposit?</h5>
-    </div>
+    <div class="row h5" data-target="work-type.area" hidden></div>
 
     <div class="row mb-4" data-target="work-type.subtype"></div>
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -83,11 +83,12 @@ class WorksController < ApplicationController
     errors = []
 
     unless WorkTypeValidator.valid?(params[:work_type])
-      errors << "Invalid value of required parameter work_type: #{params[:work_type].presence || 'nil'}"
+      errors << "Invalid value of required parameter work_type: #{params[:work_type].presence || 'missing'}"
     end
 
     unless WorkSubtypeValidator.valid?(params[:work_type], params[:subtype])
-      errors << "Invalid subtype value for work_type '#{params[:work_type]}': #{params[:subtype].join}"
+      errors << "Invalid subtype value for work_type '#{params[:work_type]}': " +
+                (Array(params[:subtype]).join.presence || 'missing')
     end
 
     return if errors.empty?

--- a/app/javascript/controllers/edit_deposit_controller.js
+++ b/app/javascript/controllers/edit_deposit_controller.js
@@ -30,7 +30,7 @@ export default class extends Controller {
     for (const [fieldName, errorList] of Object.entries(data)) {
       const target = this.targets.find(`${fieldName}Field`)
       const container = target.querySelector(`.${fieldName}-container`)
-      container.classList.toggle('is-invalid')
+      container.classList.add('is-invalid')
       const feedback = target.querySelector('.invalid-feedback')
       feedback.innerHTML += errorList.join(' ')
     }

--- a/app/javascript/controllers/work_type_controller.js
+++ b/app/javascript/controllers/work_type_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  static targets = ["form", "template", "subtype", "area"]
+  static targets = ["form", "template", "otherTemplate", "subtype", "area"]
 
   // Sets the form in the popup to use the action in the data-destination attribute
   set_collection(event) {
@@ -10,13 +10,28 @@ export default class extends Controller {
   }
 
   change(event) {
-    this.areaTarget.hidden = false
-
     const type = event.target.value
+
+    // We treat the "other" work type differently than all the others.
+    type === 'other' ?
+      this.displayOtherSubtypeOptions() :
+      this.displaySubtypeOptions(type)
+
+    // Display the work type choices
+    this.areaTarget.hidden = false
+  }
+
+  displaySubtypeOptions(type) {
     const subtypes = document.subtypes[type].map((subtype)=> {
       const id = subtype.replace(/\s/g, '_')
       return this.templateTarget.innerHTML.replace(/SUBTYPE_LABEL/g, subtype).replace(/SUBTYPE_ID/g, id)
     })
     this.subtypeTarget.innerHTML = subtypes.join('')
+    this.areaTarget.innerHTML = 'Which of the following terms further describe your deposit?'
+  }
+
+  displayOtherSubtypeOptions() {
+    this.subtypeTarget.innerHTML = this.otherTemplateTarget.innerHTML
+    this.areaTarget.innerHTML = 'Specify "Other" type'
   }
 }

--- a/app/validators/work_subtype_validator.rb
+++ b/app/validators/work_subtype_validator.rb
@@ -13,7 +13,10 @@ class WorkSubtypeValidator < ActiveModel::EachValidator
   # validate these on the incoming works/new request before there is a model
   # instance to validate.
   def self.valid?(work_type, value)
-    return true if value.nil? # Subtype is not required
+    return Array(value).first.present? if work_type == 'other'
+
+    # Subtype is not required for work types other than 'other'
+    return true if value.nil?
 
     value.all? { |subtype| subtype.in?(WorkType.subtypes_for(work_type)) }
   end

--- a/spec/components/works/work_type_modal_component_spec.rb
+++ b/spec/components/works/work_type_modal_component_spec.rb
@@ -6,6 +6,6 @@ require 'rails_helper'
 RSpec.describe Works::WorkTypeModalComponent, type: :component do
   it 'renders the component' do
     expect(render_inline(described_class.new).to_html)
-      .to include('Which of the following terms further describe your deposit?')
+      .to include('What type of content will you deposit?')
   end
 end

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe 'Create a new collection and deposit to it', js: true do
       click_button '+ Deposit to this collection' # , match: :first
 
       expect(page).to have_content 'What type of content will you deposit?'
+
+      expect(page).not_to have_css('input#subtype_other')
+      find('label', text: 'Other').click
+      expect(page).to have_css('input#subtype_other')
       find('label', text: 'Sound').click
 
       check 'Course/instruction'
@@ -47,6 +51,8 @@ RSpec.describe 'Create a new collection and deposit to it', js: true do
       expect(page).to have_content(
         "Created year must be between #{Settings.earliest_created_year} and #{Time.zone.today.year}"
       )
+      expect(page).to have_content('You must provide an abstract')
+
       fill_in 'Created year', with: ''
       fill_in 'Publication year', with: ''
       # End of client-side validation testing

--- a/spec/features/edit_draft_work_spec.rb
+++ b/spec/features/edit_draft_work_spec.rb
@@ -4,7 +4,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Edit a draft work', js: true do
-  let(:work) { create(:work, :with_keywords) }
+  let(:work) { create(:work, :with_keywords, work_type: 'other', subtype: ['Graphic novel']) }
   let(:user) { work.depositor }
 
   before do
@@ -23,6 +23,13 @@ RSpec.describe 'Edit a draft work', js: true do
       # See https://github.com/sul-dlss/happy-heron/issues/243
       check 'I agree to the SDR Terms of Deposit'
 
+      # Test validation
+      fill_in 'Other', with: ''
+      click_button 'Deposit'
+      expect(page).to have_content("You must provide a subtype for works of type 'Other'")
+      # End of validation testing
+
+      fill_in 'Other', with: 'Comic book'
       click_button 'Deposit'
 
       expect(page).to have_content('title = Test title')

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -76,10 +76,18 @@ RSpec.describe Work do
       end
     end
 
-    context 'with a work_type that lacks subtypes' do
+    context 'with a work_type that requires a user-supplied subtype and is empty' do
       let(:work) { build(:work, work_type: 'other', subtype: []) }
 
-      it 'validates' do
+      it 'does not validate' do
+        expect(work).not_to be_valid
+      end
+    end
+
+    context 'with a work_type that requires a user-supplied subtype and is present' do
+      let(:work) { build(:work, work_type: 'other', subtype: ['Pill bottle']) }
+
+      it 'does not validate' do
         expect(work).to be_valid
       end
     end


### PR DESCRIPTION

## Why was this change made?

Fixes #272

Includes:
* Render a text field for the user-supplied subtype when 'Other' type selected in modal
* Change work subtype validator to change the behavior to require a user-supplied subtype

Bonuses:
* Add an invalid-feedback div to abstract field so users know why it has turned red

![Peek 2020-11-06 13-16](https://user-images.githubusercontent.com/131982/98415908-00933380-2033-11eb-9308-27fe2ae8f57a.gif)

## How was this change tested?

CI and in browser

## Which documentation and/or configurations were updated?

None

