### PR TITLE
add validation for at least one contributor

### DIFF
--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -1,4 +1,4 @@
-<div class="contributors row inner-container" data-controller="contributors" data-action="error->contributors#error" data-target="edit-deposit.contributorsField">
+<div class="row inner-container" data-controller="contributors" data-action="error->contributors#error" data-target="edit-deposit.contributorsField">
   <div class="contributors-container col-md-12" data-target="contributors.container">
     <%= button_tag type: 'button', class: 'btn btn-sm float-right', aria: { label: 'Remove' },
         data: { action: "click->nested-form#removeAssociation" } do %>

--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -1,5 +1,5 @@
-<div class="contributor row inner-container" data-controller="contributor" data-target="edit-deposit.contributorsField">
-  <div class="col-md-12">
+<div class="contributors row inner-container" data-controller="contributors" data-action="error->contributors#error" data-target="edit-deposit.contributorsField">
+  <div class="contributors-container col-md-12" data-target="contributors.container">
     <%= button_tag type: 'button', class: 'btn btn-sm float-right', aria: { label: 'Remove' },
         data: { action: "click->nested-form#removeAssociation" } do %>
       <span class="far fa-trash-alt"></span>
@@ -11,29 +11,27 @@
     <%= form.select :role_term, grouped_options_for_select(Contributor.grouped_options),
                     {}, class: 'form-select',
                     data: {
-                      action: 'change->contributor#typeChanged',
-                      target: 'contributor.role'
+                      action: 'change->contributors#typeChanged',
+                      target: 'contributors.role'
                     } %>
   </div>
   <div class="col-md-1 role-prefix">
     is
   </div>
-  <div class="col-md-4" data-target="contributor.personName">
+  <div class="col-md-4" data-target="contributors.personName">
     <%= form.label :first_name, class: 'form-label' %>
-    <%= form.text_field :first_name, class: 'form-control', data: { target: 'contributor.personNameInput' }, required: true %>
+    <%= form.text_field :first_name, class: 'form-control', data: { action: 'change->contributors#inputChanged', target: 'contributors.personNameInput' }, required: true %>
     <div class="invalid-feedback">You must provide a first name</div>
   </div>
-  <div class="col-md-4" data-target="contributor.personName">
+  <div class="col-md-4" data-target="contributors.personName">
     <%= form.label :last_name, class: 'form-label' %>
-    <%= form.text_field :last_name, class: 'form-control', data: { target: 'contributor.personNameInput' }, required: true %>
+    <%= form.text_field :last_name, class: 'form-control', data: { action: 'change->contributors#inputChanged', target: 'contributors.personNameInput' }, required: true %>
     <div class="invalid-feedback">You must provide a last name</div>
   </div>
-  <div class="col-md-8" data-target="contributor.organizationName">
+  <div class="col-md-8" data-target="contributors.organizationName">
     <%= form.label :full_name, 'Name', class: 'form-label' %>
-    <%= form.text_field :full_name, class: 'form-control', data: { target: 'contributor.organizationNameInput' }, required: true %>
+    <%= form.text_field :full_name, class: 'form-control', data: { action: 'change->contributors#inputChanged', target: 'contributors.organizationNameInput' }, required: true %>
     <div class="invalid-feedback">You must provide a name</div>
   </div>
-  <div class="col-md-12">
-    <div data-target="contributors.error" class="invalid-feedback"></div>
-  </div>
+  <div data-target="contributors.error" class="invalid-feedback"></div>
 </div>

--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -1,4 +1,4 @@
-<div class="contributor row inner-container" data-controller="contributor">
+<div class="contributor row inner-container" data-controller="contributor" data-target="edit-deposit.contributorsField">
   <div class="col-md-12">
     <%= button_tag type: 'button', class: 'btn btn-sm float-right', aria: { label: 'Remove' },
         data: { action: "click->nested-form#removeAssociation" } do %>
@@ -20,14 +20,20 @@
   </div>
   <div class="col-md-4" data-target="contributor.personName">
     <%= form.label :first_name, class: 'form-label' %>
-    <%= form.text_field :first_name, class: 'form-control' %>
+    <%= form.text_field :first_name, class: 'form-control', data: { target: 'contributor.personNameInput' }, required: true %>
+    <div class="invalid-feedback">You must provide a first name</div>
   </div>
   <div class="col-md-4" data-target="contributor.personName">
     <%= form.label :last_name, class: 'form-label' %>
-    <%= form.text_field :last_name, class: 'form-control' %>
+    <%= form.text_field :last_name, class: 'form-control', data: { target: 'contributor.personNameInput' }, required: true %>
+    <div class="invalid-feedback">You must provide a last name</div>
   </div>
   <div class="col-md-8" data-target="contributor.organizationName">
     <%= form.label :full_name, 'Name', class: 'form-label' %>
-    <%= form.text_field :full_name, class: 'form-control' %>
+    <%= form.text_field :full_name, class: 'form-control', data: { target: 'contributor.organizationNameInput' }, required: true %>
+    <div class="invalid-feedback">You must provide a name</div>
+  </div>
+  <div class="col-md-12">
+    <div data-target="contributors.error" class="invalid-feedback"></div>
   </div>
 </div>

