### PR TITLE
Defer to contributor to have knowledge of its name and type

### DIFF
--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -69,6 +69,13 @@ class Contributor < ApplicationRecord
     contributor_type == 'person'
   end
 
+  sig { returns(T.nilable(String)) }
+  def formatted_name
+    return full_name unless person?
+
+    "#{last_name}, #{first_name}"
+  end
+
   # used by work_form
   sig { returns(String) }
   def role_term

--- a/app/services/description_generator.rb
+++ b/app/services/description_generator.rb
@@ -36,7 +36,7 @@ class DescriptionGenerator
   def title
     [
       {
-        "value": work.title
+        value: work.title
       }
     ]
   end
@@ -45,8 +45,8 @@ class DescriptionGenerator
   def keywords
     work.keywords.map do |keyword|
       {
-        "value": keyword.label,
-        "type": 'topic'
+        value: keyword.label,
+        type: 'topic'
       }
     end
   end
@@ -54,16 +54,16 @@ class DescriptionGenerator
   sig { returns(T::Hash[String, String]) }
   def abstract
     {
-      "value": work.abstract,
-      "type": 'summary'
+      value: work.abstract,
+      type: 'summary'
     }
   end
 
   sig { returns(T::Hash[String, String]) }
   def citation
     {
-      "value": work.citation,
-      "type": 'preferred citation'
+      value: work.citation,
+      type: 'preferred citation'
     }
   end
 
@@ -72,12 +72,12 @@ class DescriptionGenerator
     return unless work.created_edtf
 
     {
-      "type": 'creation',
-      "date": [
+      type: 'creation',
+      date: [
         {
-          "value": work.created_edtf,
-          "encoding": {
-            "code": 'edtf'
+          value: work.created_edtf,
+          encoding: {
+            code: 'edtf'
           }
         }
       ]
@@ -89,12 +89,12 @@ class DescriptionGenerator
     return unless work.published_edtf
 
     {
-      "type": 'publication',
-      "date": [
+      type: 'publication',
+      date: [
         {
-          "value": work.published_edtf,
-          "encoding": {
-            "code": 'edtf'
+          value: work.published_edtf,
+          encoding: {
+            code: 'edtf'
           }
         }
       ]
@@ -104,9 +104,9 @@ class DescriptionGenerator
   sig { returns(T::Hash[String, String]) }
   def contact
     {
-      "value": work.contact_email,
-      "type": 'contact',
-      "displayLabel": 'Contact'
+      value: work.contact_email,
+      type: 'contact',
+      displayLabel: 'Contact'
     }
   end
 
@@ -124,40 +124,27 @@ class DescriptionGenerator
   # in cocina model terms, returns a DescriptiveValue
   sig do
     params(work_form_contributor: Contributor)
-      .returns({ name: [{ value: T.untyped }], type: String, role: [{ value: T.untyped }] })
+      .returns({
+                 name: T::Array[T::Hash[Symbol, T.nilable(String)]],
+                 type: String,
+                 role: T::Array[T::Hash[Symbol, String]]
+               })
   end
   def contributor(work_form_contributor)
-    # TODO: we may know status primary
-    if work_form_contributor.person?
-      {
-        "name": [
-          {
-            "value": "#{work_form_contributor.last_name}, #{work_form_contributor.first_name}"
-          }
-        ],
-        "type": 'person',
-        # TODO: we will know code, uri, source code and source uri
-        "role": [
-          {
-            "value": work_form_contributor.role
-          }
-        ]
-      }
-    else
-      {
-        "name": [
-          {
-            "value": work_form_contributor.full_name
-          }
-        ],
-        "type": 'organization',
-        "role": [
-          {
-            "value": work_form_contributor.role
-          }
-        ]
-      }
-    end
+    {
+      name: [
+        {
+          value: work_form_contributor.formatted_name
+        }
+      ],
+      type: work_form_contributor.contributor_type,
+      # TODO: we will know code, uri, source code and source uri
+      role: [
+        {
+          value: work_form_contributor.role
+        }
+      ]
+    }
   end
 end
 # rubocop:enable Metrics/ClassLength


### PR DESCRIPTION

## Why was this change made?

This small refactoring makes a few small tweaks to the `Contributor` model and `DescriptionGenerator` service that allow the latter to defer to the former regarding how its name is formatted (and what its type is).

It also:

* Tightens up a type signature (though maybe that change is six-of-one-half-dozen-of-the-other as we all learn how to get value out of Sorbet); and 
* Abandons a potentially misleading Ruby hash style where the keys appear as strings but are actually symbols. *e.g.*, `{ "value": "foo" }["value"]` evaluates to `nil` rather than `"foo"` which might be surprising, and the extraneous quotes are doing nothing for us. So, dump them.

## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None

