### PR TITLE
descriptive_generator_spec: add spec for organization contrib

### DIFF
--- a/spec/factories/contributors.rb
+++ b/spec/factories/contributors.rb
@@ -15,4 +15,14 @@ FactoryBot.define do
     contributor_type { 'person' }
     role { 'Contributing author' }
   end
+
+  trait :with_org_contributor do
+    sequence :full_name do |n|
+      "organization#{n}"
+    end
+
+    work
+    contributor_type { 'organization' }
+    role { 'Sponsor' }
+  end
 end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -39,6 +39,10 @@ FactoryBot.define do
     contributors { Array.new(contributors_count) { association(:contributor) } }
   end
 
+  trait :with_mixed_contributors do
+    contributors { [association(:contributor), association(:contributor, :with_org_contributor)] }
+  end
+
   trait :with_related_links do
     transient do
       related_links_count { 2 }

--- a/spec/services/description_generator_spec.rb
+++ b/spec/services/description_generator_spec.rb
@@ -37,4 +37,29 @@ RSpec.describe DescriptionGenerator do
       ]
     )
   end
+
+  context 'with mixed contributors' do
+    let(:work) do
+      build(:work, :with_mixed_contributors)
+    end
+    let(:contrib1_name) { "#{work.contributors.first.last_name}, #{work.contributors.first.first_name}" }
+    let(:contrib2_name) { work.contributors.last.full_name }
+
+    it 'creates description cocina model for org contribtor' do
+      expect(model).to eq(
+        note: [
+          { type: 'summary', value: 'test abstract' },
+          { type: 'preferred citation', value: 'test citation' },
+          { displayLabel: 'Contact', type: 'contact', value: 'io@io.io' }
+        ],
+        title: [{ value: 'Test title' }],
+        contributor: [
+          { name: [{ value: contrib1_name }], role: [{ value: 'Contributing author' }], type: 'person' },
+          { name: [{ value: contrib2_name }], role: [{ value: 'Sponsor' }], type: 'organization' }
+        ],
+        event: [],
+        subject: []
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?

To add a spec for descriptive metadata mappings for organizational contributors

## How was this change tested?



## Which documentation and/or configurations were updated?



