### PR TITLE
Update work show page with state changes and new PURLs

### DIFF
--- a/app/channels/work_updates_channel.rb
+++ b/app/channels/work_updates_channel.rb
@@ -1,0 +1,17 @@
+# typed: strict
+# frozen_string_literal: true
+
+# An ActionCable channel for sending updates about works
+class WorkUpdatesChannel < ApplicationCable::Channel
+  extend T::Sig
+
+  sig { returns(T.any(Concurrent::ThreadPoolExecutor, T::Array[String])) }
+  def subscribed
+    stream_for Work.find(params[:workId])
+  end
+
+  sig { returns(T::Array[T.untyped]) }
+  def unsubscribed
+    stop_all_streams
+  end
+end

--- a/app/components/works/approval_component.html.erb
+++ b/app/components/works/approval_component.html.erb
@@ -10,7 +10,7 @@
         <% end %>
       </div>
       <div class="col-md-4" style="height: 4rem">
-        <%= render CheckboxButtonComponent.new(name: 'state', value: 'return', data: { action: 'approval#reveal' }) do %>
+        <%= render CheckboxButtonComponent.new(name: 'state', value: 'reject', data: { action: 'approval#reveal' }) do %>
           Return
         <% end %>
       </div>

--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -2,7 +2,7 @@
   <header class="title">
     <span class="header-text"><%= title %></span>
     <%= link_to edit_work_path(@work), aria: { label: "Edit #{title}"} do %><span class="fas fa-pencil-alt edit"></span><% end %>
-    <% if draft? %><span class="state">Draft - Not deposited</span><% end %>
+    <span data-target="work-updates.state" class="state"><%= current_state_display_label %></span>
   </header>
 
   <table class="table table-sm mb-5">
@@ -13,12 +13,16 @@
     </tr>
     </thead>
     <tbody>
-    <% if purl %>
       <tr>
         <th scope="row">Persistent link</th>
-        <td><%= link_to purl, purl %></td>
+        <td data-target="work-updates.purl">
+          <% if purl %>
+            <%= link_to purl, purl %>
+          <% else %>
+            <em>Link will become available once the work has been deposited.</em>
+          <% end %>
+        </td>
       </tr>
-    <% end %>
     <tr>
       <th scope="row">Collection</th>
       <td><%= link_to collection.name, collection %></td>

--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -16,7 +16,8 @@ module Works
              :contact_email,  :abstract, :citation,
              :published_edtf, :created_edtf,
              :depositor, :attached_files, :contributors,
-             :related_works, :related_links, to: :work
+             :related_works, :related_links, :current_state_display_label,
+             to: :work
 
     sig { returns(String) }
     def created_at
@@ -58,11 +59,6 @@ module Works
     sig { returns(String) }
     def keywords
       work.keywords.map(&:label).join(', ')
-    end
-
-    sig { returns(T::Boolean) }
-    def draft?
-      work.first_draft?
     end
   end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -10,11 +10,10 @@ class ReviewsController < ApplicationController
     work = Work.find(params[:work_id])
     authorize! work, to: :review?
     if params[:state] == 'approve'
-      work.begin_deposit!
+      EventService.begin_deposit(work: work, user: current_user)
       DepositJob.perform_later(work)
     else
-      Event.create!(work: work, user: current_user, event_type: 'return', description: params[:reason])
-      work.reject!
+      EventService.reject(work: work, user: current_user, description: params[:reason])
     end
 
     redirect_to dashboard_path

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -46,7 +46,7 @@ class WorksController < ObjectsController
 
     @form = work_form(work)
     if @form.validate(work_params) && @form.save
-      work.new_version! if work.deposited?
+      EventService.new_version(work: work, user: current_user) if work.deposited?
       after_save(work)
     else
       # Send form errors to client in JSON format to be parsed and rendered there
@@ -71,9 +71,9 @@ class WorksController < ObjectsController
   def after_save(work)
     if deposit_button_pushed?
       if work.collection.review_enabled?
-        work.submit_for_review!
+        EventService.submit_for_review(work: work, user: current_user)
       else
-        work.begin_deposit!
+        EventService.begin_deposit(work: work, user: current_user)
         DepositJob.perform_later(work)
       end
     end

