### PR TITLE
removing an association (e.g. extra contributor) should ensure input fields are set to not required

### DIFF
--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -12,6 +12,7 @@ export default class extends Controller {
   removeAssociation(event) {
     event.preventDefault()
     const item = event.target.closest(".inner-container")
+    item.querySelectorAll('input').forEach((element) => element.required = false)
     item.querySelector("input[name*='_destroy']").value = 1
     item.style.display = 'none'
   }


### PR DESCRIPTION
## Why was this change made?

Fixes #504 (bug with new contributor row being removed not validating even though the row was gone).


## How was this change tested?

In the browser


## Which documentation and/or configurations were updated?



