### PR TITLE
add super-diff gem to improve data diff in test output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ group :development, :test do
   gem 'rubocop-sorbet', require: false
   # CodeClimate is not compatible with 0.18+. See https://github.com/codeclimate/test-reporter/issues/413
   gem 'simplecov', '~> 0.17.1', require: false
+  gem 'super_diff', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       capybara (~> 3.13, < 4)
       websocket-driver (>= 0.6.5)
     ast (2.4.1)
+    attr_extras (6.2.4)
     bcrypt (3.1.16)
     bindex (0.8.1)
     bootsnap (1.5.0)
@@ -276,6 +277,8 @@ GEM
       sorbet-runtime (>= 0.5)
     parser (2.7.2.0)
       ast (~> 2.4.1)
+    patience_diff (1.1.0)
+      trollop (~> 1.16)
     pg (1.2.3)
     polyfill (1.8.0)
     psych (3.2.0)
@@ -441,8 +444,13 @@ GEM
     state_machines-activerecord (0.6.0)
       activerecord (>= 4.1)
       state_machines-activemodel (>= 0.5.0)
+    super_diff (0.5.2)
+      attr_extras (>= 6.2.4)
+      diff-lcs
+      patience_diff
     thor (1.0.1)
     thread_safe (0.3.6)
+    trollop (1.16.2)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -521,6 +529,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   state_machines-activerecord
+  super_diff
   turbolinks (~> 5)
   view_component (~> 2.18)
   web-console (>= 3.3.0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,7 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+require 'super_diff/rspec-rails'
 require 'action_policy/rspec/dsl'
 
 # Add additional requires below this line. Rails is not loaded until this point!


### PR DESCRIPTION
## Why was this change made?

Remaining contributor mappings will greatly benefit from using super-diff to see what is different in failing test cocina models and xml

## How was this change tested?



## Which documentation and/or configurations were updated?



