### PR TITLE
Work types Radio Buttons accessable through keyboard

### DIFF
--- a/app/javascript/stylesheets/toggle.scss
+++ b/app/javascript/stylesheets/toggle.scss
@@ -1,5 +1,5 @@
 input[type="radio"].toggle {
-  display: none;
+  opacity: 0;
 }
 
 input[type="radio"].toggle:checked + label {
@@ -15,6 +15,14 @@ input[type="radio"].toggle:checked + label {
   .uncheck {
     display: none;
   }
+}
+
+input[type="radio"].toggle:focus + label {
+  border: 3px solid $primary;
+  background-color: rgba($primary, 0.3);
+  left: -1.5px;
+  position: relative;  
+  top: -1.5px;
 }
 
 input[type="radio"].toggle + label {


### PR DESCRIPTION
## Why was this change made?
Fixes #432, implements suggestions from [blog post](https://www.a11ywithlindsey.com/blog/create-custom-keyboard-accessible-radio-buttons) that was linked in the ticket.

**Note** Because this is a radio button group, when a work type is selected and the work sub-types check-boxes are displayed, the user needs to use the arrow keys to select another work-type. 

![radio-keyboard](https://user-images.githubusercontent.com/71847/99321083-449fe880-282a-11eb-8275-c40acc76062e.gif)

## How was this change tested?
Testing suite.


## Which documentation and/or configurations were updated?
n/a

