### PR TITLE
Updates to show page

### DIFF
--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -24,23 +24,15 @@
       <% end %>
       <tr>
         <th scope="row">Collection</th>
-        <td><%= @work.collection.name %></td>
+        <td><%= link_to @work.collection.name, @work.collection %></td>
       </tr>
       <tr>
         <th scope="row">Deposit type</th>
         <td><%= @work.work_type %></td>
       </tr>
       <tr>
-        <th scope="row">Deposit subtypes</th>
-        <td><%= @work.subtype.join(', ') %></td>
-      </tr>
-      <tr>
         <th scope="row">Depositor</th>
         <td><%= @work.depositor %></td>
-      </tr>
-      <tr>
-        <th scope="row">Contact</th>
-        <td><%= @work.contact_email %>></td>
       </tr>
       <tr>
         <th scope="row">Version details</th>
@@ -95,7 +87,7 @@
       </tr>
       <tr>
         <th scope="row">Contact</th>
-        <td><%= @work.contact_email %>></td>
+        <td><%= @work.contact_email %></td>
       </tr>
       </tbody>
     </table>
@@ -108,10 +100,14 @@
       </tr>
       </thead>
       <tbody>
-      <% @work.contributors.each do |c| %>
+      <% @work.contributors.each do |contributor| %>
         <tr>
-          <td><%= c.first_name %> <%= c.last_name %></td>
-          <td><%= c.role %></td>
+          <% if contributor.person? %>
+            <td><%= contributor.first_name %> <%= contributor.last_name %></td>
+          <% else %>
+            <td><%= contributor.full_name %></td>
+          <% end %>
+          <td><%= contributor.role %></td>
         </tr>
       <% end %>
       </tbody>
@@ -139,21 +135,6 @@
     <table class="table table-sm mb-5">
       <thead class="table-light">
       <tr>
-        <th scope="col" class="table-title col-3">Collection</th>
-        <th scope="col"></th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr>
-        <th scope="row">Collection</th>
-        <td><%= @work.collection.name %></td>
-      </tr>
-      </tbody>
-    </table>
-
-    <table class="table table-sm mb-5">
-      <thead class="table-light">
-      <tr>
         <th scope="col" class="table-title col-3">Description<%= link_to edit_work_path(@work, anchor: "description"), aria: { label: "Edit description"} do %><span class="fas fa-pencil-alt edit"></span><% end %></th>
         <th scope="col"></th>
       </tr>
@@ -166,6 +147,10 @@
       <tr>
         <th scope="row">Keywords</th>
         <td><%= @work.keywords.map {|keyword| keyword.label}.join(', ') %></td>
+      </tr>
+      <tr>
+        <th scope="row">Deposit subtypes</th>
+        <td><%= @work.subtype.join(', ') %></td>
       </tr>
       <tr>
         <th scope="row">Preferred citation</th>
@@ -227,6 +212,5 @@
       </tr>
       </tbody>
     </table>
-
   </section>
 </div>

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -60,6 +60,9 @@ RSpec.describe 'Create a new collection and deposit to it', js: true do
       fill_in 'Title of deposit', with: 'My Title'
       fill_in 'Contact email', with: user.email
 
+      select 'Publisher', from: 'Role term'
+      fill_in 'Name', with: 'Best Publisher'
+
       fill_in 'Publication year', with: '2020'
       select 'February', from: 'Publication month'
 
@@ -110,9 +113,12 @@ RSpec.describe 'Create a new collection and deposit to it', js: true do
       click_button 'Deposit'
 
       expect(page).to have_content('My Title')
+      expect(page).to have_link(Collection.last.name)
+      expect(page).to have_content(user.email)
       expect(page).to have_content('sound')
       expect(page).to have_content('Course/instruction, Musical notation, Poetry reading')
       expect(page).to have_content(user.email)
+      expect(page).to have_content('Best Publisher')
       expect(page).to have_content('2020-03-06/2020-10-30')
       expect(page).to have_content('Whatever')
       expect(page).to have_content('CC-PDDC Public Domain Dedication and Certification')
@@ -131,8 +137,7 @@ RSpec.describe 'Create a new collection and deposit to it', js: true do
       check 'I agree to the SDR Terms of Deposit'
       click_button 'Deposit'
 
-      expect(page).not_to have_content('title = My Title')
-      expect(page).not_to have_content('agree_to_terms = true')
+      expect(page).not_to have_content('My Title')
       expect(page).to have_content('Deposit your content')
     end
   end


### PR DESCRIPTION
Fixes #424


## Why was this change made?

This commit includes a number of enhancements to the show page in line with the most recently requested changes:

* Link to collection in Details section
* Move subtypes from Details to Description section
* Remove contact email from Details section
* Remove stray angle bracket from contact email
* Allow for organizational contributors to show up
* Remove entire Collection section

### BEFORE

![Screenshot from 2020-11-11 15-55-56](https://user-images.githubusercontent.com/131982/98878656-594e3c00-2438-11eb-8a3d-3b8bf9c97655.png)

### AFTER

![Screenshot from 2020-11-11 15-55-25](https://user-images.githubusercontent.com/131982/98878667-5f441d00-2438-11eb-8e06-e33f8c57cda9.png)


## How was this change tested?

Locally and CI

## Which documentation and/or configurations were updated?

None

