### PR TITLE
Fix file removal in work form bug

### DIFF
--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -1,6 +1,6 @@
 <div class="contributor row inner-container" data-controller="contributor">
   <div class="col-md-12">
-    <%= button_tag class: 'btn btn-sm float-right', aria: { label: 'Remove' },
+    <%= button_tag type: 'button', class: 'btn btn-sm float-right', aria: { label: 'Remove' },
         data: { action: "click->nested-form#removeAssociation" } do %>
       <span class="far fa-trash-alt"></span>
     <% end %>

--- a/app/components/works/contributors_component.html.erb
+++ b/app/components/works/contributors_component.html.erb
@@ -13,7 +13,7 @@
   <% end %>
 
   <div data-target="nested-form.add_item">
-    <%= button_tag '+ Add another author/contributor', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
+    <%= button_tag '+ Add another author/contributor', type: 'button', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
   </div>
 
 </section>

--- a/app/components/works/file_row_component.html.erb
+++ b/app/components/works/file_row_component.html.erb
@@ -24,7 +24,7 @@
   </div>
 
   <div class="col-md-1">
-    <%= button_tag class: "dz-remove pull-right btn", data: { action: "click->dropzone#removeAssociation" } do %>
+    <%= button_tag type: 'button', class: "dz-remove pull-right btn", data: { action: "click->dropzone#removeAssociation" } do %>
       <span class="far fa-trash-alt"></span>
     <% end %>
   </div>

--- a/app/components/works/related_link_component.html.erb
+++ b/app/components/works/related_link_component.html.erb
@@ -14,6 +14,6 @@
   <% end %>
 
   <div data-target="nested-form.add_item">
-    <%= button_tag '+ Add another link', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
+    <%= button_tag '+ Add another link', type: 'button', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
   </div>
 </div>

--- a/app/components/works/related_link_row_component.html.erb
+++ b/app/components/works/related_link_row_component.html.erb
@@ -8,8 +8,8 @@
     </div>
 
     <div class="col-md-1">
-      <%= button_tag class: 'btn btn-sm float-right', aria: { label: 'Remove' },
-          data: { action: "click->nested-form#removeAssociation" } do %>
+      <%= button_tag type: 'button', class: 'btn btn-sm float-right', aria: { label: 'Remove' },
+       data: { action: "click->nested-form#removeAssociation" } do %>
         <span class="far fa-trash-alt"></span>
       <% end %>
     </div>

--- a/app/components/works/related_work_component.html.erb
+++ b/app/components/works/related_work_component.html.erb
@@ -14,6 +14,6 @@
   <% end %>
 
   <div data-target="nested-form.add_item">
-    <%= button_tag '+ Add another related work', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
+    <%= button_tag '+ Add another related work', type: 'button', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
   </div>
 </div>

--- a/app/components/works/related_work_row_component.html.erb
+++ b/app/components/works/related_work_row_component.html.erb
@@ -7,8 +7,8 @@
   </div>
 
   <div class="col-md-1">
-    <%= button_tag class: 'btn btn-sm float-right', aria: { label: 'Remove' },
-        data: { action: "click->nested-form#removeAssociation" } do %>
+    <%= button_tag type: 'button', class: 'btn btn-sm float-right', aria: { label: 'Remove' },
+     data: { action: "click->nested-form#removeAssociation" } do %>
       <span class="far fa-trash-alt"></span>
     <% end %>
   </div>


### PR DESCRIPTION
## Why was this change made?

This was a head-scratcher. Adding a file to the work form and them adding keywords, related links, related works, or contributors *could* result in one or more files being removed. Why? Apparently because of our use of buttons as submit buttons instead of as button-type buttons.

## How was this change tested?

locally. I could not reproduce in the test suite so there are no test changes.

## Which documentation and/or configurations were updated?



none