### PR TITLE
[Full Team Sign Off] Rubocop adjustments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,12 +6,19 @@ require:
 
 inherit_from: .rubocop_todo.yml
 
+#### Local Settings
+
 AllCops:
   Exclude:
     - db/**/*
     - node_modules/**/*
     - bin/**/*
     - vendor/**/*
+
+Lint/MissingSuper: # (new in 0.89)
+  Enabled: true
+  Exclude:
+    - app/components/**/*
 
 Metrics/BlockLength:
   Exclude:
@@ -21,23 +28,25 @@ RSpec/DescribeClass:
   Exclude:
     - spec/features/**/*
     - spec/requests/**/*
+
 RSpec/EmptyExampleGroup:
   Exclude:
     - spec/policies/**/*
+
 RSpec/ExampleLength:
   Enabled: false
+
 RSpec/MultipleMemoizedHelpers:
   Max: 15
+
 RSpec/NestedGroups:
   Max: 5
+
 RSpec/ScatteredSetup:
   Exclude:
     - spec/policies/**/*
 
-Lint/MissingSuper: # (new in 0.89)
-  Enabled: true
-  Exclude:
-    - app/components/**/*
+#### Turning on New Rules
 
 Layout/BeginEndAlignment: # (new in 0.91)
   Enabled: true
@@ -45,6 +54,7 @@ Layout/EmptyLinesAroundAttributeAccessor: # (new in 0.83)
   Enabled: true
 Layout/SpaceAroundMethodCallOperator: # (new in 0.82)
   Enabled: true
+
 Lint/BinaryOperatorWithIdenticalOperands: # (new in 0.89)
   Enabled: true
 Lint/ConstantDefinitionInBlock: # (new in 0.91)
@@ -53,9 +63,13 @@ Lint/DeprecatedOpenSSLConstant: # (new in 0.84)
   Enabled: true
 Lint/DuplicateElsifCondition: # (new in 0.88)
   Enabled: true
+Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)
+  Enabled: true
 Lint/DuplicateRequire: # (new in 0.90)
   Enabled: true
 Lint/DuplicateRescueException: # (new in 0.89)
+  Enabled: true
+Lint/EmptyBlock: # (new in 1.1)
   Enabled: true
 Lint/EmptyConditionalBody: # (new in 0.89)
   Enabled: true
@@ -69,6 +83,8 @@ Lint/IdentityComparison: # (new in 0.91)
   Enabled: true
 Lint/MixedRegexpCaptureTypes: # (new in 0.85)
   Enabled: true
+Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
+  Enabled: true
 Lint/OutOfRangeRegexpRef: # (new in 0.89)
   Enabled: true
 Lint/RaiseException: # (new in 0.81)
@@ -79,9 +95,13 @@ Lint/SelfAssignment: # (new in 0.89)
   Enabled: true
 Lint/StructNewOverride: # (new in 0.81)
   Enabled: true
+Lint/ToEnumArguments: # (new in 1.1)
+  Enabled: true
 Lint/TopLevelReturnWithArgument: # (new in 0.89)
   Enabled: true
 Lint/TrailingCommaInAttributeDeclaration: # (new in 0.90)
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
   Enabled: true
 Lint/UnreachableLoop: # (new in 0.89)
   Enabled: true
@@ -89,56 +109,7 @@ Lint/UselessMethodDefinition: # (new in 0.90)
   Enabled: true
 Lint/UselessTimes: # (new in 0.91)
   Enabled: true
-Style/AccessorGrouping: # (new in 0.87)
-  Enabled: false # because this doesn't work well with Sorbet annotations
-Style/BisectedAttrAccessor: # (new in 0.87)
-  Enabled: true
-Style/CaseLikeIf: # (new in 0.88)
-  Enabled: true
-Style/ClassEqualityComparison: # (new in 0.93)
-  Enabled: true
-Style/CombinableLoops: # (new in 0.90)
-  Enabled: true
-Style/ExplicitBlockArgument: # (new in 0.89)
-  Enabled: true
-Style/ExponentialNotation: # (new in 0.82)
-  Enabled: true
-Style/GlobalStdStream: # (new in 0.89)
-  Enabled: true
-Style/HashAsLastArrayItem: # (new in 0.88)
-  Enabled: true
-Style/HashEachMethods: # (new in 0.80)
-  Enabled: true
-Style/HashLikeCase: # (new in 0.88)
-  Enabled: true
-Style/HashTransformKeys: # (new in 0.80)
-  Enabled: true
-Style/HashTransformValues: # (new in 0.80)
-  Enabled: true
-Style/KeywordParametersOrder: # (new in 0.90)
-  Enabled: true
-Style/OptionalBooleanParameter: # (new in 0.89)
-  Enabled: true
-Style/RedundantAssignment: # (new in 0.87)
-  Enabled: true
-Style/RedundantFetchBlock: # (new in 0.86)
-  Enabled: true
-Style/RedundantFileExtensionInRequire: # (new in 0.88)
-  Enabled: true
-Style/RedundantRegexpCharacterClass: # (new in 0.85)
-  Enabled: true
-Style/RedundantRegexpEscape: # (new in 0.85)
-  Enabled: true
-Style/RedundantSelfAssignment: # (new in 0.90)
-  Enabled: true
-Style/SingleArgumentDig: # (new in 0.89)
-  Enabled: true
-Style/SlicingWithRange: # (new in 0.83)
-  Enabled: true
-Style/SoleNestedConditional: # (new in 0.89)
-  Enabled: true
-Style/StringConcatenation: # (new in 0.89)
-  Enabled: true
+
 Performance/AncestorsInclude: # (new in 1.7)
   Enabled: true
 Performance/BigDecimalWithNumericArgument: # (new in 1.7)
