### PR TITLE
Prevent form submission when pressing return in the keyword widget

### DIFF
--- a/app/components/works/keywords_component.html.erb
+++ b/app/components/works/keywords_component.html.erb
@@ -20,7 +20,7 @@
                role="searchbox" aria-autocomplete="list" autocomplete="off"
                id="work_keywords"
                aria-describedby="keyword-container"
-               data-action="change->keywords#add"
+               data-action="change->keywords#add keypress->keywords#checkForEnter"
                aria-controls="keyword-results">
       </span>
     </span>

--- a/app/javascript/controllers/keywords_controller.js
+++ b/app/javascript/controllers/keywords_controller.js
@@ -29,6 +29,13 @@ export default class extends Controller {
     this.containerTarget.classList.remove('is-invalid')
   }
 
+  checkForEnter(event) {
+    if (event.key === 'Enter') {
+      event.preventDefault() // prevent form submission
+      this.add(event);
+    }
+  }
+
   removeAssociation(event) {
     const item = event.target.closest(".selection-choice")
     item.querySelector("input[name*='_destroy']").value = 1


### PR DESCRIPTION
## Why was this change made?
Fixes #476


## How was this change tested?



## Which documentation and/or configurations were updated?



