### PR TITLE
Upgrade Bootstrap to 5.0.0-alpha3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,10 @@ end
 
 group :test do
   gem 'apparition'
-  gem 'capybara', '>= 2.15'
+  # Pinned to git until 3.34.0 is released which disables smooth scrolling
+  # Using smooth scrolling is a feature of bootstrap 5.0.0-alpha3, which causes
+  # capybara to be unable to find elements below the fold.
+  gem 'capybara', github: 'teamcapybara/capybara'
   gem 'rspec-sorbet'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: https://github.com/teamcapybara/capybara.git
+  revision: 051a64d19296b1624925f55e39a60c779afe6abc
+  specs:
+    capybara (3.33.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -100,14 +113,6 @@ GEM
       capistrano (~> 3.0)
       sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
-    capybara (3.33.0)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (~> 1.5)
-      xpath (~> 3.2)
     cocina-models (0.42.1)
       activesupport
       dry-struct (~> 1.0)
@@ -491,7 +496,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-rvm
-  capybara (>= 2.15)
+  capybara!
   config (~> 2.2)
   devise (~> 4.7)
   devise-remote-user (~> 1.0)

--- a/app/javascript/stylesheets/work.scss
+++ b/app/javascript/stylesheets/work.scss
@@ -31,7 +31,7 @@
     }
 
     .state {
-      @extend .font-italic;
+      @extend .fst-italic;
       margin-left: 30px;
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.2.1",
-    "bootstrap": "5.0.0-alpha2",
+    "bootstrap": "5.0.0-alpha3",
     "dropzone": "^5.7.2",
     "popper.js": "^1.16.1",
     "stimulus": "^1.1.1",

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -11,3 +11,4 @@ require 'capybara/rspec'
 # end
 
 Capybara.javascript_driver = :apparition
+Capybara.disable_animation = true

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,10 +1529,10 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bootstrap@5.0.0-alpha2:
-  version "5.0.0-alpha2"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.0.0-alpha2.tgz#e37ce5836ef57c691d7e2369f7381b872d215f83"
-  integrity sha512-ZhW32+m5ImJoEkDKn43QQk2KovpJFisV/7TAg/RCzDi+B8m7FUgLHWx1Auu0Jt3/DQXDYwp6iwsprP3ej4u3ng==
+bootstrap@5.0.0-alpha3:
+  version "5.0.0-alpha3"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.0.0-alpha3.tgz#f5abbd38740383d6b8e041212aef5ea220e7daaa"
+  integrity sha512-ghwrMFNzqOwfB0nJ1iYbkERd+EK1PblUl7rEEynY35jD0TUlSY6yrjG2M42qI++NhAUBEqGcjmmHkMGs3QyNHA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
This also required using the trunk of capybara because Bootstrap added a smooth-scrolling directive, which causes capybara to be unable to find some elements.  The change in capybara trunk disables smooth scolling and allows the elements to be found

Fixes #512