### PR TITLE
contributor mappings improvements

### DIFF
--- a/app/services/contributors_generator.rb
+++ b/app/services/contributors_generator.rb
@@ -1,0 +1,243 @@
+# typed: true
+# frozen_string_literal: true
+
+# generates Cocina::Models::Contributors to be used by DescriptionGenerator (ultimately in a Cocina::Models::RequestDRO)
+# rubocop:disable Metrics/ClassLength
+class ContributorsGenerator
+  extend T::Sig
+
+  sig { params(work: Work).returns(T::Array[Cocina::Models::Contributor]) }
+  def self.generate(work:)
+    new(work: work).generate
+  end
+
+  sig { params(work: Work).returns(T::Array[Cocina::Models::DescriptiveValue]) }
+  def self.form_from_contributors(work:)
+    new(work: work).form_from_contributors
+  end
+
+  sig { params(work: Work).void }
+  def initialize(work:)
+    @work = work
+  end
+
+  sig { returns(T::Array[Cocina::Models::Contributor]) }
+  def generate
+    result = []
+
+    work.contributors.each do |work_form_contributor|
+      result << contributor(work_form_contributor)
+    end
+
+    result
+  end
+
+  FORM_EVENT = Cocina::Models::DescriptiveValue.new(
+    {
+      value: 'Event',
+      type: 'resource types',
+      source: { value: 'DataCite resource types' }
+    }
+  )
+
+  sig { returns(T::Array[Cocina::Models::DescriptiveValue]) }
+  def form_from_contributors
+    work.contributors.each do |contributor|
+      next unless contributor.role == 'Conference' || contributor.role == 'Event'
+
+      return [FORM_EVENT]
+    end
+
+    []
+  end
+
+  private
+
+  sig { returns(Work) }
+  attr_reader :work
+
+  sig { params(contributor: Contributor).returns(T.nilable(Cocina::Models::Contributor)) }
+  def contributor(contributor)
+    # FIXME: TODO: mappings for status (primary) and/or order
+    Cocina::Models::Contributor.new(
+      "name": name_descriptive_value(contributor),
+      "type": contributor_type(contributor),
+      "role": cocina_roles(contributor.role)
+    )
+  end
+
+  sig { params(contributor: Contributor).returns(T::Array[Cocina::Models::DescriptiveValue]) }
+  def name_descriptive_value(contributor)
+    return [Cocina::Models::DescriptiveValue.new(value: full_name(contributor))] unless contributor.person?
+
+    [Cocina::Models::DescriptiveValue.new(value: full_name(contributor), type: 'inverted full name')]
+  end
+
+  sig { params(contributor: Contributor).returns(T.nilable(String)) }
+  def full_name(contributor)
+    return "#{contributor.last_name}, #{contributor.first_name}" if contributor.person?
+
+    contributor.full_name
+  end
+
+  sig { params(contributor: Contributor).returns(String) }
+  def contributor_type(contributor)
+    return 'conference' if contributor.role == 'Conference'
+    return 'event' if contributor.role == 'Event'
+
+    contributor.contributor_type
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  sig { params(role: String).returns(T::Array[Cocina::Models::DescriptiveValue]) }
+  def cocina_roles(role)
+    result = [
+      Cocina::Models::DescriptiveValue.new(
+        value: role,
+        source: {
+          value: 'Stanford self-deposit contributor types'
+        }
+      )
+    ]
+    result << T.must(marcrelator_role(role)) if marcrelator_role(role)
+    result << T.must(datacite_role(role)) if datacite_role(role)
+    result
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  # rubocop:disable Metrics/MethodLength
+  sig { params(role: String).returns(T.nilable(Cocina::Models::DescriptiveValue)) }
+  def marcrelator_role(role)
+    mr_code = ROLE_TO_MARC_RELATOR_CODE[role]
+    mr_value = MARC_RELATOR_CODE_TO_VALUE[mr_code]
+    return unless mr_code || mr_value
+
+    Cocina::Models::DescriptiveValue.new(
+      value: mr_value,
+      code: mr_code,
+      uri: "http://id.loc.gov/vocabulary/relators/#{mr_code}",
+      source: {
+        code: 'marcrelator',
+        uri: 'http://id.loc.gov/vocabulary/relators/'
+      }
+    )
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  # rubocop:disable Metrics/MethodLength
+  sig { params(role: String).returns(T.nilable(Cocina::Models::DescriptiveValue)) }
+  def datacite_role(role)
+    datacite_role = ROLE_TO_DATA_CITE_VALUE[role]
+    return if datacite_role.blank?
+
+    case datacite_role
+    when String
+      datacite_source = 'DataCite contributor types'
+    when :creator
+      datacite_role = datacite_role.to_s.capitalize
+      datacite_source = 'DataCite properties'
+    end
+
+    Cocina::Models::DescriptiveValue.new(
+      value: datacite_role,
+      source: {
+        value: datacite_source
+      }
+    )
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  ROLE_TO_MARC_RELATOR_CODE = {
+    # person
+    'Author' => 'aut',
+    'Composer' => 'cmp',
+    'Contributing author' => 'ctb',
+    'Copyright holder' => 'cph',
+    'Creator' => 'cre',
+    'Data collector' => 'com',
+    'Data contributor' => 'dtc',
+    'Editor' => 'edt',
+    'Event organizer' => 'orm',
+    'Interviewee' => 'ive',
+    'Interviewer' => 'ivr',
+    'Performer' => 'prf',
+    'Photographer' => 'pht',
+    'Primary thesis advisor' => 'ths',
+    'Principal investigator' => 'rth',
+    'Researcher' => 'res',
+    'Software developer' => 'prg',
+    'Speaker' => 'spk',
+    'Thesis advisor' => 'ths',
+    # organization (when not already listed above)
+    # 'Conference' => '', # not a marcrelator role
+    'Degree granting institution' => 'dgg',
+    # 'Event' => '', # not a marcrelator role
+    'Funder' => 'fnd',
+    'Host institution' => 'his',
+    'Issuing body' => 'isb',
+    'Publisher' => 'pbl',
+    'Research group' => 'res',
+    'Sponsor' => 'spn'
+  }.freeze
+
+  MARC_RELATOR_CODE_TO_VALUE = {
+    'aut' => 'author',
+    'cmp' => 'composer',
+    'com' => 'compiler',
+    'cph' => 'copyright holder',
+    'cre' => 'creator',
+    'ctb' => 'contributor',
+    'dgg' => 'degree granting institution',
+    'dtc' => 'data contributor',
+    'edt' => 'editor',
+    'fnd' => 'funder',
+    'his' => 'host institution',
+    'isb' => 'issuing body',
+    'ive' => 'interviewee',
+    'ivr' => 'interviewer',
+    'orm' => 'organizer',
+    'pbl' => 'publisher',
+    'pht' => 'photographer',
+    'prf' => 'performer',
+    'prg' => 'programmer',
+    'res' => 'researcher',
+    'rth' => 'research team head',
+    'spk' => 'speaker',
+    'spn' => 'sponsor',
+    'ths' => 'thesis advisor'
+  }.freeze
+
+  ROLE_TO_DATA_CITE_VALUE = {
+    # person
+    'Author' => :creator,
+    'Composer' => :creator,
+    'Contributing author' => :creator,
+    'Copyright holder' => 'RightsHolder',
+    'Creator' => :creator,
+    'Data collector' => 'DataCollector',
+    'Data contributor' => 'Other',
+    'Editor' => 'Editor',
+    'Event organizer' => 'Supervisor',
+    'Interviewee' => 'Other',
+    'Interviewer' => 'Other',
+    'Performer' => 'Other',
+    'Photographer' => :creator,
+    'Primary thesis advisor' => 'Other',
+    'Principal investigator' => 'ProjectLeader',
+    'Researcher' => 'Researcher',
+    'Software developer' => :creator,
+    'Speaker' => 'Other',
+    'Thesis advisor' => 'Other',
+    # organization (when not already listed above)
+    'Conference' => nil, # see form_from_contributors
+    'Degree granting institution' => 'Other',
+    'Event' => nil, # see form_from_contributors
+    'Funder' => nil,
+    'Host institution' => 'HostingInstitution',
+    'Issuing body' => 'Distributor',
+    'Publisher' => nil,
+    'Research group' => 'ResearchGroup',
+    'Sponsor' => 'Sponsor'
+  }.freeze
+end
+# rubocop:enable Metrics/ClassLength

