### PR TITLE
Date range should appear on one line

### DIFF
--- a/app/components/works/dates_component.html.erb
+++ b/app/components/works/dates_component.html.erb
@@ -5,21 +5,19 @@
       Publication date
     </div>
     <div class="col-sm-10">
-      <div class="row">
-        <div class="col-sm-2">
-          <label for="work_published_year" class="visually-hidden">Publication year</label>
-          <%= number_field_tag 'work[published(1i)]', nil, id: 'work_published_year', class: "form-control", min: Settings.earliest_publication_year, max: Time.zone.today.year %>
-          <div class="invalid-feedback">Publication year must be between <%= Settings.earliest_publication_year %> and <%= Time.zone.today.year %></div>
-        </div>
-        <div class="col-sm-3">
-          <label for="work_published_month" class="visually-hidden">Publication month</label>
-          <%= select_month nil, { prefix: 'work', field_name: 'published(2i)', prompt: 'month'}, id: 'work_published_month', class: "form-control" %>
-        </div>
+      <div class="year">
+        <label for="work_published_year" class="visually-hidden">Publication year</label>
+        <%= number_field_tag 'work[published(1i)]', nil, id: 'work_published_year', class: "form-control", min: Settings.earliest_publication_year, max: Time.zone.today.year %>
+        <div class="invalid-feedback">Publication year must be between <%= Settings.earliest_publication_year %> and <%= Time.zone.today.year %></div>
+      </div>
+      <div class="month">
+        <label for="work_published_month" class="visually-hidden">Publication month</label>
+        <%= select_month nil, { prefix: 'work', field_name: 'published(2i)', prompt: 'month'}, id: 'work_published_month', class: "form-control" %>
+      </div>
 
-        <div class="col-sm-2">
-          <label for="work_published_day" class="visually-hidden">Publication day</label>
-          <%= select_day nil, { prefix: 'work', field_name: 'published(3i)', prompt: 'day'}, id: 'work_published_day', class: "form-control" %>
-        </div>
+      <div class="day">
+        <label for="work_published_day" class="visually-hidden">Publication day</label>
+        <%= select_day nil, { prefix: 'work', field_name: 'published(3i)', prompt: 'day'}, id: 'work_published_day', class: "form-control" %>
       </div>
     </div>
   </div>
@@ -36,21 +34,19 @@
       <%= form.label :creation_type_single, 'Single date' %>
     </div>
     <div class="col-sm-10">
-      <div class="row">
-        <div class="col-sm-2">
-          <label for="work_created_year" class="visually-hidden">Created year</label>
-          <%= number_field_tag 'work[created(1i)]', nil, id: 'work_created_year', class: "form-control", min: Settings.earliest_created_year, max: Time.zone.today.year %>
-          <div class="invalid-feedback">Created year must be between <%= Settings.earliest_publication_year %> and <%= Time.zone.today.year %></div>
-        </div>
-        <div class="col-sm-3">
-          <label for="work_created_month" class="visually-hidden">Created month</label>
-          <%= select_month nil, { prefix: 'work', field_name: 'created(2i)', prompt: 'month'}, id: 'work_created_month', class: "form-control" %>
-        </div>
+      <div class="year">
+        <label for="work_created_year" class="visually-hidden">Created year</label>
+        <%= number_field_tag 'work[created(1i)]', nil, id: 'work_created_year', class: "form-control", min: Settings.earliest_created_year, max: Time.zone.today.year %>
+        <div class="invalid-feedback">Created year must be between <%= Settings.earliest_publication_year %> and <%= Time.zone.today.year %></div>
+      </div>
+      <div class="month">
+        <label for="work_created_month" class="visually-hidden">Created month</label>
+        <%= select_month nil, { prefix: 'work', field_name: 'created(2i)', prompt: 'month'}, id: 'work_created_month', class: "form-control" %>
+      </div>
 
-        <div class="col-sm-2">
-          <label for="work_created_day" class="visually-hidden">Created day</label>
-          <%= select_day nil, { prefix: 'work', field_name: 'created(3i)', prompt: 'day'}, id: 'work_created_day', class: "form-control" %>
-        </div>
+      <div class="day">
+        <label for="work_created_day" class="visually-hidden">Created day</label>
+        <%= select_day nil, { prefix: 'work', field_name: 'created(3i)', prompt: 'day'}, id: 'work_created_day', class: "form-control" %>
       </div>
     </div>
   </div>
