### PR TITLE
contributor -> cocina model gets status=primary

### DIFF
--- a/app/services/description_generator.rb
+++ b/app/services/description_generator.rb
@@ -103,7 +103,8 @@ class DescriptionGenerator
       date: [
         {
           value: work.published_edtf,
-          encoding: { code: 'edtf' }
+          encoding: { code: 'edtf' },
+          status: 'primary'
         }
       ]
     )

--- a/spec/services/contributors_generator_spec.rb
+++ b/spec/services/contributors_generator_spec.rb
@@ -214,6 +214,7 @@ RSpec.describe ContributorsGenerator do
           Cocina::Models::Contributor.new(
             name: [{ value: contributor.full_name }],
             type: 'conference',
+            status: 'primary',
             role: [
               {
                 value: 'Conference',
@@ -241,6 +242,7 @@ RSpec.describe ContributorsGenerator do
               }
             ],
             type: 'person',
+            status: 'primary',
             role: contributing_author_roles
           )
         ]
@@ -254,8 +256,6 @@ RSpec.describe ContributorsGenerator do
       let(:contributor) { build(:contributor, role: 'Data collector') }
       let(:work) { build(:work, contributors: [contributor]) }
 
-      # TODO: add status primary
-
       it 'creates Cocina::Models::Contributor with DataCite role' do
         expect(cocina_model).to eq(
           [
@@ -267,6 +267,7 @@ RSpec.describe ContributorsGenerator do
                 }
               ],
               type: 'person',
