### PR TITLE
Extract the EDTF handling from the WorkForm

### DIFF
--- a/app/components/works/dates_component.html.erb
+++ b/app/components/works/dates_component.html.erb
@@ -7,8 +7,8 @@
     <div class="col-sm-10">
       <div class="year">
         <label for="work_published_year" class="visually-hidden">Publication year</label>
-        <%= number_field_tag 'work[published(1i)]', nil, id: 'work_published_year', class: "form-control", min: Settings.earliest_publication_year, max: Time.zone.today.year %>
-        <div class="invalid-feedback">Publication year must be between <%= Settings.earliest_publication_year %> and <%= Time.zone.today.year %></div>
+        <%= number_field_tag 'work[published(1i)]', nil, id: 'work_published_year', class: "form-control", min: earliest_year, max: Time.zone.today.year %>
+        <div class="invalid-feedback">Publication year must be between <%= earliest_year %> and <%= Time.zone.today.year %></div>
       </div>
       <div class="month">
         <label for="work_published_month" class="visually-hidden">Publication month</label>
@@ -36,8 +36,8 @@
     <div class="col-sm-10">
       <div class="year">
         <label for="work_created_year" class="visually-hidden">Created year</label>
-        <%= number_field_tag 'work[created(1i)]', nil, id: 'work_created_year', class: "form-control", min: Settings.earliest_created_year, max: Time.zone.today.year %>
-        <div class="invalid-feedback">Created year must be between <%= Settings.earliest_publication_year %> and <%= Time.zone.today.year %></div>
+        <%= number_field_tag 'work[created(1i)]', nil, id: 'work_created_year', class: "form-control", min: earliest_year, max: Time.zone.today.year %>
+        <div class="invalid-feedback">Created year must be between <%= earliest_year %> and <%= Time.zone.today.year %></div>
       </div>
       <div class="month">
         <label for="work_created_month" class="visually-hidden">Created month</label>
@@ -61,8 +61,8 @@
       <div class="start-date">
         <div class="year">
           <label for="work_created_range_start_year" class="visually-hidden">Created range start year</label>
-          <%= number_field_tag 'work[created_range(1i)]', nil, id: 'work_created_range_start_year', class: "form-control", min: Settings.earliest_created_year, max: Time.zone.today.year %>
-          <div class="invalid-feedback">Created year must be between <%= Settings.earliest_publication_year %> and <%= Time.zone.today.year %></div>
+          <%= number_field_tag 'work[created_range(1i)]', nil, id: 'work_created_range_start_year', class: "form-control", min: earliest_year, max: Time.zone.today.year %>
+          <div class="invalid-feedback">Created year must be between <%= earliest_year %> and <%= Time.zone.today.year %></div>
         </div>
         <div class="month">
           <label for="work_created_range_start_month" class="visually-hidden">Created range start month</label>
@@ -81,8 +81,8 @@
       <div class="end-date">
         <div class="year">
           <label for="work_created_range_end_year" class="visually-hidden">Created range end year</label>
-          <%= number_field_tag 'work[created_range(4i)]', nil, id: 'work_created_range_end_year', class: "form-control", min: Settings.earliest_created_year, max: Time.zone.today.year %>
-          <div class="invalid-feedback">Created year must be between <%= Settings.earliest_publication_year %> and <%= Time.zone.today.year %></div>
+          <%= number_field_tag 'work[created_range(4i)]', nil, id: 'work_created_range_end_year', class: "form-control", min: earliest_year, max: Time.zone.today.year %>
+          <div class="invalid-feedback">Created year must be between <%= earliest_year %> and <%= Time.zone.today.year %></div>
         </div>
         <div class="month">
           <label for="work_created_range_end_month" class="visually-hidden">Created range end month</label>

--- a/app/components/works/dates_component.html.erb
+++ b/app/components/works/dates_component.html.erb
@@ -30,8 +30,8 @@
 
   <div class="mb-3 row">
     <div class="col-sm-2">
-      <%= form.radio_button :creation_type, 'single', class: 'form-check-input' %>
-      <%= form.label :creation_type_single, 'Single date' %>
+      <%= form.radio_button :created_type, 'single', class: 'form-check-input' %>
+      <%= form.label :created_type_single, 'Single date' %>
     </div>
     <div class="col-sm-10">
       <div class="year">