@@ -157,6 +128,7 @@ Performance/StringInclude: # (new in 1.7)
   Enabled: true
 Performance/Sum: # (new in 1.8)
   Enabled: true
+
 Rails/ActiveRecordCallbacksOrder: # (new in 2.7)
   Enabled: true
 Rails/AfterCommitOverride: # (new in 2.8)
@@ -193,23 +165,64 @@ RSpec/MultipleExpectations:
   Enabled: false
 RSpec/StubbedMock: # (new in 1.44)
   Enabled: true
-Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)
-  Enabled: true
-Lint/EmptyBlock: # (new in 1.1)
-  Enabled: true
-Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
-  Enabled: true
-Lint/ToEnumArguments: # (new in 1.1)
-  Enabled: true
-Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
-  Enabled: true
+
+Style/AccessorGrouping: # (new in 0.87)
+  Enabled: false # because this doesn't work well with Sorbet annotations
 Style/ArgumentsForwarding: # (new in 1.1)
+  Enabled: true
+Style/BisectedAttrAccessor: # (new in 0.87)
+  Enabled: true
+Style/CaseLikeIf: # (new in 0.88)
+  Enabled: true
+Style/ClassEqualityComparison: # (new in 0.93)
   Enabled: true
 Style/CollectionCompact: # (new in 1.2)
   Enabled: true
+Style/CombinableLoops: # (new in 0.90)
+  Enabled: true
 Style/DocumentDynamicEvalDefinition: # (new in 1.1)
   Enabled: true
+Style/ExplicitBlockArgument: # (new in 0.89)
+  Enabled: true
+Style/ExponentialNotation: # (new in 0.82)
+  Enabled: true
+Style/GlobalStdStream: # (new in 0.89)
+  Enabled: true
+Style/HashAsLastArrayItem: # (new in 0.88)
+  Enabled: true
+Style/HashEachMethods: # (new in 0.80)
+  Enabled: true
+Style/HashLikeCase: # (new in 0.88)
+  Enabled: true
+Style/HashTransformKeys: # (new in 0.80)
+  Enabled: true
+Style/HashTransformValues: # (new in 0.80)
+  Enabled: true
+Style/KeywordParametersOrder: # (new in 0.90)
+  Enabled: true
 Style/NegatedIfElseCondition: # (new in 1.2)
+  Enabled: true
+Style/OptionalBooleanParameter: # (new in 0.89)
+  Enabled: true
+Style/RedundantAssignment: # (new in 0.87)
+  Enabled: true
+Style/RedundantFetchBlock: # (new in 0.86)
+  Enabled: true
+Style/RedundantFileExtensionInRequire: # (new in 0.88)
+  Enabled: true
+Style/RedundantRegexpCharacterClass: # (new in 0.85)
+  Enabled: true
+Style/RedundantRegexpEscape: # (new in 0.85)
+  Enabled: true
+Style/RedundantSelfAssignment: # (new in 0.90)
+  Enabled: true
+Style/SingleArgumentDig: # (new in 0.89)
+  Enabled: true
+Style/SlicingWithRange: # (new in 0.83)
+  Enabled: true
+Style/SoleNestedConditional: # (new in 0.89)
+  Enabled: true
+Style/StringConcatenation: # (new in 0.89)
   Enabled: true
 Style/SwapValues: # (new in 1.1)
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,7 +28,7 @@ Metrics/ClassLength:
   Max: 150
 
 Metrics/MethodLength:
-  Max: 20
+  Max: 15
 
 RSpec/DescribeClass:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,12 @@ Metrics/BlockLength:
   Exclude:
     - spec/**/*
 
+Metrics/ClassLength:
+  Max: 150
+
+Metrics/MethodLength:
+  Max: 20
+
 RSpec/DescribeClass:
   Exclude:
     - spec/features/**/*

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,35 +6,20 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 3
+# Offense count: 2
 # Configuration parameters: IgnoredMethods, Max.
 Metrics/AbcSize:
   Exclude:
     - 'app/controllers/works_controller.rb'
-    - 'app/models/license.rb'
     - 'app/services/storage_migrator.rb'
 
-# Offense count: 5
+# Offense count: 1
 # Configuration parameters: CountComments, Max, CountAsOne, ExcludedMethods.
 Metrics/MethodLength:
   Exclude:
-    - 'app/controllers/works_controller.rb'
-    - 'app/services/description_generator.rb'
     - 'app/services/request_generator.rb'
