### PR TITLE
[Refactor] move display logic from the model to a component

### DIFF
--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -2,7 +2,7 @@
   <header class="title">
     <span class="header-text"><%= title %></span>
     <%= link_to edit_work_path(@work), aria: { label: "Edit #{title}"} do %><span class="fas fa-pencil-alt edit"></span><% end %>
-    <span data-target="work-updates.state" class="state"><%= current_state_display_label %></span>
+    <span data-target="work-updates.state" class="state"><%= render Works::StateDisplayComponent.new(work: work) %></span>
   </header>
 
   <table class="table table-sm mb-5">

--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -16,7 +16,7 @@ module Works
              :contact_email,  :abstract, :citation,
              :published_edtf, :created_edtf,
              :depositor, :attached_files, :contributors,
-             :related_works, :related_links, :current_state_display_label,
+             :related_works, :related_links,
              to: :work
 
     sig { returns(String) }

--- a/app/components/works/state_display_component.rb
+++ b/app/components/works/state_display_component.rb
@@ -1,0 +1,31 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Works
+  # Displays information about the current state of the deposit
+  class StateDisplayComponent < ApplicationComponent
+    STATE_DISPLAY_LABELS = T.let(
+      {
+        'first_draft' => 'Draft - Not deposited',
+        'version_draft' => 'New version draft - Not deposited',
+        'pending_approval' => 'Pending approval - Not deposited',
+        'depositing' => 'Deposit in progress <span class="fas fa-spinner fa-pulse"></span>'.html_safe,
+        'deposited' => 'Deposited'
+      }.freeze,
+      T::Hash[String, String]
+    )
+
+    sig { params(work: Work).void }
+    def initialize(work:)
+      @work = work
+    end
+
+    sig { returns(Work) }
+    attr_reader :work
+
+    sig { returns(T.nilable(String)) }
+    def call
+      STATE_DISPLAY_LABELS.fetch(work.state)
+    end
+  end
+end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -5,17 +5,6 @@
 class Work < ApplicationRecord
   extend T::Sig
 
-  STATE_DISPLAY_LABELS = T.let(
-    {
-      'first_draft' => 'Draft - Not deposited',
-      'version_draft' => 'New version draft - Not deposited',
-      'pending_approval' => 'Pending approval - Not deposited',
-      'depositing' => 'Deposit in progress <span class="fas fa-spinner fa-pulse"></span>'.html_safe,
-      'deposited' => 'Deposited'
-    }.freeze,
-    T::Hash[String, String]
-  )
-
   belongs_to :collection
   belongs_to :depositor, class_name: 'User'
 
@@ -76,10 +65,5 @@ class Work < ApplicationRecord
     when Date
       super(edtf.to_edtf)
     end
-  end
-
-  sig { returns(T.nilable(String)) }
-  def current_state_display_label
-    STATE_DISPLAY_LABELS[state]
   end
 end

--- a/app/services/event_service.rb
+++ b/app/services/event_service.rb
@@ -13,14 +13,14 @@ class EventService
   def self.reject(work:, user:, description:)
     work.reject!
     Event.create!(work: work, user: user, event_type: 'reject', description: description)
-    WorkUpdatesChannel.broadcast_to(work, state: work.current_state_display_label)
+    WorkUpdatesChannel.broadcast_to(work, state: current_state_display_label(work))
   end
 
   sig { params(work: Work, user: User, description: String).returns(T.nilable(Integer)) }
   def self.begin_deposit(work:, user:, description: '')
     work.begin_deposit!
     Event.create!(work: work, user: user, event_type: 'begin_deposit', description: description)
-    WorkUpdatesChannel.broadcast_to(work, state: work.current_state_display_label)
+    WorkUpdatesChannel.broadcast_to(work, state: current_state_display_label(work))
   end
 
   sig { params(work: Work).returns(T.nilable(Integer)) }
@@ -28,7 +28,7 @@ class EventService
     work.deposit_complete!
     Event.create!(work: work, user: work.depositor, event_type: 'deposit_complete')
     WorkUpdatesChannel.broadcast_to(work,
-                                    state: work.current_state_display_label,
+                                    state: current_state_display_label(work),
                                     purl: link_to(T.must(work.purl), T.must(work.purl)))
   end
 
@@ -36,13 +36,18 @@ class EventService
   def self.new_version(work:, user:)
     work.new_version!
     Event.create!(work: work, user: user, event_type: 'new_version')
-    WorkUpdatesChannel.broadcast_to(work, state: work.current_state_display_label)
+    WorkUpdatesChannel.broadcast_to(work, state: current_state_display_label(work))
   end
 
   sig { params(work: Work, user: User).returns(T.nilable(Integer)) }
   def self.submit_for_review(work:, user:)
     work.submit_for_review!
     Event.create!(work: work, user: user, event_type: 'submit_for_review')
-    WorkUpdatesChannel.broadcast_to(work, state: work.current_state_display_label)
+    WorkUpdatesChannel.broadcast_to(work, state: current_state_display_label(work))
+  end
+
+  sig { params(work: Work).returns(T.nilable(String)) }
+  def self.current_state_display_label(work)
+    Works::StateDisplayComponent.new(work: work).call
   end
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -225,10 +225,4 @@ RSpec.describe Work do
       end
     end
   end
-
-  describe '#current_state_display_label' do
-    it 'returns the label as a string' do
-      expect(work.current_state_display_label).to eq('Draft - Not deposited')
-    end
-  end
 end


### PR DESCRIPTION
## Why was this change made?

The model is for concerns about persistence and the component is for presentation.

## How was this change tested?



## Which documentation and/or configurations were updated?