--- a/app/services/description_generator.rb
+++ b/app/services/description_generator.rb
@@ -20,11 +20,12 @@ class DescriptionGenerator
   def generate
     Cocina::Models::Description.new({
                                       title: title,
-                                      contributor: contributors,
+                                      contributor: ContributorsGenerator.generate(work: work),
                                       subject: keywords,
                                       note: [abstract, citation, contact],
                                       event: [created_date, published_date].compact,
-                                      relatedResource: related_links + related_works
+                                      relatedResource: related_links + related_works,
+                                      form: ContributorsGenerator.form_from_contributors(work: work)
                                     }, false, false)
   end
 
@@ -106,50 +107,6 @@ class DescriptionGenerator
       type: 'contact',
       displayLabel: 'Contact'
     )
-  end
-
-  sig { returns(T::Array[Cocina::Models::Contributor]) }
-  def contributors
-    work.contributors.map do |work_form_contributor|
-      contributor(work_form_contributor)
-    end
-  end
-
-  # in cocina model terms, returns a DescriptiveValue
-  sig { params(work_form_contributor: Contributor).returns(Cocina::Models::Contributor) }
-  def contributor(work_form_contributor)
-    # TODO: we may know status primary
-    if work_form_contributor.person?
-      Cocina::Models::Contributor.new(
-        name: [
-          {
-            value: "#{work_form_contributor.last_name}, #{work_form_contributor.first_name}"
-          }
-        ],
-        type: work_form_contributor.contributor_type,
-        # TODO: we will know code, uri, source code and source uri
-        role: [
-          {
-            value: work_form_contributor.role
-          }
-        ]
-      )
-    else
-      Cocina::Models::Contributor.new(
-        name: [
-          {
-            value: work_form_contributor.full_name
-          }
-        ],
-        type: work_form_contributor.contributor_type,
-        # TODO: we will know code, uri, source code and source uri
-        role: [
-          {
-            value: work_form_contributor.role
-          }
-        ]
-      )
-    end
   end
 
   sig { returns(T::Array[Cocina::Models::RelatedResource]) }