+              status: 'primary',
               role: [
                 {
                   value: 'Data collector',
@@ -296,7 +297,7 @@ RSpec.describe ContributorsGenerator do
     end
 
     context 'with person with multiple roles, one maps to DataCite creator property' do
-      # FIXME: implement deduping of names to get multiple roles
+      # NOTE: deduping of names to get multiple roles has been officially postponed by Amy and Arcadia
       xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_contributor.txt#L50'
     end
 
@@ -304,14 +305,13 @@ RSpec.describe ContributorsGenerator do
       let(:contributor) { build(:contributor, :with_org_contributor, role: 'Host institution') }
       let(:work) { build(:work, contributors: [contributor]) }
 
-      # TODO: add status primary
-
       it 'creates Cocina::Models::Contributor without marc relator role' do
         expect(cocina_model).to eq(
           [
             Cocina::Models::Contributor.new(
               name: [{ value: contributor.full_name }],
               type: 'organization',
+              status: 'primary',
               role: [
                 {
                   value: 'Host institution',
@@ -337,7 +337,7 @@ RSpec.describe ContributorsGenerator do
     end
 
     context 'with organization with multiple roles' do
-      # FIXME: implement deduping of names to get multiple roles
+      # NOTE: deduping of names to get multiple roles has been officially postponed by Amy and Arcadia
       xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_contributor.txt#L150'
     end
 
@@ -346,12 +346,12 @@ RSpec.describe ContributorsGenerator do
       let(:work) { build(:work, contributors: [contributor]) }
 
       it 'creates Cocina::Models::Contributor' do
-        # TODO: add status primary
         expect(cocina_model).to eq(
           [
             Cocina::Models::Contributor.new(
               name: [{ value: contributor.full_name }],
               type: 'conference',
+              status: 'primary',
               role: [
                 {
                   value: 'Conference',
@@ -374,12 +374,12 @@ RSpec.describe ContributorsGenerator do
       let(:work) { build(:work, contributors: [contributor]) }
 
       it 'creates Cocina::Models::Contributor with DataCite role' do
-        # TODO: add status primary
         expect(cocina_model).to eq(
           [
             Cocina::Models::Contributor.new(
               name: [{ value: contributor.full_name }],
               type: 'event',
+              status: 'primary',
               role: [
                 {
                   value: 'Event',
@@ -402,8 +402,9 @@ RSpec.describe ContributorsGenerator do
       let(:contributor2) { build(:contributor, role: 'Author') }
       let(:work) { build(:work, contributors: [contributor1, contributor2]) }
 
+      # TODO: implement order
+
       it 'creates array of Cocina::Models::Contributor, one for each person contributor' do
-        # TODO: add order
         expect(cocina_model).to eq(
           [
             Cocina::Models::Contributor.new(
@@ -414,6 +415,8 @@ RSpec.describe ContributorsGenerator do
                 }
               ],
               type: 'person',
+              status: 'primary',
+              # order: 1,
               role: author_roles
             ),
             Cocina::Models::Contributor.new(
@@ -424,6 +427,7 @@ RSpec.describe ContributorsGenerator do
                 }
               ],
               type: 'person',
+              # order: 2,
               role: author_roles
             )
           ]
@@ -437,7 +441,6 @@ RSpec.describe ContributorsGenerator do
       let(:work) { build(:work, contributors: [contributor1, contributor2]) }
 
       it 'creates array of Cocina::Models::Contributors' do
-        # TODO: add status primary / order
         expect(cocina_model).to eq(
           [
             Cocina::Models::Contributor.new(
@@ -448,6 +451,7 @@ RSpec.describe ContributorsGenerator do
                 }
               ],
               type: 'person',
+              status: 'primary',
               role: author_roles
             ),
             Cocina::Models::Contributor.new(
@@ -466,8 +470,9 @@ RSpec.describe ContributorsGenerator do
       let(:contributor3) { build(:contributor, role: 'Author') }
       let(:work) { build(:work, contributors: [contributor1, contributor2, contributor3]) }
 
+      # TODO: implement order
+
       it 'creates array of Cocina::Models::Contributors' do
-        # TODO: add status primary / order
         expect(cocina_model).to eq(
           [
             Cocina::Models::Contributor.new(
@@ -478,11 +483,14 @@ RSpec.describe ContributorsGenerator do
                 }
               ],
               type: 'person',
+              status: 'primary',
+              # order: 1,
               role: author_roles
             ),
             Cocina::Models::Contributor.new(
               name: [{ value: contributor2.full_name }],
               type: 'organization',
+              # order: 2,
               role: author_roles
             ),
             Cocina::Models::Contributor.new(
@@ -493,6 +501,7 @@ RSpec.describe ContributorsGenerator do
                 }
               ],
               type: 'person',
+              # order: 3,
               role: author_roles
             )
           ]
@@ -506,8 +515,9 @@ RSpec.describe ContributorsGenerator do
       let(:contributor3) { build(:contributor, role: 'Author') }
       let(:work) { build(:work, contributors: [contributor1, contributor2, contributor3]) }
 
+      # TODO: implement order
+
       it 'creates array of Cocina::Models::Contributors' do
-        # TODO: add status primary / order
         expect(cocina_model).to eq(
           [
             Cocina::Models::Contributor.new(
@@ -518,6 +528,8 @@ RSpec.describe ContributorsGenerator do
                 }
               ],
               type: 'person',
+              status: 'primary',
+              # order: 1,
               role: author_roles
             ),
             Cocina::Models::Contributor.new(
@@ -533,6 +545,7 @@ RSpec.describe ContributorsGenerator do
                 }
               ],
               type: 'person',
+              # order: 2,
               role: author_roles
             )
           ]
@@ -545,12 +558,12 @@ RSpec.describe ContributorsGenerator do
       let(:work) { build(:work, contributors: [contributor]) }
 
       it 'creates Cocina::Models::Contributor per spec' do
-        # TODO: add status primary
         expect(cocina_model).to eq(
           [
             Cocina::Models::Contributor.new(
               name: [{ value: contributor.full_name }],
               type: 'organization',
+              status: 'primary',
               role: [
                 {
                   value: 'Funder',

--- a/spec/services/description_generator_spec.rb
+++ b/spec/services/description_generator_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe DescriptionGenerator do
         {
           name: [{ value: contributor.full_name }],
           type: contributor.contributor_type,
+          status: 'primary',
           role: [
             {
               value: contributor.role,
@@ -217,6 +218,7 @@ RSpec.describe DescriptionGenerator do
           {
             name: [{ value: contributor1.full_name }],
             type: 'event',
+            status: 'primary',
             role: [
               {
                 value: 'Event',
@@ -346,6 +348,7 @@ RSpec.describe DescriptionGenerator do
               }
             ],
             type: person_contrib.contributor_type,
+            status: 'primary',
             role: [
               {
                 value: person_contrib.role,

--- a/spec/services/description_generator_spec.rb
+++ b/spec/services/description_generator_spec.rb
@@ -88,8 +88,25 @@ RSpec.describe DescriptionGenerator do
   it 'creates description cocina model' do
     expect(model).to eq(
       event: [
-        { date: [{ encoding: { code: 'edtf' }, value: '2020-03-04/2020-10-31' }], type: 'creation' },
-        { date: [{ encoding: { code: 'edtf' }, value: '2020-02-14' }], type: 'publication' }
+        {
+          date: [
+            {
+              encoding: { code: 'edtf' },
+              value: '2020-03-04/2020-10-31'
+            }
+          ],
+          type: 'creation'
+        },
+        {
+          date: [
+            {
+              encoding: { code: 'edtf' },
+              value: '2020-02-14',
+              status: 'primary'
+            }
+          ],
+          type: 'publication'
+        }
       ],
       subject: [
         { type: 'topic', value: 'MyString' },
@@ -280,7 +297,13 @@ RSpec.describe DescriptionGenerator do
                 role: publisher_roles
               }
             ],
-            date: [{ encoding: { code: 'edtf' }, value: '2020-02-14' }]
+            date: [
+              {
+                encoding: { code: 'edtf' },
+                value: '2020-02-14',
+                status: 'primary'
+              }
+            ]
           }
         ],
         form: types_form,
@@ -325,7 +348,7 @@ RSpec.describe DescriptionGenerator do
     end
   end
 
-  # Arcadia to add h2 spec for when there is a person and a publisher
+  # NOTE: Arcadia to add h2 mapping spec for when there is a person and a publisher
   context 'when author, publisher and publication date are entered by user' do
     let(:person_contrib) { build(:contributor, role: 'Author') }
     let(:pub_contrib) { build(:contributor, :with_org_contributor, role: 'Publisher') }
@@ -382,7 +405,13 @@ RSpec.describe DescriptionGenerator do
                 role: publisher_roles
               }
             ],
-            date: [{ encoding: { code: 'edtf' }, value: '2020-02-14' }]
+            date: [
+              {
+                encoding: { code: 'edtf' },
+                value: '2020-02-14',
+                status: 'primary'
+              }
+            ]
           }
         ],
         form: types_form,


### PR DESCRIPTION
~~[DRAFT] until I get a final confirmation from Arcadia that the implementation of this is as she desired.~~
~~[DRAFT] until team agrees on ordering and primary status implications from H2 UI and cocina models.~~

## Why was this change made?

Part of #240.

## How was this change tested?

unit tests from Arcadia's h2 mapping spec for contributors, with a bunch of TODO / FIXME comments removed!

## Which documentation and/or configurations were updated?



