### PR TITLE
Type alias antics

### DIFF
--- a/app/models/related_link.rb
+++ b/app/models/related_link.rb
@@ -3,7 +3,25 @@
 
 # Models a URI that is related to a work
 class RelatedLink < ApplicationRecord
+  extend T::Sig
+
+  COCINA_HASH_TYPE_NO_TITLE = T.type_alias { { type: String, access: { url: T::Array[{ value: String }] } } }
+  COCINA_HASH_TYPE_WITH_TITLE = T.type_alias do
+    { type: String, access: { url: T::Array[{ value: String }] }, title: T::Array[{ value: String }] }
+  end
+  COCINA_HASH_TYPE = T.type_alias { T.any(COCINA_HASH_TYPE_NO_TITLE, COCINA_HASH_TYPE_WITH_TITLE) }
+
   belongs_to :work
 
   validates :url, presence: true
+
+  sig { returns(COCINA_HASH_TYPE) }
+  def to_cocina_hash
+    {
+      type: 'related to',
+      access: { url: [{ value: url }] }
+    }.tap do |h|
+      h[:title] = [{ value: link_title }] if link_title.present?
+    end
+  end
 end

--- a/app/models/related_work.rb
+++ b/app/models/related_work.rb
@@ -3,7 +3,21 @@
 
 # Models a citation of a work that is related to the deposited work.
 class RelatedWork < ApplicationRecord
+  extend T::Sig
+
+  COCINA_HASH_TYPE = T.type_alias { { type: String, note: T::Array[{ type: String, value: String }] } }
+
   belongs_to :work
 
   validates :citation, presence: true
+
+  sig { returns(COCINA_HASH_TYPE) }
+  def to_cocina_hash
+    {
+      type: 'related to',
+      note: [
+        { type: 'preferred citation', value: citation }
+      ]
+    }
+  end
 end

--- a/app/services/description_generator.rb
+++ b/app/services/description_generator.rb
@@ -161,35 +161,14 @@ class DescriptionGenerator
     end
   end
 
-  sig do
-    returns(T::Array[
-      T.any(
-        { type: String, access: { url: T::Array[{ value: String }] } },
-        { type: String, access: { url: T::Array[{ value: String }] }, title: T::Array[{ value: String }] }
-      )
-    ])
-  end
+  sig { returns(T::Array[RelatedLink::COCINA_HASH_TYPE]) }
   def related_links
-    work.related_links.map do |rel_link|
-      {
-        type: 'related to',
-        access: { url: [{ value: rel_link.url }] }
-      }.tap do |h|
-        h[:title] = [{ value: rel_link.link_title }] if rel_link.link_title.present?
-      end
-    end
+    work.related_links.map(&:to_cocina_hash)
   end
 
-  sig { returns(T::Array[{ type: String, note: T::Array[{ type: String, value: String }] }]) }
+  sig { returns(T::Array[RelatedWork::COCINA_HASH_TYPE]) }
   def related_works
-    work.related_works.map do |rel_work|
-      {
-        type: 'related to',
-        note: [
-          { type: 'preferred citation', value: rel_work.citation }
-        ]
-      }
-    end
+    work.related_works.map(&:to_cocina_hash)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/services/description_generator.rb
+++ b/app/services/description_generator.rb
@@ -6,7 +6,23 @@
 class DescriptionGenerator
   extend T::Sig
 
-  sig { params(work: Work).returns(T::Hash[Symbol, T::Array[T::Hash[String, T.untyped]]]) }
+  STRING_HASH_TYPE = T.type_alias { T::Hash[String, String] }
+  STRING_HASH_ARRAY_TYPE = T.type_alias { T::Array[STRING_HASH_TYPE] }
+  NILABLE_DATE_TYPE = T.type_alias do
+    T.nilable({ type: String, date: T::Array[{ value: T.nilable(String), encoding: { code: String } }] })
+  end
+  COCINA_DESCRIPTION_TYPE = T.type_alias do
+    {
+      title: STRING_HASH_ARRAY_TYPE,
+      contributor: T::Array[T::Array[Object]],
+      subject: STRING_HASH_ARRAY_TYPE,
+      note: [STRING_HASH_TYPE, STRING_HASH_TYPE, STRING_HASH_TYPE],
+      event: T::Array[NILABLE_DATE_TYPE],
+      relatedResource: T::Array[T.any(RelatedLink::COCINA_HASH_TYPE, RelatedWork::COCINA_HASH_TYPE)]
+    }
+  end
+
+  sig { params(work: Work).returns(COCINA_DESCRIPTION_TYPE) }
   def self.generate(work:)
     new(work: work).generate
   end