@@ -61,45 +57,39 @@
        <%= form.label :creation_type_range, 'Date range' %>
     </div>
 
-    <div class="col-md-10">
-      <div class="row">
-        <div class="col-sm-2">
+    <div class="col-md-10 date-range">
+      <div class="start-date">
+        <div class="year">
           <label for="work_created_range_start_year" class="visually-hidden">Created range start year</label>
           <%= number_field_tag 'work[created_range(1i)]', nil, id: 'work_created_range_start_year', class: "form-control", min: Settings.earliest_created_year, max: Time.zone.today.year %>
           <div class="invalid-feedback">Created year must be between <%= Settings.earliest_publication_year %> and <%= Time.zone.today.year %></div>
         </div>
-        <div class="col-sm-3">
+        <div class="month">
           <label for="work_created_range_start_month" class="visually-hidden">Created range start month</label>
           <%= select_month nil, { prefix: 'work', field_name: 'created_range(2i)', prompt: 'month'}, id: 'work_created_range_start_month', class: "form-control" %>
         </div>
-
-        <div class="col-sm-2">
+        <div class="day">
           <label for="work_created_range_start_day" class="visually-hidden">Created range start day</label>
           <%= select_day nil, { prefix: 'work', field_name: 'created_range(3i)', prompt: 'day'}, id: 'work_created_range_start_day', class: "form-control" %>
         </div>
-        <div style="width: 1.5rem; margin-right:.5rem; margin-top:0.5em">
-          to
-        </div>
       </div>
-    </div>
-  </div>
 
-  <div class="row">
-    <div class="col-md-2">
-    </div>
-    <div class="col-md-10">
-      <div class="row">
-        <div class="col-sm-2">
+      <div class="range-separator">
+        to
+      </div>
+
+      <div class="end-date">
+        <div class="year">
           <label for="work_created_range_end_year" class="visually-hidden">Created range end year</label>
           <%= number_field_tag 'work[created_range(4i)]', nil, id: 'work_created_range_end_year', class: "form-control", min: Settings.earliest_created_year, max: Time.zone.today.year %>
           <div class="invalid-feedback">Created year must be between <%= Settings.earliest_publication_year %> and <%= Time.zone.today.year %></div>
         </div>
-        <div class="col-sm-3">
+        <div class="month">
           <label for="work_created_range_end_month" class="visually-hidden">Created range end month</label>
           <%= select_month nil, { prefix: 'work', field_name: 'created_range(5i)', prompt: 'month'}, id: 'work_created_range_end_month', class: "form-control" %>
         </div>
 
-        <div class="col-sm-2">
+        <div class="day">
           <label for="work_created_range_end_day" class="visually-hidden">Created range end day</label>
           <%= select_day nil, { prefix: 'work', field_name: 'created_range(6i)', prompt: 'day'}, id: 'work_created_range_end_day', class: "form-control" %>
         </div>

--- a/app/javascript/stylesheets/editor.scss
+++ b/app/javascript/stylesheets/editor.scss
@@ -51,6 +51,42 @@
     }
   }
 
+  #dates {
+    .year, .month, .day {
+      display: inline-block;
+      vertical-align: top;
+    }
+
+    .year {
+      width: 6rem;
+      margin-right: 1rem;
+
+      .invalid-feedback {
+        white-space: nowrap;
+      }
+    }
+
+    .month {
+      width: 8rem;
+      margin-right: 1rem;
+    }
+
+    .day {
+      width: 4.9rem;
+    }
+
+    .date-range {
+      display: flex;
+      flex-wrap: wrap;
+
+      .range-separator {
+        width: 1.5rem;
+        margin: .5rem;
+        text-align: center;
+      }
+    }
+  }
+
   .form-check .invalid-feedback::before {
     background-image: escape-svg($form-feedback-icon-invalid);
     background-repeat: no-repeat;


### PR DESCRIPTION

 if the browser window is large enough


## Why was this change made?
Fixes #383


## How was this change tested?


<img width="755" alt="Screen Shot 2020-11-13 at 8 25 30 AM" src="https://user-images.githubusercontent.com/92044/99082651-0c7a7a80-258a-11eb-9a32-673a7fe74c5b.png">
<img width="1165" alt="Screen Shot 2020-11-13 at 8 25 20 AM" src="https://user-images.githubusercontent.com/92044/99082655-0daba780-258a-11eb-9420-69658f2f99d3.png">


## Which documentation and/or configurations were updated?