-    - 'app/services/storage_migrator.rb'
 
 # Offense count: 1
 RSpec/AnyInstance:
   Exclude:
     - 'spec/channels/application_cable/connection_spec.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: SuggestedStrictness, Include.
-# Include: **/*.rb, **/*.rbi, **/*.rake, **/*.ru
-Sorbet/FalseSigil:
-  Exclude:
-    - 'bin/**/*'
-    - 'db/**/*.rb'
-    - 'script/**/*'
-    - 'config/initializers/dry_types.rb'

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -78,6 +78,7 @@ class WorksController < ObjectsController
     redirect_to work
   end
 
+  # rubocop:disable Metrics/MethodLength
   def work_params
     top_level = T.cast(params.require(:work), ActionController::Parameters)
     top_level.permit(:title, :work_type, :contact_email,
@@ -96,6 +97,7 @@ class WorksController < ObjectsController
                      related_works_attributes: %i[_destroy id citation],
                      related_links_attributes: %i[_destroy id link_title url])
   end
+  # rubocop:enable Metrics/MethodLength
 
   def validate_work_types!
     errors = []

--- a/app/forms/contributor_populator.rb
+++ b/app/forms/contributor_populator.rb
@@ -5,7 +5,6 @@
 class ContributorPopulator < ApplicationPopulator
   # The fragment represents one row of the contributor data from the HTML form
   # find out if incoming Contributor is already added.
-  # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/AbcSize
   def call(form, fragment:, **)
     item = existing_record(form: form, id: fragment['id'])
@@ -28,6 +27,5 @@ class ContributorPopulator < ApplicationPopulator
     end
     item || form.contributors.append(Contributor.new)
   end
-  # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
 end

--- a/app/models/work_type.rb
+++ b/app/models/work_type.rb
@@ -136,6 +136,7 @@ class WorkType
   end
 
   # id is a value acceptable for MODS typeOfResource
+  # rubocop:disable Metrics/MethodLength
   sig { returns(T::Array[WorkType]) }
   def self.all
     [
@@ -157,6 +158,7 @@ class WorkType
           cocina_type: Cocina::Models::Vocab.object)
     ]
   end
+  # rubocop:enable Metrics/MethodLength
 
   sig { returns(T::Array[String]) }
   def self.type_list

--- a/app/models/work_type.rb
+++ b/app/models/work_type.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 # Represents the list of valid work types
-# rubocop:disable Metrics/ClassLength
 class WorkType
   extend T::Sig
 
@@ -137,7 +136,6 @@ class WorkType
   end
 
   # id is a value acceptable for MODS typeOfResource
-  # rubocop:disable Metrics/MethodLength
   sig { returns(T::Array[WorkType]) }
   def self.all
     [
@@ -159,7 +157,6 @@ class WorkType
           cocina_type: Cocina::Models::Vocab.object)
     ]
   end
-  # rubocop:enable Metrics/MethodLength
 
   sig { returns(T::Array[String]) }
   def self.type_list
@@ -171,4 +168,3 @@ class WorkType
     find(id).subtypes
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/services/contributors_generator.rb
+++ b/app/services/contributors_generator.rb
@@ -120,7 +120,6 @@ class ContributorsGenerator
     )
   end
 
-  # rubocop:disable Metrics/MethodLength
   sig { params(role: String).returns(T.nilable(Cocina::Models::DescriptiveValue)) }
   def marcrelator_role(role)
     mr_code = ROLE_TO_MARC_RELATOR_CODE[role]
@@ -137,9 +136,7 @@ class ContributorsGenerator
       }
     )
   end
-  # rubocop:enable Metrics/MethodLength
 
-  # rubocop:disable Metrics/MethodLength
   sig { params(role: String).returns(T.nilable(Cocina::Models::DescriptiveValue)) }
   def datacite_role(role)
     datacite_role = ROLE_TO_DATA_CITE_VALUE[role]
@@ -160,7 +157,6 @@ class ContributorsGenerator
       }
     )
   end
-  # rubocop:enable Metrics/MethodLength
 
   ROLE_TO_MARC_RELATOR_CODE = {
     # person

--- a/app/services/description_generator.rb
+++ b/app/services/description_generator.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 # This generates a RequestDRO Description for a work
-# rubocop:disable Metrics/ClassLength
 class DescriptionGenerator
   extend T::Sig
 
@@ -145,4 +144,3 @@ class DescriptionGenerator
     end
   end
 end
-# rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
## Why was this change made?

Per discussion in dev planning 2020-11-17, here is a PR to increase the class length max and the method length max for rubocop.  
- the first commit is a refactor to slightly reorganize the rubocop.yml file (for ease of maintenance);  
- the second commit is the rule changes
- the third commit is the inline comments that must be removed with these rule changes
- the fourth commit is regenerating rubocop_todo (by hand, so maxes aren't increased)

Weigh in below, check the box when you've reviewed the PR at least once.  If there's lively discussion below, we'll move this to an infradev meeting
- [x] @aaron-collier 
- [x] @jermnelson 
- [x] @jmartin-sul 
- [x] @justinlittman 
- [x] @jcoyne 
- [x] @mjgiarlo 
- [x] @peetucket 
