### PR TITLE
Add a depositing state

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -30,7 +30,7 @@ class CollectionsController < ObjectsController
     @form = collection_form(collection)
     if @form.validate(collection_params) && @form.save
       # TODO: https://github.com/sul-dlss/happy-heron/issues/92
-      # DepositCollectionJob.perform_later(@collection) if deposit?
+      # DepositCollectionJob.perform_later(@collection) if deposit_button_pushed?
       redirect_to dashboard_path
     else
       render :new
@@ -44,7 +44,7 @@ class CollectionsController < ObjectsController
     @form = collection_form(collection)
     if @form.validate(collection_params) && @form.save
       # TODO: https://github.com/sul-dlss/happy-heron/issues/92
-      # DepositCollectionJob.perform_later(@collection) if deposit?
+      # DepositCollectionJob.perform_later(@collection) if deposit_button_pushed?
       redirect_to dashboard_path
     else
       render :edit
@@ -54,7 +54,7 @@ class CollectionsController < ObjectsController
   private
 
   def collection_form(collection)
-    return CollectionForm.new(collection) if deposit?
+    return CollectionForm.new(collection) if deposit_button_pushed?
 
     DraftCollectionForm.new(collection)
   end

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -5,7 +5,7 @@
 class ObjectsController < ApplicationController
   protected
 
-  def deposit?
+  def deposit_button_pushed?
     params[:commit] == 'Deposit'
   end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -10,6 +10,7 @@ class ReviewsController < ApplicationController
     work = Work.find(params[:work_id])
     authorize! work, to: :review?
     if params[:state] == 'approve'
+      work.begin_deposit!
       DepositJob.perform_later(work)
     else
       Event.create!(work: work, user: current_user, event_type: 'return', description: params[:reason])

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -62,17 +62,18 @@ class WorksController < ObjectsController
 
   sig { params(work: Work).returns(Reform::Form) }
   def work_form(work)
-    return WorkForm.new(work) if deposit?
+    return WorkForm.new(work) if deposit_button_pushed?
 
     DraftWorkForm.new(work)
   end
 
   sig { params(work: Work).void }
   def after_save(work)
-    if deposit?
+    if deposit_button_pushed?
       if work.collection.review_enabled?
         work.submit_for_review!
       else
+        work.begin_deposit!
         DepositJob.perform_later(work)
       end
     end

--- a/app/jobs/deposit_status_job.rb
+++ b/app/jobs/deposit_status_job.rb
@@ -13,7 +13,7 @@ class DepositStatusJob < BaseDepositJob
 
     if result.success?
       work.druid = result.value!
-      work.deposit!
+      work.deposit_complete!
     else
       Honeybadger.notify("Job #{job_id} for work #{work.id} failed with: #{result.failure}")
     end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -28,8 +28,12 @@ class Work < ApplicationRecord
   }
 
   state_machine initial: :first_draft do
-    event :deposit do
-      transition first_draft: :deposited, version_draft: :deposited
+    event :begin_deposit do
+      transition first_draft: :depositing, version_draft: :depositing, pending_approval: :depositing
+    end
+
+    event :deposit_complete do
+      transition depositing: :deposited
     end
 
     event :submit_for_review do

--- a/sorbet/custom/models/work.rbi
+++ b/sorbet/custom/models/work.rbi
@@ -6,6 +6,9 @@ class Work
   sig { void }
   def new_version!; end
 
+  sig { void }
+  def begin_deposit!; end
+
   sig { returns(T::Boolean) }
   def deposited?; end
 

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -129,7 +129,6 @@ RSpec.describe 'Create a new collection and deposit to it', js: true do
       expect(page).to have_content('2020-03-06/2020-10-30')
       expect(page).to have_content('Whatever')
       expect(page).to have_content('CC-PDDC Public Domain Dedication and Certification')
-      expect(page).to have_content('Draft - Not deposited')
     end
   end
 

--- a/spec/jobs/deposit_status_job_spec.rb
+++ b/spec/jobs/deposit_status_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DepositStatusJob do
 
   let(:client) { instance_double(Dor::Services::Client, objects: objects) }
   let(:druid) { 'druid:bc123df4567' }
-  let(:work) { build(:work) }
+  let(:work) { build(:work, state: 'depositing') }
   let(:result) { Success() }
   let(:job_id) { 1234 }
 
@@ -34,7 +34,7 @@ RSpec.describe DepositStatusJob do
     it 'notifies' do
       described_class.perform_now(work: work, job_id: job_id)
       expect(work.druid).to be_nil
-      expect(work.state_name).to eq :first_draft
+      expect(work.state_name).to eq :depositing
       expect(Honeybadger).to have_received(:notify)
     end
   end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -188,19 +188,20 @@ RSpec.describe Work do
       expect(work.state).to eq('first_draft')
     end
 
-    context 'with deposit event' do
+    context 'with begin_deposit event' do
       before do
-        work.deposit!
+        work.begin_deposit!
       end
 
       it 'transitions to deposited' do
-        expect(work.state).to eq('deposited')
+        expect(work.state).to eq('depositing')
       end
     end
 
     context 'with new version event' do
       before do
-        work.deposit!
+        work.begin_deposit!
+        work.deposit_complete!
         work.new_version!
       end
 

--- a/spec/requests/works_spec.rb
+++ b/spec/requests/works_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe 'Works requests' do
           expect(work.embargo_date).to eq Date.parse("#{embargo_year}-04-04")
           expect(work.subtype).to eq ['Article', 'Presentation slides']
           expect(DepositJob).to have_received(:perform_later).with(work)
-          expect(work.state).to eq 'first_draft'
+          expect(work.state).to eq 'depositing'
         end
       end
 
@@ -342,7 +342,7 @@ RSpec.describe 'Works requests' do
           expect(work.created_edtf).to be_nil
           expect(work.embargo_date).to be_nil
           expect(work.subtype).to be_empty
-          expect(work.state).to eq 'first_draft'
+          expect(work.state).to eq 'depositing'
           expect(DepositJob).to have_received(:perform_later)
         end
       end


### PR DESCRIPTION

## Why was this change made?

So the user can see when their work has been submitted for deposit, but isn't done yet.
Fixes #490 

## How was this change tested?



## Which documentation and/or configurations were updated?



