### PR TITLE
map contributors from work form into cocina model for deposit

### DIFF
--- a/app/jobs/deposit_job.rb
+++ b/app/jobs/deposit_job.rb
@@ -29,6 +29,7 @@ class DepositJob < BaseDepositJob
                                            logger: Rails.logger,
                                            connection: connection)
   end
+
   sig { params(blobs: T::Array[ActiveStorage::Blob]).returns(T::Array[SdrClient::Deposit::Files::DirectUploadRequest]) }
   def upload_responses(blobs)
     SdrClient::Deposit::UploadFiles.upload(file_metadata: build_file_metadata(blobs),

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -69,20 +69,20 @@ class Contributor < ApplicationRecord
     contributor_type == 'person'
   end
 
-  # This is used by the form
+  # used by work_form
   sig { returns(String) }
   def role_term
     [contributor_type, role].join(SEPARATOR)
   end
 
-  # This is used by the the controller for setting values from the form.
+  # used by work_controller for setting values from the form.
   sig { params(val: String).void }
   def role_term=(val)
     contributor_type, role = val.split(SEPARATOR)
     self.attributes = { contributor_type: contributor_type, role: role }
   end
 
-  # The list for the form
+  # list for work_form pulldown
   sig { returns(T::Array[T::Array[T.any(String, T::Array[String])]]) }
   def self.grouped_options
     ROLE_LABEL.map do |key, label|

--- a/app/services/description_generator.rb
+++ b/app/services/description_generator.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 # This generates a RequestDRO Description for a work
+# rubocop:disable Metrics/ClassLength
 class DescriptionGenerator
   extend T::Sig
 
@@ -19,6 +20,7 @@ class DescriptionGenerator
   def generate
     {
       title: title,
+      contributor: contributors,
       subject: keywords,
       note: [abstract, citation, contact],
       event: [created_date, published_date].compact
@@ -107,4 +109,55 @@ class DescriptionGenerator
       "displayLabel": 'Contact'
     }
   end
+
+  sig { returns(T::Array[T::Array[Object]]) }
+  def contributors
+    result = []
+
+    work.contributors.each do |work_form_contributor|
+      result << contributor(work_form_contributor)
+    end
+
+    result
+  end
+
+  # in cocina model terms, returns a DescriptiveValue
+  sig do
+    params(work_form_contributor: Contributor)
+      .returns({ name: [{ value: T.untyped }], type: String, role: [{ value: T.untyped }] })
+  end
+  def contributor(work_form_contributor)
+    # TODO: we may know status primary
+    if work_form_contributor.person?
+      {
+        "name": [
+          {
+            "value": "#{work_form_contributor.last_name}, #{work_form_contributor.first_name}"
+          }
+        ],
+        "type": 'person',
+        # TODO: we will know code, uri, source code and source uri
+        "role": [
+          {
+            "value": work_form_contributor.role
+          }
+        ]
+      }
+    else
+      {
+        "name": [
+          {
+            "value": work_form_contributor.full_name
+          }
+        ],
+        "type": 'organization',
+        "role": [
+          {
+            "value": work_form_contributor.role
+          }
+        ]
+      }
+    end
+  end
 end
+# rubocop:enable Metrics/ClassLength

--- a/spec/services/description_generator_spec.rb
+++ b/spec/services/description_generator_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe DescriptionGenerator do
   subject(:model) { described_class.generate(work: work) }
 
   let(:work) do
-    build(:work, :with_creation_dates, :published, :with_keywords)
+    build(:work, :with_creation_dates, :published, :with_keywords, :with_contributors)
   end
 
-  it 'makes the descripion' do
+  it 'creates description cocina model' do
     expect(model).to eq(
       event: [
         { date: [{ encoding: { code: 'edtf' }, value: '2020-03-04/2020-10-31' }], type: 'creation' },
@@ -26,7 +26,12 @@ RSpec.describe DescriptionGenerator do
         { type: 'preferred citation', value: 'test citation' },
         { displayLabel: 'Contact', type: 'contact', value: 'io@io.io' }
       ],
-      title: [{ value: 'Test title' }]
+      title: [{ value: 'Test title' }],
+      contributor: [
+        { name: [{ value: 'Last1, First1' }], role: [{ value: 'Contributing author' }], type: 'person' },
+        { name: [{ value: 'Last2, First2' }], role: [{ value: 'Contributing author' }], type: 'person' },
+        { name: [{ value: 'Last3, First3' }], role: [{ value: 'Contributing author' }], type: 'person' }
+      ]
     )
   end
 end

--- a/spec/services/request_generator_spec.rb
+++ b/spec/services/request_generator_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe RequestGenerator do
               value: 'Test title'
             }
           ],
+          contributor: [],
           event: [],
           subject: [],
           note: [
@@ -70,6 +71,7 @@ RSpec.describe RequestGenerator do
             }
           ],
           event: [],
+          contributor: [],
           subject: [],
           note: [
             {


### PR DESCRIPTION
Part of #240 -- waiting for Arcadia to provide more complete mappings for roles.

## Why was this change made?

The contributor data from the work form needs to be saved as descriptive metadata in a deposit.

## How was this change tested?

testing locally, running it on stage and seeing that the contributor mappings are being passed into sdr-api, added unit test and tweaked unit test.

## Which documentation and/or configurations were updated?



