### PR TITLE
Use the structs we have rather than defining complex interfaces

### DIFF
--- a/app/services/request_generator.rb
+++ b/app/services/request_generator.rb
@@ -15,27 +15,23 @@ class RequestGenerator
     @work = work
   end
 
+  sig { returns(Cocina::Models::RequestDRO) }
   def generate_model
-    Cocina::Models::RequestDRO.new(generate)
-  end
-
-  sig { returns(Hash) }
-  def generate
-    {
-      administrative: {
-        hasAdminPolicy: Settings.h2.hydrus_apo
-      },
-      identification: {
-        sourceId: "hydrus:#{work.id}" # TODO: what should this be?
-      },
-      structural: {
-        contains: work.attached_files.map { |af| build_fileset(af) }
-      },
-      label: work.title,
-      type: cocina_type,
-      description: DescriptionGenerator.generate(work: work),
-      version: 0
-    }
+    Cocina::Models::RequestDRO.new({
+                                     administrative: {
+                                       hasAdminPolicy: Settings.h2.hydrus_apo
+                                     },
+                                     identification: {
+                                       sourceId: "hydrus:#{work.id}" # TODO: what should this be?
+                                     },
+                                     structural: {
+                                       contains: work.attached_files.map { |af| build_fileset(af) }
+                                     },
+                                     label: work.title,
+                                     type: cocina_type,
+                                     description: DescriptionGenerator.generate(work: work),
+                                     version: 0
+                                   }, false, false)
   end
 
   private

--- a/sorbet/custom/cocina-models.rbi
+++ b/sorbet/custom/cocina-models.rbi
@@ -1,0 +1,42 @@
+# typed: strong
+
+# A manually created (partial) interface for Cocina::Models.
+# Structs are hard for sorbet to infer automatically, see https://sorbet.org/docs/tstruct
+module Cocina::Models
+  class Title
+    sig { params(value: String).void }
+    def initialize(value:); end
+  end
+
+  class Contributor
+    sig { params(name: T::Array[T.any(DescriptiveValue, T::Hash[T.untyped, T.untyped])],
+                 type: String,
+                 role: T::Array[T.any(DescriptiveValue, T::Hash[T.untyped, T.untyped])]).void }
+    def initialize(name:, type:, role:); end
+  end
+
+  class DescriptiveValue
+    sig { params(value: String, type: String, displayLabel: String).void }
+    def initialize(value:, type: nil, displayLabel: nil); end
+  end
+
+  class Event
+    sig { params(type: String, date: T::Array[T.any(DescriptiveValue, T::Hash[T.untyped, T.untyped])]).void }
+    def initialize(type:, date:); end
+  end
+
+  class DescriptiveAccessMetadata
+  sig { params(url: T::Array[DescriptiveValue]).void }
+  def initialize(url:); end
+  end
+
+  class RelatedResource
+    sig do
+      params(type: String,
+             access: DescriptiveAccessMetadata,
+             title: T::Array[DescriptiveValue],
+             note: T::Array[DescriptiveValue]).void
+    end
+    def initialize(type:, access: nil, title: nil, note: nil); end
+  end
+end

--- a/spec/services/description_generator_spec.rb
+++ b/spec/services/description_generator_spec.rb
@@ -4,7 +4,7 @@
 require 'rails_helper'
 
 RSpec.describe DescriptionGenerator do
-  subject(:model) { described_class.generate(work: work) }
+  subject(:model) { described_class.generate(work: work).to_h }
 
   let(:work) do
     build(:work, :with_creation_dates, :published, :with_keywords, :with_contributors,


### PR DESCRIPTION
Unfortunately sorbet doesn't understand dry-struct signatures, so I had to manually define a partial interface to Cocina::Models.  We might want to look at moving cocina-models from dry-struct to https://sorbet.org/docs/tstruct

## Why was this change made?

Discussion  in infrastructure meeting today.

## How was this change tested?



## Which documentation and/or configurations were updated?