@@ -16,7 +32,7 @@ class DescriptionGenerator
     @work = work
   end
 
-  sig { returns(T::Hash[Symbol, T::Array[T::Hash[String, T.untyped]]]) }
+  sig { returns(COCINA_DESCRIPTION_TYPE) }
   def generate
     {
       title: title,
@@ -33,7 +49,7 @@ class DescriptionGenerator
   sig { returns(Work) }
   attr_reader :work
 
-  sig { returns(T::Array[T::Hash[String, String]]) }
+  sig { returns(STRING_HASH_ARRAY_TYPE) }
   def title
     [
       {
@@ -42,7 +58,7 @@ class DescriptionGenerator
     ]
   end
 
-  sig { returns(T::Array[T::Hash[String, String]]) }
+  sig { returns(STRING_HASH_ARRAY_TYPE) }
   def keywords
     work.keywords.map do |keyword|
       {
@@ -52,7 +68,7 @@ class DescriptionGenerator
     end
   end
 
-  sig { returns(T::Hash[String, String]) }
+  sig { returns(STRING_HASH_TYPE) }
   def abstract
     {
       "value": work.abstract,
@@ -60,7 +76,7 @@ class DescriptionGenerator
     }
   end
 
-  sig { returns(T::Hash[String, String]) }
+  sig { returns(STRING_HASH_TYPE) }
   def citation
     {
       "value": work.citation,
@@ -68,7 +84,7 @@ class DescriptionGenerator
     }
   end
 
-  sig { returns(T.nilable(T::Hash[String, T.any(String, T::Array[T.untyped])])) }
+  sig { returns(NILABLE_DATE_TYPE) }
   def created_date
     return unless work.created_edtf
 
@@ -85,7 +101,7 @@ class DescriptionGenerator
     }
   end
 
-  sig { returns(T.nilable(T::Hash[String, T.any(String, T::Array[T.untyped])])) }
+  sig { returns(NILABLE_DATE_TYPE) }
   def published_date
     return unless work.published_edtf
 
@@ -102,7 +118,7 @@ class DescriptionGenerator
     }
   end
 
-  sig { returns(T::Hash[String, String]) }
+  sig { returns(STRING_HASH_TYPE) }
   def contact
     {
       "value": work.contact_email,

--- a/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -41655,6 +41655,11 @@ module RelatedLink::GeneratedRelationMethods
   extend ::Mutex_m
 end
 
+class RelatedLink
+  extend ::T::Private::Methods::MethodHooks
+  extend ::T::Private::Methods::SingletonMethodHooks
+end
+
 class RelatedWork
   def autosave_associated_records_for_work(*args); end
 end
@@ -41687,6 +41692,11 @@ end
 
 module RelatedWork::GeneratedRelationMethods
   extend ::Mutex_m
+end
+
+class RelatedWork
+  extend ::T::Private::Methods::MethodHooks
+  extend ::T::Private::Methods::SingletonMethodHooks
 end
 
 module Reline


### PR DESCRIPTION
leaving this as a draft based on the unmerged branch it refactors, for discussion.

## Why was this change made?

As an experiment with refactoring and type aliases, to see whether people like any of the changes here.  Could be a useful pattern for dealing with complex return types?

I started on the refactoring suggested by @mjgiarlo in a review comment on another PR (https://github.com/sul-dlss/happy-heron/pull/408#discussion_r520778696), because it seemed a quick enough thing to try while that part of the code was already in my working memory.

Pushing the cocina hash building back into the relevant model in the first commit made me want to define reusable types to cut down on repetition.

Then in the second commit I sort of leaned on type aliases to build up somewhat more exacting return signatures that (I found) readable.

Off the top of my head, the pros and cons of the second commit seem to be...
* pros
  * less of a mess of nested array and hash types everywhere
  * reusable/composable parts let you define canonical types in one place and put them together elsewhere
  * lets you do validation of complex shapes built up by helper methods, without so much repetitive type declaration
  * lets you easily see when two methods which have complex return shapes actually return the same thing
* cons
  * more indirection/constant definition
  * may have to page or tab around or look at multiple sigs to figure out the full shape of a type composed from type aliases
  * i have no idea whether this type aliasing construct will need re-working once ruby supports type info natively

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?

arguably makes the code more self-documenting?

