### PR TITLE
Unauthenticated users should not able to view works

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -3,7 +3,7 @@
 
 # The endpoint for CRUD about a Work
 class WorksController < ApplicationController
-  before_action :authenticate_user!, except: [:show]
+  before_action :authenticate_user!
   before_action :ensure_sdr_updatable
   verify_authorized except: [:show]
 

--- a/spec/requests/works_spec.rb
+++ b/spec/requests/works_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe 'Works requests' do
       expect(response).to redirect_to(new_user_session_path)
     end
 
-    it 'allows GETs to /works/:work_id' do
+    it 'redirects from /works/:work_id to login URL' do
       get "/works/#{work.id}"
-      expect(response).to have_http_status(:ok)
+      expect(response).to redirect_to(new_user_session_path)
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

We don't have a requirement to let in unauthenticated users.

## How was this change tested?



## Which documentation and/or configurations were updated?