--- a/sorbet/custom/cocina-models.rbi
+++ b/sorbet/custom/cocina-models.rbi
@@ -16,8 +16,15 @@ module Cocina::Models
   end
 
   class DescriptiveValue
-    sig { params(value: String, type: String, displayLabel: String).void }
-    def initialize(value:, type: nil, displayLabel: nil); end
+    sig do
+      params(value: T.nilable(String),
+             code: T.nilable(String),
+             uri: T.nilable(String),
+             type: T.nilable(String),
+             source: T.nilable(Object),
+             displayLabel: String).void
+    end
+    def initialize(value: nil, code: nil, uri: nil, type: nil, source: nil, displayLabel: nil); end
   end
 
   class Event

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -43,10 +43,6 @@ FactoryBot.define do
     contributors { Array.new(contributors_count) { association(:contributor) } }
   end
 
-  trait :with_mixed_contributors do
-    contributors { [association(:contributor), association(:contributor, :with_org_contributor)] }
-  end
-
   trait :with_related_links do
     transient do
       related_links_count { 2 }

--- a/spec/services/contributors_generator_spec.rb
+++ b/spec/services/contributors_generator_spec.rb
@@ -1,0 +1,493 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ContributorsGenerator do
+  subject(:cocina_model) { described_class.generate(work: work) }
+
+  let(:stanford_self_deposit_source) do
+    {
+      value: 'Stanford self-deposit contributor types'
+    }
+  end
+  let(:marc_relator_source) do
+    {
+      code: 'marcrelator',
+      uri: 'http://id.loc.gov/vocabulary/relators/'
+    }
+  end
+  let(:datacite_creator_role) do
+    Cocina::Models::DescriptiveValue.new(
+      value: 'Creator',
+      source: {
+        value: 'DataCite properties'
+      }
+    )
+  end
+  let(:contributing_author_roles) do
+    [
+      {
+        value: 'Contributing author',
+        source: stanford_self_deposit_source
+      },
+      Cocina::Models::DescriptiveValue.new(
+        value: 'contributor',
+        code: 'ctb',
+        uri: 'http://id.loc.gov/vocabulary/relators/ctb',
+        source: marc_relator_source
+      ),
+      datacite_creator_role
+    ]
+  end
+  let(:author_roles) do
+    [
+      {
+        value: 'Author',
+        source: stanford_self_deposit_source
+      },
+      {
+        value: 'author',
+        code: 'aut',
+        uri: 'http://id.loc.gov/vocabulary/relators/aut',
+        source: marc_relator_source
+      },
+      datacite_creator_role
+    ]
+  end
+  let(:sponsor_roles) do
+    [
+      {
+        value: 'Sponsor',
+        source: stanford_self_deposit_source
+      },
+      Cocina::Models::DescriptiveValue.new(
+        value: 'sponsor',
+        code: 'spn',
+        uri: 'http://id.loc.gov/vocabulary/relators/spn',
+        source: marc_relator_source
+      ),
+      Cocina::Models::DescriptiveValue.new(
+        value: 'Sponsor',
+        source: {
+          value: 'DataCite contributor types'
+        }
+      )
+    ]
+  end
+  let(:event_form) do
+    Cocina::Models::DescriptiveValue.new(
+      value: 'Event',
+      type: 'resource types',
+      source: {
+        value: 'DataCite resource types'
+      }
+    )
+  end
+
+  context 'without marcrelator mapping' do
+    let(:contributor) { build(:contributor, :with_org_contributor, role: 'Conference') }
+    let(:work) { build(:work, contributors: [contributor]) }
+
+    it 'creates Cocina::Models::Contributor without marc relator role' do
+      expect(cocina_model).to eq(
+        [
+          Cocina::Models::Contributor.new(
+            name: [{ value: contributor.full_name }],
+            type: 'conference',
+            role: [
+              {
+                value: 'Conference',
+                source: stanford_self_deposit_source
+              }
+            ]
+          )
+        ]
+      )
+    end
+  end
+
+  context 'with DataCite creator mapping for role' do
+    let(:contributor) { build(:contributor) }
+    let(:work) { build(:work, contributors: [contributor]) }
+
+    it 'creates Cocina::Models::Contributor with DataCite role' do
+      expect(cocina_model).to eq(
+        [
+          Cocina::Models::Contributor.new(
+            name: [
+              {
+                value: "#{contributor.last_name}, #{contributor.first_name}",
+                type: 'inverted full name'
+              }
+            ],
+            type: 'person',
+            role: contributing_author_roles
+          )
+        ]
+      )
+    end
+  end
+
+  context 'with single name with multiple roles mapping to DataCite creator property' do
+    xit 'TODO: possibly covered with h2 mapping specs ... tune in soon'
+  end
+
+  # from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_contributor.txt
+  describe 'h2 mapping specification examples' do
+    context 'with person with single role' do
+      let(:contributor) { build(:contributor, role: 'Data collector') }
+      let(:work) { build(:work, contributors: [contributor]) }
+
+      # TODO: add status primary
+
+      it 'creates Cocina::Models::Contributor with DataCite role' do
+        expect(cocina_model).to eq(
+          [
+            Cocina::Models::Contributor.new(
+              name: [
+                {
+                  value: "#{contributor.last_name}, #{contributor.first_name}",
+                  type: 'inverted full name'
+                }
+              ],
+              type: 'person',
+              role: [
+                {
+                  value: 'Data collector',
+                  source: stanford_self_deposit_source
+                },
+                Cocina::Models::DescriptiveValue.new(
+                  value: 'compiler',
+                  code: 'com',
+                  uri: 'http://id.loc.gov/vocabulary/relators/com',
+                  source: marc_relator_source
+                ),
+                Cocina::Models::DescriptiveValue.new(
+                  value: 'DataCollector',
+                  source: {
+                    value: 'DataCite contributor types'
+                  }
+                )
+              ]
+            )
+          ]
+        )
+      end
+
+      it 'ContributorsGenerator.form_from_contributors returns []' do
+        expect(described_class.form_from_contributors(work: work)).to eq []
+      end
+    end
+
+    context 'with person with multiple roles, one maps to DataCite creator property' do
+      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_contributor.txt#L50'
+    end
+
+    context 'with organization with single role' do
+      let(:contributor) { build(:contributor, :with_org_contributor, role: 'Host institution') }
+      let(:work) { build(:work, contributors: [contributor]) }
+
+      # TODO: add status primary
+
+      it 'creates Cocina::Models::Contributor without marc relator role' do
+        expect(cocina_model).to eq(
+          [
+            Cocina::Models::Contributor.new(
+              name: [{ value: contributor.full_name }],
+              type: 'organization',
+              role: [
+                {
+                  value: 'Host institution',
+                  source: stanford_self_deposit_source
+                },
+                Cocina::Models::DescriptiveValue.new(
+                  value: 'host institution',
+                  code: 'his',
+                  uri: 'http://id.loc.gov/vocabulary/relators/his',
+                  source: marc_relator_source
+                ),
+                Cocina::Models::DescriptiveValue.new(
+                  value: 'HostingInstitution',
+                  source: {
+                    value: 'DataCite contributor types'
+                  }
+                )
+              ]
+            )
+          ]
+        )
+      end
+    end
+
+    context 'with organization with multiple roles' do
+      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_contributor.txt#L150'
+    end
+
+    context 'with conference as contributor' do
+      let(:contributor) { build(:contributor, :with_org_contributor, role: 'Conference') }
+      let(:work) { build(:work, contributors: [contributor]) }
+
+      it 'creates Cocina::Models::Contributor' do
+        # TODO: add status primary
+        expect(cocina_model).to eq(
+          [
+            Cocina::Models::Contributor.new(
+              name: [{ value: contributor.full_name }],
+              type: 'conference',
+              role: [
+                {
+                  value: 'Conference',
+                  source: stanford_self_deposit_source
+                }
+              ]
+            )
+          ]
+        )
+      end
+
+      it 'ContributorsGenerator.form_from_contributors returns populated form attribute' do
+        form = described_class.form_from_contributors(work: work)
+
+        expect(form).to eq([event_form])
+      end
+    end
+
+    context 'with event as contributor' do
+      let(:contributor) { build(:contributor, :with_org_contributor, role: 'Event') }
+      let(:work) { build(:work, contributors: [contributor]) }
+
+      it 'creates Cocina::Models::Contributor with DataCite role' do
+        # TODO: add status primary
+        expect(cocina_model).to eq(
+          [
+            Cocina::Models::Contributor.new(
+              name: [{ value: contributor.full_name }],
+              type: 'event',
+              role: [
+                {
+                  value: 'Event',
+                  source: stanford_self_deposit_source
+                }
+              ]
+            )
+          ]
+        )
+      end
+
+      it 'ContributorsGenerator.form_from_contributors returns populated form attribute' do
+        form = described_class.form_from_contributors(work: work)
+
+        expect(form).to eq([event_form])
+      end
+    end
+
+    context 'with multiple person contributors' do
+      let(:contributor1) { build(:contributor, role: 'Author') }
+      let(:contributor2) { build(:contributor, role: 'Author') }
+      let(:work) { build(:work, contributors: [contributor1, contributor2]) }
+
+      it 'creates array of Cocina::Models::Contributor, one for each person contributor' do
+        # TODO: add order
+        expect(cocina_model).to eq(
+          [
+            Cocina::Models::Contributor.new(
+              name: [
+                {
+                  value: "#{contributor1.last_name}, #{contributor1.first_name}",
+                  type: 'inverted full name'
+                }
+              ],
+              type: 'person',
+              role: author_roles
+            ),
+            Cocina::Models::Contributor.new(
+              name: [
+                {
+                  value: "#{contributor2.last_name}, #{contributor2.first_name}",
+                  type: 'inverted full name'
+                }
+              ],
+              type: 'person',
+              role: author_roles
+            )
+          ]
+        )
+      end
+    end
+
+    context 'with multiple contributors - person and organization' do
+      let(:contributor1) { build(:contributor, role: 'Author') }
+      let(:contributor2) { build(:contributor, :with_org_contributor, role: 'Sponsor') }
+      let(:work) { build(:work, contributors: [contributor1, contributor2]) }
+
+      it 'creates array of Cocina::Models::Contributors' do
+        # TODO: add status primary / order
+        expect(cocina_model).to eq(
+          [
+            Cocina::Models::Contributor.new(
+              name: [
+                {
+                  value: "#{contributor1.last_name}, #{contributor1.first_name}",
+                  type: 'inverted full name'
+                }
+              ],
+              type: 'person',
+              role: author_roles
+            ),
+            Cocina::Models::Contributor.new(
+              name: [{ value: contributor2.full_name }],
+              type: 'organization',
+              role: sponsor_roles
+            )
+          ]
+        )
+      end
+    end
+
+    context 'with multipe person contributors and organization as author' do
+      let(:contributor1) { build(:contributor, role: 'Author') }
+      let(:contributor2) { build(:contributor, :with_org_contributor, role: 'Author') }
+      let(:contributor3) { build(:contributor, role: 'Author') }
+      let(:work) { build(:work, contributors: [contributor1, contributor2, contributor3]) }
+
+      it 'creates array of Cocina::Models::Contributors' do
+        # TODO: add status primary / order
+        expect(cocina_model).to eq(
+          [
+            Cocina::Models::Contributor.new(
+              name: [
+                {
+                  value: "#{contributor1.last_name}, #{contributor1.first_name}",
+                  type: 'inverted full name'
+                }
+              ],
+              type: 'person',
+              role: author_roles
+            ),
+            Cocina::Models::Contributor.new(
+              name: [{ value: contributor2.full_name }],
+              type: 'organization',
+              role: author_roles
+            ),
+            Cocina::Models::Contributor.new(
+              name: [
+                {
+                  value: "#{contributor3.last_name}, #{contributor3.first_name}",
+                  type: 'inverted full name'
+                }
+              ],
+              type: 'person',
+              role: author_roles
+            )
+          ]
+        )
+      end
+    end
+
+    context 'with multipe person contributors and organization as non-author' do
+      let(:contributor1) { build(:contributor, role: 'Author') }
+      let(:contributor2) { build(:contributor, :with_org_contributor, role: 'Sponsor') }
+      let(:contributor3) { build(:contributor, role: 'Author') }
+      let(:work) { build(:work, contributors: [contributor1, contributor2, contributor3]) }
+
+      it 'creates array of Cocina::Models::Contributors' do
+        # TODO: add status primary / order
+        expect(cocina_model).to eq(
+          [
+            Cocina::Models::Contributor.new(
+              name: [
+                {
+                  value: "#{contributor1.last_name}, #{contributor1.first_name}",
+                  type: 'inverted full name'
+                }
+              ],
+              type: 'person',
+              role: author_roles
+            ),
+            Cocina::Models::Contributor.new(
+              name: [{ value: contributor2.full_name }],
+              type: 'organization',
+              role: sponsor_roles
+            ),
+            Cocina::Models::Contributor.new(
+              name: [
+                {
+                  value: "#{contributor3.last_name}, #{contributor3.first_name}",
+                  type: 'inverted full name'
+                }
+              ],
+              type: 'person',
+              role: author_roles
+            )
+          ]
+        )
+      end
+    end
+
+    context 'with organization as funder' do
+      let(:contributor) { build(:contributor, :with_org_contributor, full_name: 'Stanford University', role: 'Funder') }
+      let(:work) { build(:work, contributors: [contributor]) }
+
+      it 'creates Cocina::Models::Contributor per spec' do
+        # TODO: add status primary
+        expect(cocina_model).to eq(
+          [
+            Cocina::Models::Contributor.new(
+              name: [{ value: contributor.full_name }],
+              type: 'organization',
+              role: [
+                {
+                  value: 'Funder',
+                  source: stanford_self_deposit_source
+                },
+                {
+                  value: 'funder',
+                  code: 'fnd',
+                  uri: 'http://id.loc.gov/vocabulary/relators/fnd',
+                  source: marc_relator_source
+                }
+              ]
+            )
+          ]
+        )
+      end
+    end
+
+    context 'with publisher and publication date entered by user' do
+      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_contributor.txt#L671'
+    end
+
+    context 'with publisher entered by user' do
+      let(:contributor) do
+        build(:contributor,
+              :with_org_contributor, full_name: 'Stanford University Press', role: 'Publisher')
+      end
+      let(:work) { build(:work, contributors: [contributor]) }
+
+      it 'creates Cocina::Models::Contributor per spec' do
+        # TODO: add status primary
+        expect(cocina_model).to eq(
+          [
+            Cocina::Models::Contributor.new(
+              name: [{ value: contributor.full_name }],
+              type: 'organization',
+              role: [
+                {
+                  value: 'Publisher',
+                  source: stanford_self_deposit_source
+                },
+                {
+                  value: 'publisher',
+                  code: 'pbl',
+                  uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                  source: marc_relator_source
+                }
+              ]
+            )
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/services/request_generator_spec.rb
+++ b/spec/services/request_generator_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe RequestGenerator do
               displayLabel: 'Contact'
             }
           ],
