### PR TITLE
Entrance users with a spinner

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -10,7 +10,7 @@ class Work < ApplicationRecord
       'first_draft' => 'Draft - Not deposited',
       'version_draft' => 'New version draft - Not deposited',
       'pending_approval' => 'Pending approval - Not deposited',
-      'depositing' => 'Deposit in progress',
+      'depositing' => 'Deposit in progress <span class="fas fa-spinner fa-pulse"></span>'.html_safe,
       'deposited' => 'Deposited'
     }.freeze,
     T::Hash[String, String]

--- a/spec/services/event_service_spec.rb
+++ b/spec/services/event_service_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe EventService do
 
     it 'broadcasts the state change' do
       described_class.begin_deposit(work: work, user: depositor)
-      expect(WorkUpdatesChannel).to have_received(:broadcast_to).with(work, state: 'Deposit in progress').once
+      expect(WorkUpdatesChannel).to have_received(:broadcast_to)
+        .with(work, state: 'Deposit in progress <span class="fas fa-spinner fa-pulse"></span>').once
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Do this so they know that they should expect a scintilling update to their work any moment now...

![Peek 2020-11-19 16-52](https://user-images.githubusercontent.com/131982/99742525-84640b80-2a88-11eb-8adb-340937511751.gif)

I do not love this approach of stuffing HTML in a string in the model, but I also do not have a better approach in my quiver at the moment. Happy to take suggestions and amend.


## How was this change tested?

CI, local browser

## Which documentation and/or configurations were updated?

NONE