--- a/app/javascript/controllers/work_updates_controller.js
+++ b/app/javascript/controllers/work_updates_controller.js
@@ -1,0 +1,40 @@
+import { Controller } from "stimulus"
+import consumer from '../channels/consumer'
+
+export default class extends Controller {
+  static targets = ['state', 'purl']
+
+  connect() {
+    let workUpdatesController = this
+
+    this.subscription = consumer.subscriptions.create(
+      {
+        channel: 'WorkUpdatesChannel',
+        workId: this.data.get('workId')
+      },
+      {
+        connected() {
+          // Called when the subscription is ready for use on the server
+        },
+        disconnected() {
+          // Called when the subscription has been terminated by the server
+        },
+        received(data) {
+          // Called when there's incoming data on the websocket for this channel
+          workUpdatesController.renderUpdates(data)
+        }
+      }
+    )
+  }
+
+  disconnect() {
+    this.subscription.unsubscribe()
+  }
+
+  renderUpdates(data) {
+    for (const [attribute, value] of Object.entries(data)) {
+      const target = this.targets.find(attribute)
+      target.innerHTML = value
+    }
+  }
+}

--- a/app/jobs/deposit_status_job.rb
+++ b/app/jobs/deposit_status_job.rb
@@ -12,8 +12,8 @@ class DepositStatusJob < BaseDepositJob
     raise TryAgainLater, "No result yet for job #{job_id}" if result.nil?
 
     if result.success?
-      work.druid = result.value!
-      work.deposit_complete!
+      work.update!(druid: result.value!)
+      EventService.deposit_complete(work: work)
     else
       Honeybadger.notify("Job #{job_id} for work #{work.id} failed with: #{result.failure}")
     end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -5,6 +5,17 @@
 class Work < ApplicationRecord
   extend T::Sig
 
+  STATE_DISPLAY_LABELS = T.let(
+    {
+      'first_draft' => 'Draft - Not deposited',
+      'version_draft' => 'New version draft - Not deposited',
+      'pending_approval' => 'Pending approval - Not deposited',
+      'depositing' => 'Deposit in progress',
+      'deposited' => 'Deposited'
+    }.freeze,
+    T::Hash[String, String]
+  )
+
   belongs_to :collection
   belongs_to :depositor, class_name: 'User'
 
@@ -65,5 +76,10 @@ class Work < ApplicationRecord
     when Date
       super(edtf.to_edtf)
     end
+  end
+
+  sig { returns(T.nilable(String)) }
+  def current_state_display_label
+    STATE_DISPLAY_LABELS[state]
   end
 end

--- a/app/services/event_service.rb
+++ b/app/services/event_service.rb
@@ -1,0 +1,48 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Triggers state changes, logs events, and broadcasts changes
+class EventService
+  extend T::Sig
+
+  class << self
+    include ActionView::Helpers::UrlHelper
+  end
+
+  sig { params(work: Work, user: User, description: String).returns(T.nilable(Integer)) }
+  def self.reject(work:, user:, description:)
+    work.reject!
+    Event.create!(work: work, user: user, event_type: 'reject', description: description)
+    WorkUpdatesChannel.broadcast_to(work, state: work.current_state_display_label)
+  end
+
+  sig { params(work: Work, user: User, description: String).returns(T.nilable(Integer)) }
+  def self.begin_deposit(work:, user:, description: '')
+    work.begin_deposit!
+    Event.create!(work: work, user: user, event_type: 'begin_deposit', description: description)
+    WorkUpdatesChannel.broadcast_to(work, state: work.current_state_display_label)
+  end
+
+  sig { params(work: Work).returns(T.nilable(Integer)) }
+  def self.deposit_complete(work:)
+    work.deposit_complete!
+    Event.create!(work: work, user: work.depositor, event_type: 'deposit_complete')
+    WorkUpdatesChannel.broadcast_to(work,
+                                    state: work.current_state_display_label,
+                                    purl: link_to(T.must(work.purl), T.must(work.purl)))
+  end
+
+  sig { params(work: Work, user: User).returns(T.nilable(Integer)) }
+  def self.new_version(work:, user:)
+    work.new_version!
+    Event.create!(work: work, user: user, event_type: 'new_version')
+    WorkUpdatesChannel.broadcast_to(work, state: work.current_state_display_label)
+  end
+
+  sig { params(work: Work, user: User).returns(T.nilable(Integer)) }
+  def self.submit_for_review(work:, user:)
+    work.submit_for_review!
+    Event.create!(work: work, user: user, event_type: 'submit_for_review')
+    WorkUpdatesChannel.broadcast_to(work, state: work.current_state_display_label)
+  end
+end

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -1,4 +1,4 @@
-<div class="container" id="work">
+<div class="container" id="work" data-controller="work-updates" data-work-updates-work-id="<%= @work.id %>">
   <%= render Works::ApprovalComponent.new(work: @work) %>
 
   <%= render Works::DetailComponent.new(work: @work) %>