-          relatedResource: []
+          relatedResource: [],
+          form: []
         },
         identification: {
           sourceId: "hydrus:#{work.id}"
@@ -89,7 +90,8 @@ RSpec.describe RequestGenerator do
               displayLabel: 'Contact'
             }
           ],
-          relatedResource: []
+          relatedResource: [],
+          form: []
         },
         identification: {
           sourceId: "hydrus:#{work.id}"


### PR DESCRIPTION
part of #240 (map contributors into cocina model)

## Why was this change made?

This PR is mostly focused on getting the h2 contributor details mapped to the cocina model.  My two reference docs from Arcadia:
- https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_contributor.txt#L717
- https://docs.google.com/spreadsheets/d/1CvEd_NODprNhM2D9VfvJBFs1jfAMEUr0kDxXHe2HkL4

This is maybe 85% of the work;  I thought it best to get this up in a PR while I work on the rest, which may be tricky.

The beginnings of these mappings were in the description_generator;  i move those to the new contributors_generator class.

## How was this change tested?

I wrote unit tests, mostly corresponding to Arcadia's mappings, but in 3 cases I haven't yet implemented her specs. I also added a test or two of my own, including one for the full descriptive metadata.

## Which documentation and/or configurations were updated?

my questions peppered Arcadia as I worked;  the two documents above are excellent.

