### PR TITLE
DescriptionGenerator: map #related_works to cocina representation

### DIFF
--- a/app/services/description_generator.rb
+++ b/app/services/description_generator.rb
@@ -24,7 +24,7 @@ class DescriptionGenerator
       subject: keywords,
       note: [abstract, citation, contact],
       event: [created_date, published_date].compact,
-      relatedResource: related_resource
+      relatedResource: related_links + related_works
     }
   end
 
@@ -169,7 +169,7 @@ class DescriptionGenerator
       )
     ])
   end
-  def related_resource
+  def related_links
     work.related_links.map do |rel_link|
       {
         type: 'related to',
@@ -177,6 +177,18 @@ class DescriptionGenerator
       }.tap do |h|
         h[:title] = [{ value: rel_link.link_title }] if rel_link.link_title.present?
       end
+    end
+  end
+
+  sig { returns(T::Array[{ type: String, note: T::Array[{ type: String, value: String }] }]) }
+  def related_works
+    work.related_works.map do |rel_work|
+      {
+        type: 'related to',
+        note: [
+          { type: 'preferred citation', value: rel_work.citation }
+        ]
+      }
     end
   end
 end

--- a/spec/services/description_generator_spec.rb
+++ b/spec/services/description_generator_spec.rb
@@ -7,12 +7,16 @@ RSpec.describe DescriptionGenerator do
   subject(:model) { described_class.generate(work: work) }
 
   let(:work) do
-    build(:work, :with_creation_dates, :published, :with_keywords,
-          :with_contributors, :with_some_untitled_related_links)
+    build(:work, :with_creation_dates, :published, :with_keywords, :with_contributors,
+          :with_some_untitled_related_links, :with_related_works)
   end
   let(:contrib1_name) { "#{work.contributors.first.last_name}, #{work.contributors.first.first_name}" }
   let(:contrib2_name) { "#{work.contributors[1].last_name}, #{work.contributors[1].first_name}" }
   let(:contrib3_name) { "#{work.contributors.last.last_name}, #{work.contributors.last.first_name}" }
+  let(:citation_value) do
+    'Giarlo, M.J. (2013). Academic Libraries as Data Quality Hubs. '\
+        'Journal of Librarianship and Scholarly Communication, 1(3).'
+  end
 
   it 'creates description cocina model' do
     expect(model).to eq(
@@ -54,6 +58,14 @@ RSpec.describe DescriptionGenerator do
         {
           type: 'related to',
           access: { url: [{ value: 'https://your.awesome.research.ai' }] }
+        },
+        {
+          type: 'related to',
+          note: [{ value: citation_value, type: 'preferred citation' }]
+        },
+        {
+          type: 'related to',
+          note: [{ value: citation_value, type: 'preferred citation' }]
         }
       ]
     )


### PR DESCRIPTION
## Why was this change made?

Implement the mapping from H2 `RelatedWork` model to Cocina `description` `relatedResource`.

closes #340

example from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_related_resource.txt --
```
1. Related citation
Stanford University (Stanford, CA.). (2020). May 2020 dataset. Atmospheric Pressure. Professor Maya Aguirre. Department of Earth Sciences, Stanford University.
{
  "relatedResource": [
    {
      "type": "related to",
      "note": [
        {
          "value": "Stanford University (Stanford, CA.). (2020). May 2020 dataset. Atmospheric Pressure. Professor Maya Aguirre. Department of Earth Sciences, Stanford University.",
          "type": "preferred citation"
        }
      ]
    }
  ]
}
<relatedItem>
  <note type="preferred citation">Stanford University (Stanford, CA.). (2020). May 2020 dataset. Atmospheric Pressure. Professor Maya Aguirre. Department of Earth Sciences, Stanford University.</note>
</relatedItem>
```
## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?

n/a