--- a/sorbet/custom/models/work.rbi
+++ b/sorbet/custom/models/work.rbi
@@ -9,6 +9,12 @@ class Work
   sig { void }
   def begin_deposit!; end
 
+  sig { void }
+  def reject!; end
+
+  sig { void }
+  def deposit_complete!; end
+
   sig { returns(T::Boolean) }
   def deposited?; end
 

--- a/spec/channels/work_updates_channel_spec.rb
+++ b/spec/channels/work_updates_channel_spec.rb
@@ -1,0 +1,33 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WorkUpdatesChannel do
+  let(:user) { create(:user) }
+  let(:work) { create(:work) }
+
+  before do
+    stub_connection(current_user: user)
+  end
+
+  describe '#subscribed' do
+    it 'subscribes successfully' do
+      subscribe(workId: work.id)
+
+      expect(subscription).to be_confirmed
+      expect(subscription).to have_stream_from("work_updates:#{work.to_gid_param}")
+    end
+  end
+
+  describe '#unsubscribed' do
+    it 'unsubscribes successfully' do
+      subscribe(workId: work.id)
+
+      expect(subscription).to have_stream_from("work_updates:#{work.to_gid_param}")
+
+      perform :unsubscribed
+      expect(subscription).not_to have_streams
+    end
+  end
+end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -23,6 +23,18 @@ FactoryBot.define do
     state { 'pending_approval' }
   end
 
+  trait :first_draft do
+    state { 'first_draft' }
+  end
+
+  trait :depositing do
+    state { 'depositing' }
+  end
+
+  trait :deposited do
+    state { 'deposited' }
+  end
+
   trait :with_creation_dates do
     created_edtf { EDTF.parse('2020-03-04/2020-10-31') }
   end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Work do
     end
   end
 
-  describe 'purl' do
+  describe '#purl' do
     context 'with a druid' do
       it 'constructs purl' do
         work.update(druid: 'druid:hb093rg5848')
@@ -223,6 +223,12 @@ RSpec.describe Work do
       it 'returns nil' do
         expect(work.purl).to eq(nil)
       end
+    end
+  end
+
+  describe '#current_state_display_label' do
+    it 'returns the label as a string' do
+      expect(work.current_state_display_label).to eq('Draft - Not deposited')
     end
   end
 end

--- a/spec/requests/reviews_spec.rb
+++ b/spec/requests/reviews_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Works requests' do
 
     describe 'rejecting a deposit' do
       it 'returns the deposit and records the reason' do
-        post "/works/#{work.id}/review", params: { state: 'return', reason: 'Add more stuff' }
+        post "/works/#{work.id}/review", params: { state: 'reject', reason: 'Add more stuff' }
         expect(response).to redirect_to(dashboard_path)
         expect(DepositJob).not_to have_received(:perform_later)
         expect(work.reload).to be_first_draft