@@ -53,8 +53,8 @@
 
   <div class="mb-3 row">
     <div class="col-md-2">
-      <%= form.radio_button :creation_type, 'range', class: 'form-check-input' %>
-       <%= form.label :creation_type_range, 'Date range' %>
+      <%= form.radio_button :created_type, 'range', class: 'form-check-input' %>
+       <%= form.label :created_type_range, 'Date range' %>
     </div>
 
     <div class="col-md-10 date-range">

--- a/app/components/works/dates_component.rb
+++ b/app/components/works/dates_component.rb
@@ -9,5 +9,7 @@ module Works
     end
 
     attr_reader :form
+
+    delegate :earliest_year, to: :Settings
   end
 end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -82,7 +82,7 @@ class WorksController < ObjectsController
     top_level = T.cast(params.require(:work), ActionController::Parameters)
     top_level.permit(:title, :work_type, :contact_email,
                      'published(1i)', 'published(2i)', 'published(3i)',
-                     :creation_type,
+                     :created_type,
                      'created(1i)', 'created(2i)', 'created(3i)',
                      'created_range(1i)', 'created_range(2i)', 'created_range(3i)',
                      'created_range(4i)', 'created_range(5i)', 'created_range(6i)',

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -6,6 +6,7 @@ require 'reform/form/coercion'
 # The form for draft work creation and editing
 # rubocop:disable Metrics/ClassLength
 class DraftWorkForm < Reform::Form
+  feature Coercion
   feature Edtf
 
   property :work_type

--- a/app/forms/edtf.rb
+++ b/app/forms/edtf.rb
@@ -1,0 +1,38 @@
+# typed: false
+# frozen_string_literal: true
+
+# Form behaviors for EDTF fields
+module Edtf
+  # Adds a property method that can handle the :edtf and :range options
+  module ClassMethods
+    def property(name, options = {}, &block)
+      if options[:edtf]
+        prop_name = name.to_s.delete_suffix('_edtf')
+        property "#{prop_name}(1i)", virtual: true
+        property "#{prop_name}(2i)", virtual: true
+        property "#{prop_name}(3i)", virtual: true
+
+        create_range(prop_name) if options[:range]
+      end
+      super(name, options, &block)
+    end
+
+    def create_range(prop_name)
+      property "#{prop_name}_range(1i)", virtual: true
+      property "#{prop_name}_range(2i)", virtual: true
+      property "#{prop_name}_range(3i)", virtual: true
+      property "#{prop_name}_range(4i)", virtual: true
+      property "#{prop_name}_range(5i)", virtual: true
+      property "#{prop_name}_range(6i)", virtual: true
+      property :creation_type, virtual: true, default: 'single'
+    end
+  end
+
+  def self.included(includer)
+    includer.extend ClassMethods
+  end
+
+  def deserialize!(params)
+    super EdtfParamsFilter.new.call(schema, params)
+  end
+end

--- a/app/forms/edtf.rb
+++ b/app/forms/edtf.rb
@@ -24,7 +24,7 @@ module Edtf
       property "#{prop_name}_range(4i)", virtual: true
       property "#{prop_name}_range(5i)", virtual: true
       property "#{prop_name}_range(6i)", virtual: true
-      property :creation_type, virtual: true, default: 'single'
+      property "#{prop_name}_type", virtual: true, default: 'single'
     end
   end
 

--- a/app/forms/edtf_params_filter.rb
+++ b/app/forms/edtf_params_filter.rb
@@ -1,0 +1,52 @@
+# typed: false
+# frozen_string_literal: true
+
+# Responsible for deserializing the form inputs into edtf values
+class EdtfParamsFilter
+  def call(schema, params)
+    date_attributes = {}
+    schema.each do |dfn|
+      next unless dfn[:edtf]
+
+      name = dfn[:name].delete_suffix('_edtf')
+
+      # TODO: derive creation_type from "created"
+      date_attributes[dfn[:name]] = deserialize(params, name, dfn[:range] && params[:creation_type] == 'range')
+    end
+
+    params.merge(date_attributes)
+  end
+
+  def deserialize(params, name, range)
+    EDTF.parse(range ? deserialize_edtf_range(params, name) : deserialize_edtf(params, name))
+  end
+
+  def deserialize_edtf(params, date_attribute, offset = 0)
+    year = params.delete("#{date_attribute}(#{1 + offset}i)")
+    month = params.delete("#{date_attribute}(#{2 + offset}i)")
+    day = params.delete("#{date_attribute}(#{3 + offset}i)")
+
+    deserialize_edtf_date(year, month, day)
+  end
+
+  def deserialize_edtf_range(params, name)
+    range_name = "#{name}_range"
+    start = deserialize_edtf(params, range_name)
+    finish = deserialize_edtf(params, range_name, 3)
+    return unless start && finish
+
+    # Slash is the range separator in EDTF
+    [start, finish].join('/')
+  end
+
+  def deserialize_edtf_date(year, month, day)
+    return if year.blank?
+
+    date = year.dup
+    if month.present?
+      date += "-#{format('%<month>02d', month: month)}"
+      date += "-#{format('%<day>02d', day: day)}" if day.present?
+    end
+    date
+  end
+end

--- a/app/forms/edtf_params_filter.rb
+++ b/app/forms/edtf_params_filter.rb
@@ -10,8 +10,7 @@ class EdtfParamsFilter
 
       name = dfn[:name].delete_suffix('_edtf')
 
-      # TODO: derive creation_type from "created"
-      date_attributes[dfn[:name]] = deserialize(params, name, dfn[:range] && params[:creation_type] == 'range')
+      date_attributes[dfn[:name]] = deserialize(params, name, dfn[:range] && params["#{name}_type"] == 'range')
     end
 
     params.merge(date_attributes)

--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -6,12 +6,6 @@ require 'reform/form/coercion'
 # The form for deposit work creation and editing (which includes validation)
 class WorkForm < DraftWorkForm
   validates :abstract, :access, :title, presence: true
-  validates 'created(1i)', 'created_range(1i)', 'created_range(4i)',
-            inclusion: { in: Settings.earliest_created_year..Time.zone.today.year },
-            allow_nil: true
-  validates 'published(1i)',
-            inclusion: { in: Settings.earliest_publication_year..Time.zone.today.year },
-            allow_nil: true
   validates 'release', presence: true, inclusion: { in: %w[immediate embargo] }
   validates :keywords, length: { minimum: 1, message: 'Please add at least one keyword.' }
   validates :attached_files, length: { minimum: 1, message: 'Please add at least one file.' }

--- a/app/validators/created_in_past_validator.rb
+++ b/app/validators/created_in_past_validator.rb
@@ -1,0 +1,25 @@
+# typed: true
+# frozen_string_literal: true
+
+# An ActiveModel validator for EDTF formatted dates
+class CreatedInPastValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.nil?
+
+    case value
+    when Date
+      validate_date(record, attribute, value)
+    when EDTF::Interval
+      validate_date(record, attribute, value.from, 'start')
+      validate_date(record, attribute, value.to, 'end')
+    end
+  end
+
+  private
+
+  def validate_date(record, attribute, value, prefix = nil)
+    prefix &&= "#{prefix} "
+    record.errors.add(attribute, "#{prefix}must have a four digit year") if Settings.earliest_year > value.year
+    record.errors.add(attribute, "#{prefix}must be in the past") if Time.zone.today.year < value.year
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,8 +17,7 @@ remote_user_headers:
 h2:
   hydrus_apo: 'druid:zx485kb6348'
 
-earliest_publication_year: 1000
-earliest_created_year: 1000
+earliest_year: 1000
 
 # feature flag
 allow_sdr_content_changes: true

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe 'Create a new collection and deposit to it', js: true do
       fill_in 'Created year', with: '999'
       click_button 'Deposit'
       expect(page).to have_content(
-        "Publication year must be between #{Settings.earliest_publication_year} and #{Time.zone.today.year}"
+        "Publication year must be between #{Settings.earliest_year} and #{Time.zone.today.year}"
       )
       expect(page).to have_content(
-        "Created year must be between #{Settings.earliest_created_year} and #{Time.zone.today.year}"
+        "Created year must be between #{Settings.earliest_year} and #{Time.zone.today.year}"
       )
       expect(page).to have_content('You must provide an abstract')
 

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -110,42 +110,4 @@ RSpec.describe WorkForm do
       expect(form.errors.messages).not_to include({ subtype: ['is not a valid subtype for work type data'] })
     end
   end
-
-  describe 'year validation' do
-    let(:current_year) { Time.zone.today.year }
-
-    %w[published(1i) created(1i) created_range(1i) created_range(4i)].each do |attribute|
-      before { form.validate(attribute => year, keywords: [{ label: 'foo' }], attached_files: [{ label: 'bar' }]) }
-
-      context "with a four-digit integer <= the current year as #{attribute}" do
-        let(:year) { current_year - 1 }
-
-        it { is_expected.to be_valid }
-      end
-
-      context "with a four-digit integer > the current year as #{attribute}" do
-        let(:year) { current_year + 1 }
-
-        it { is_expected.not_to be_valid }
-      end
-
-      context "with a < four-digit integer as #{attribute}" do
-        let(:year) { 999 }
-
-        it { is_expected.not_to be_valid }
-      end
-
-      context 'with a string' do
-        let(:year) { current_year.to_s }
-
-        it { is_expected.to be_valid }
-      end
-
-      context 'with a float' do
-        let(:year) { current_year.to_f }
-
-        it { is_expected.to be_valid }
-      end
-    end
-  end
 end

--- a/spec/requests/works_spec.rb
+++ b/spec/requests/works_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe 'Works requests' do
                    related_works_attributes: related_works,
                    related_links_attributes: related_links,
                    'published(1i)' => '2020', 'published(2i)' => '2', 'published(3i)' => '14',
-                   creation_type: 'range',
+                   created_type: 'range',
                    'created(1i)' => '2020', 'created(2i)' => '2', 'created(3i)' => '14',
                    'created_range(1i)' => '2020', 'created_range(2i)' => '3', 'created_range(3i)' => '4',
                    'created_range(4i)' => '2020', 'created_range(5i)' => '10', 'created_range(6i)' => '31',

--- a/spec/validators/created_in_past_validator_spec.rb
+++ b/spec/validators/created_in_past_validator_spec.rb
@@ -1,0 +1,71 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreatedInPastValidator do
+  let(:options) { { attributes: ['hi'] } }
+  let(:validator) { described_class.new(options) }
+  let(:record) { WorkForm.new(Work.new) }
+
+  before do
+    validator.validate_each(record, attribute, value)
+  end
+
+  context 'when there is a single date' do
+    let(:attribute) { :created_edtf }
+    let(:value) { EDTF.parse('1800-01-01') }
+
+    it 'has no errors' do
+      expect(record.errors).to be_empty
+    end
+
+    context 'with a date prior to 1000' do
+      let(:attribute) { :created_edtf }
+      let(:value) { EDTF.parse('0800-01-01') }
+
+      it 'has errors' do
+        expect(record.errors.full_messages).to eq ['Created edtf must have a four digit year']
+      end
+    end
+
+    context 'with a date after the current year' do
+      let(:attribute) { :created_edtf }
+      let(:year) { Time.zone.today.year + 1 }
+      let(:value) { EDTF.parse("#{year}-01-01") }
+
+      it 'has errors' do
+        expect(record.errors.full_messages).to eq ['Created edtf must be in the past']
+      end
+    end
+  end
+
+  context 'when there is a date range' do
+    let(:attribute) { :created_edtf }
+    let(:value) { EDTF.parse('1800-01-01/1900-01-01') }
+
+    it 'has no errors' do
+      expect(record.errors).to be_empty
+    end
+
+    context 'with a start date prior to 1000' do
+      let(:attribute) { :created_edtf }
+      let(:value) { EDTF.parse('0800-01-01/1900-01-01') }
+
+      it 'has errors' do
+        expect(record.errors.full_messages).to eq ['Created edtf start must have a four digit year']
+      end
+    end
+
+    context 'with a start date after the current year' do
+      let(:attribute) { :created_edtf }
+      let(:year) { Time.zone.today.year + 1 }
+      let(:value) { EDTF.parse("#{year}-01-01/2200-01-01") }
+
+      it 'has errors' do
+        expect(record.errors.full_messages).to eq ['Created edtf start must be in the past',
+                                                   'Created edtf end must be in the past']
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

This allows the WorkForm to have fewer responsibilities.

This (casting the date parts to a date)  is somewhat required so that we can validate a date is in the future (rather than just the year). So, either we break it out into smaller pieces or it’s going to grow much larger.  See #329

This is all based on what is already in reform-rails: https://github.com/trailblazer/reform-rails/blob/master/lib/reform/form/multi_parameter_attributes.rb

## How was this change tested?



## Which documentation and/or configurations were updated?



