### PR TITLE
publisher contributors correctly mapped to cocina event, not cocina contributor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,7 +27,7 @@ RSpec/EmptyExampleGroup:
 RSpec/ExampleLength:
   Enabled: false
 RSpec/MultipleMemoizedHelpers:
-  Max: 13
+  Max: 15
 RSpec/NestedGroups:
   Max: 5
 RSpec/ScatteredSetup:

--- a/app/services/description_generator.rb
+++ b/app/services/description_generator.rb
@@ -23,7 +23,7 @@ class DescriptionGenerator
                                       contributor: ContributorsGenerator.generate(work: work),
                                       subject: keywords,
                                       note: [abstract, citation, contact],
-                                      event: [created_date, published_date].compact,
+                                      event: generate_events,
                                       relatedResource: related_links + related_works,
                                       form: generate_form
                                     }, false, false)
@@ -39,6 +39,15 @@ class DescriptionGenerator
     [
       Cocina::Models::Title.new(value: work.title)
     ]
+  end
+
+  sig { returns(T::Array[Cocina::Models::Event]) }
+  def generate_events
+    pub_events = ContributorsGenerator.events_from_publisher_contributors(work: work, pub_date: published_date)
+    return [T.must(created_date)] + pub_events if pub_events.present? && created_date
+    return pub_events if pub_events.present? # and no created_date
+
+    [created_date, published_date].compact # no pub_events
   end
 
   sig { returns(T::Array[Cocina::Models::DescriptiveValue]) }
@@ -79,10 +88,8 @@ class DescriptionGenerator
       type: 'creation',
       date: [
         {
-          "value": work.created_edtf,
-          "encoding": {
-            "code": 'edtf'
-          }
+          value: work.created_edtf,
+          encoding: { code: 'edtf' }
         }
       ]
     )
@@ -96,10 +103,8 @@ class DescriptionGenerator
       type: 'publication',
       date: [
         {
-          "value": work.published_edtf,
-          "encoding": {
-            "code": 'edtf'
-          }
+          value: work.published_edtf,
+          encoding: { code: 'edtf' }
         }
       ]
     )

--- a/sorbet/custom/cocina-models.rbi
+++ b/sorbet/custom/cocina-models.rbi
@@ -29,8 +29,12 @@ module Cocina::Models
   end
 
   class Event
-    sig { params(type: String, date: T::Array[T.any(DescriptiveValue, T::Hash[T.untyped, T.untyped])]).void }
-    def initialize(type:, date:); end
+    sig do
+      params(type: String,
+             date: T.nilable(T::Array[T.any(DescriptiveValue, T::Hash[T.untyped, T.untyped])]),
+             contributor: T.nilable(T::Array[T.any(Contributor, T::Hash[T.untyped, T.untyped])])).void
+    end
+    def initialize(type:, date: nil, contributor: nil); end
   end
 
   class DescriptiveAccessMetadata


### PR DESCRIPTION
## Why was this change made?

Part of #240;   when a contributor in h2 is a "Publisher" it maps to a Cocina "Event" not a "Contributor".  And for fun, you have to combine it with the publication date which is optional.  And for even more fun, Cocina model objects are immutable, so ... 

## How was this change tested?

unit tests from Arcadia's h2 mapping spec for contributors AND a couple of my own added in.

## Which documentation and/or configurations were updated?