--- a/spec/services/event_service_spec.rb
+++ b/spec/services/event_service_spec.rb
@@ -1,0 +1,127 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EventService do
+  let(:depositor) { create(:user) }
+
+  before do
+    allow(WorkUpdatesChannel).to receive(:broadcast_to)
+  end
+
+  describe '.reject' do
+    let(:work) { create(:work, :pending_approval, depositor: depositor) }
+
+    it 'rejects the work' do
+      expect { described_class.reject(work: work, user: depositor, description: 'bad') }
+        .to change(work, :state)
+        .from('pending_approval').to('first_draft')
+    end
+
+    it 'creates an event' do
+      expect { described_class.reject(work: work, user: depositor, description: 'bad') }
+        .to change(Event, :count)
+        .by(1)
+    end
+
+    it 'broadcasts the state change' do
+      described_class.reject(work: work, user: depositor, description: 'bad')
+      expect(WorkUpdatesChannel).to have_received(:broadcast_to).with(work, state: 'Draft - Not deposited').once
+    end
+  end
+
+  describe '.begin_deposit' do
+    let(:work) { create(:work, :first_draft, depositor: depositor) }
+
+    it 'begins depositing the work' do
+      expect { described_class.begin_deposit(work: work, user: depositor) }
+        .to change(work, :state)
+        .from('first_draft').to('depositing')
+    end
+
+    it 'creates an event' do
+      expect { described_class.begin_deposit(work: work, user: depositor) }
+        .to change(Event, :count)
+        .by(1)
+    end
+
+    it 'broadcasts the state change' do
+      described_class.begin_deposit(work: work, user: depositor)
+      expect(WorkUpdatesChannel).to have_received(:broadcast_to).with(work, state: 'Deposit in progress').once
+    end
+  end
+
+  describe '.deposit_complete' do
+    let(:work) { create(:work, :depositing, depositor: depositor, druid: 'druid:bk875mg9867') }
+
+    it 'completes depositing the work' do
+      expect { described_class.deposit_complete(work: work) }
+        .to change(work, :state)
+        .from('depositing').to('deposited')
+    end
+
+    it 'creates an event' do
+      expect { described_class.deposit_complete(work: work) }
+        .to change(Event, :count)
+        .by(1)
+    end
+
+    it 'broadcasts the state change' do
+      described_class.deposit_complete(work: work)
+      expect(WorkUpdatesChannel).to have_received(:broadcast_to)
+        .with(
+          work,
+          state: 'Deposited',
+          purl: '<a href="https://purl.stanford.edu/bk875mg9867">https://purl.stanford.edu/bk875mg9867</a>'
+        )
+        .once
+    end
+  end
+
+  describe '.new_version' do
+    let(:work) { create(:work, :deposited, depositor: depositor) }
+
+    it 'adds a new version of the work' do
+      expect { described_class.new_version(work: work, user: depositor) }
+        .to change(work, :state)
+        .from('deposited').to('version_draft')
+    end
+
+    it 'creates an event' do
+      expect { described_class.new_version(work: work, user: depositor) }
+        .to change(Event, :count)
+        .by(1)
+    end
+
+    it 'broadcasts the state change' do
+      described_class.new_version(work: work, user: depositor)
+      expect(WorkUpdatesChannel).to have_received(:broadcast_to)
+        .with(work, state: 'New version draft - Not deposited')
+        .once
+    end
+  end
+
+  describe '.submit_for_review' do
+    let(:work) { create(:work, :first_draft, depositor: depositor) }
+
+    it 'submits the work for review' do
+      expect { described_class.submit_for_review(work: work, user: depositor) }
+        .to change(work, :state)
+        .from('first_draft').to('pending_approval')
+    end
+
+    it 'creates an event' do
+      expect { described_class.submit_for_review(work: work, user: depositor) }
+        .to change(Event, :count)
+        .by(1)
+    end
+
+    it 'broadcasts the state change' do
+      described_class.submit_for_review(work: work, user: depositor)
+      expect(WorkUpdatesChannel).to have_received(:broadcast_to)
+        .with(work, state: 'Pending approval - Not deposited')
+        .once
+    end
+  end
+end


### PR DESCRIPTION
Fixes #508

## Why was this change made?

This commit makes the work show page more interactive by updating the display dynamically, via ActionCable, whenever the work undergoes state changes (moving from draft to depositing to deposited, etc.). It also updates the Purl link when the item gets a druid assigned to it. This makes for a more interactive experience, and prevents page reloads for updates. It also serves as a working example of how to use ActionCable to deliver user-facing features.

Question for @astridu: should we animate/highlight/flash these changes when they occur, or is it preferable to go with the more inobtrusive experience (see screen cap below to see current implementation).

Includes:
* Add an ActionCable channel for streaming work updates to clients
* Rename 'return' to 'reject' for consistent domain language across the app
* Add a Stimulus controller to the work show page to handle ActionCable interaction
* Create a new event service that makes sure every work state change is accompanied by an associated event and a broadcast sent to the WorkUpdatesChannel
* Allow the work model to return user-friendly labels for supported states

## How was this change tested?

CI and local browser.

![Peek 2020-11-19 13-08](https://user-images.githubusercontent.com/131982/99730010-9f2a8600-2a70-11eb-90ba-41e051a16d78.gif)

## Which documentation and/or configurations were updated?

None