--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -13,4 +13,5 @@ class WorkForm < DraftWorkForm
   validates :license, presence: true, inclusion: { in: License.license_list }
   validates :subtype, work_subtype: true
   validates :work_type, presence: true, work_type: true
+  validates :contributors, length: { minimum: 1, message: 'Please add at least one contributor.' }
 end

--- a/app/javascript/controllers/contributor_controller.js
+++ b/app/javascript/controllers/contributor_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  static targets = ["personName", "organizationName", "role"]
+  static targets = ["personName", "organizationName", "role", "personNameInput", "organizationNameInput"]
 
   connect() {
     this.updateDisplay()
@@ -20,11 +20,15 @@ export default class extends Controller {
 
   displayOrganization() {
     this.personNameTargets.forEach((element) => element.hidden = true)
+    this.personNameInputTargets.forEach((element) => element.required = false)
     this.organizationNameTarget.hidden = false
+    this.organizationNameInputTarget.required = true
   }
 
   displayPerson() {
     this.personNameTargets.forEach((element) => element.hidden = false)
+    this.personNameInputTargets.forEach((element) => element.required = true)
     this.organizationNameTarget.hidden = true
+    this.organizationNameInputTarget.required = false
   }
 }

--- a/app/javascript/controllers/contributors_controller.js
+++ b/app/javascript/controllers/contributors_controller.js
@@ -1,10 +1,14 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  static targets = ["personName", "organizationName", "role", "personNameInput", "organizationNameInput"]
+  static targets = ["personName", "organizationName", "role", "personNameInput", "organizationNameInput", "container", "error"]
 
   connect() {
     this.updateDisplay()
+  }
+
+  inputChanged() {
+    this.containerTarget.classList.remove('is-invalid')
   }
 
   typeChanged() {
@@ -16,6 +20,12 @@ export default class extends Controller {
       this.displayPerson()
     else
       this.displayOrganization()
+  }
+
+  // Triggered when edit-deposit controller sends an error event
+  error(e) {
+    this.containerTarget.classList.add('is-invalid')
+    this.errorTarget.innerHTML = e.detail.join(' ')
   }
 
   displayOrganization() {

--- a/app/javascript/controllers/edit_deposit_controller.js
+++ b/app/javascript/controllers/edit_deposit_controller.js
@@ -3,7 +3,7 @@ import { Controller } from "stimulus";
 export default class extends Controller {
   static targets = ["title", "titleField",
                     "file", "fileField",
-                    "keywordsField"];
+                    "keywordsField", "contributorsField"];
 
   connect() {
     // TODO see what of the things are already valid

--- a/sorbet/rbi/sorbet-typed/lib/tzinfo/~>1.1/tzinfo.rbi
+++ b/sorbet/rbi/sorbet-typed/lib/tzinfo/~>1.1/tzinfo.rbi
@@ -5,7 +5,7 @@
 #
 #   https://github.com/sorbet/sorbet-typed/edit/master/lib/tzinfo/~>1.1/tzinfo.rbi
 #
-# typed: false
+# typed: strict
 
 module TZInfo
 end

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -64,6 +64,9 @@ RSpec.describe 'Create a new collection and deposit to it', js: true do
       fill_in 'Title of deposit', with: 'My Title'
       fill_in 'Contact email', with: user.email
 
+      fill_in 'First name', with: 'Contributor First Name'
+      fill_in 'Last name', with: 'Contributor Last Name'
+
       select 'Publisher', from: 'Role term'
       fill_in 'Name', with: 'Best Publisher'
 

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe WorkForm do
   subject(:form) { described_class.new(work) }
 
   let(:work) { build(:work) }
-  let(:work_with_contributors) { build(:work, :with_contributors) }
 
   describe 'populator on files' do
     let!(:blob) do
@@ -59,17 +58,17 @@ RSpec.describe WorkForm do
 
     context 'with no contributors' do
       it 'does not validate' do
-        form.valid?
+        expect(form).not_to be_valid
         expect(form.errors.messages).to include(contributor_error)
       end
     end
 
     context 'with contributors' do
-      let(:form_with_contributors) { described_class.new(work_with_contributors) }
+      let(:work) { build(:work, :with_contributors, :with_attached_file, :with_keywords) }
 
       it 'validates' do
-        form_with_contributors.valid?
-        expect(form_with_contributors.errors.messages).not_to include(contributor_error)
+        expect(form).to be_valid
+        expect(form.errors.messages).not_to include(contributor_error)
       end
     end
   end

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe WorkForm do
   subject(:form) { described_class.new(work) }
 
   let(:work) { build(:work) }
+  let(:work_with_contributors) { build(:work, :with_contributors) }
 
   describe 'populator on files' do
     let!(:blob) do
@@ -53,11 +54,36 @@ RSpec.describe WorkForm do
     end
   end
 
+  describe 'contributors validation' do
+    let(:contributor_error) { { contributors: ['Please add at least one contributor.'] } }
+
+    context 'with no contributors' do
+      it 'does not validate' do
+        form.valid?
+        expect(form.errors.messages).to include(contributor_error)
+      end
+    end
+
+    context 'with contributors' do
+      let(:form_with_contributors) { described_class.new(work_with_contributors) }
+
+      it 'validates' do
+        form_with_contributors.valid?
+        expect(form_with_contributors.errors.messages).not_to include(contributor_error)
+      end
+    end
+  end
+
   describe 'email validation' do
     it 'does not validate with an invalid contact email' do
       form.validate(contact_email: 'notavalidemail')
       expect(form).not_to be_valid
       expect(form.errors.messages).to include({ contact_email: ['is invalid'] })
+    end
+
+    it 'validates with a correct contact email' do
+      form.validate(contact_email: 'avalidemail@test.com')
+      expect(form.errors.messages).not_to include({ contact_email: ['is invalid'] })
     end
   end
 

--- a/spec/requests/works_spec.rb
+++ b/spec/requests/works_spec.rb
@@ -297,6 +297,7 @@ RSpec.describe 'Works requests' do
             contact_email: 'io@io.io',
             abstract: 'test abstract',
             attached_files_attributes: files,
+            contributors_attributes: contributors,
             keywords_attributes: {
               '0' => { '_destroy' => 'false', 'label' => 'Feminism', 'uri' => 'http://id.worldcat.org/fast/922671' }
             },
@@ -311,6 +312,11 @@ RSpec.describe 'Works requests' do
             filename: 'apple-touch-icon.png',
             content_type: 'image/png'
           )
+        end
+
+        let(:contributors) do
+          { '999' =>
+            { '_destroy' => 'false', 'full_name' => 'Stanford', 'role_term' => 'organization|Host institution' } }
         end
 
         let(:files) do
@@ -328,7 +334,7 @@ RSpec.describe 'Works requests' do
           post "/collections/#{collection.id}/works", params: { work: work_params, commit: 'Deposit' }
           expect(response).to have_http_status(:found)
           work = Work.last
-          expect(work.contributors).to be_empty
+          expect(work.contributors.size).to eq 1
           expect(work.attached_files.size).to eq 1
           expect(work.keywords.size).to eq 1
           expect(work.published_edtf).to be_nil
@@ -380,6 +386,7 @@ RSpec.describe 'Works requests' do
             work_type: 'text',
             contact_email: 'io@io.io',
             abstract: 'test abstract',
+            contributors_attributes: contributors,
             attached_files_attributes: files,
             keywords_attributes: {
               '0' => { '_destroy' => 'false', 'label' => 'Feminism', 'uri' => 'http://id.worldcat.org/fast/922671' }
@@ -387,6 +394,12 @@ RSpec.describe 'Works requests' do
             license: 'CC0-1.0',
             release: 'immediate'
           }
+        end
+
+        let(:contributors) do
+          { '999' =>
+            { '_destroy' => 'false', 'first_name' => 'Naomi',
+              'last_name' => 'Dushay', 'role_term' => 'person|Author' } }
         end
 
         let(:upload) do
@@ -412,7 +425,7 @@ RSpec.describe 'Works requests' do
           post "/collections/#{collection.id}/works", params: { work: work_params, commit: 'Deposit' }
           expect(response).to have_http_status(:found)
           work = Work.last
-          expect(work.contributors).to be_empty
+          expect(work.contributors.size).to eq 1
           expect(work.attached_files.size).to eq 1
           expect(work.keywords.size).to eq 1
           expect(work.published_edtf).to be_nil

--- a/spec/requests/works_spec.rb
+++ b/spec/requests/works_spec.rb
@@ -316,7 +316,8 @@ RSpec.describe 'Works requests' do
 
         let(:contributors) do
           { '999' =>
-            { '_destroy' => 'false', 'full_name' => 'Stanford', 'role_term' => 'organization|Host institution' } }
+            { '_destroy' => 'false', 'first_name' => '', 'last_name' => '',
+              'full_name' => 'Stanford', 'role_term' => 'organization|Host institution' } }
         end
 
         let(:files) do
@@ -398,7 +399,7 @@ RSpec.describe 'Works requests' do
 
         let(:contributors) do
           { '999' =>
-            { '_destroy' => 'false', 'first_name' => 'Naomi',
+            { '_destroy' => 'false', 'full_name' => '', 'first_name' => 'Naomi',
               'last_name' => 'Dushay', 'role_term' => 'person|Author' } }
         end
 


### PR DESCRIPTION
## Why was this change made?

Fixes #386 

- validate that there is at least one contributor at the work form level, as well as client side.  
- Need to disable client side validation for specific fields depending on role selected, which is done via the same JS methods that hide/show input fields.
- Rename `contributor` JS controller to `contributors` controller to be consistent with keywords

## How was this change tested?

Updated tests to add contributors to continue to get them to pass now that contributor is required.
Added some new unit tests

## Which documentation and/or configurations were updated?



