### PR TITLE
Do not display the deposit button if the collections state is in draft

### DIFF
--- a/app/components/dashboard/collection_component.html.erb
+++ b/app/components/dashboard/collection_component.html.erb
@@ -43,12 +43,14 @@
     <div class="mb-3">See all deposits</div>
   <% end %>
 
-  <%= button_tag '+ Deposit to this collection',
-        data: {
-          destination: new_collection_work_path(collection),
-          toggle: 'modal',
-          target: '#workTypeModal',
-          action: "work-type#set_collection"
-        },
-        class: "btn btn-primary" %>
+  <% if allowed_to?(:deposit?, collection) %>
+    <%= button_tag '+ Deposit to this collection',
+          data: {
+            destination: new_collection_work_path(collection),
+            toggle: 'modal',
+            target: '#workTypeModal',
+            action: "work-type#set_collection"
+          },
+          class: "btn btn-primary" %>
+  <% end %>
 </section>

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -3,6 +3,8 @@
 
 # Authorization policy for Collection objects
 class CollectionPolicy < ApplicationPolicy
+  NO_DEPOSIT_STATUS = %w[first_draft depositing].freeze
+
   # Return the relation defining the collections you can deposit into.
   scope_for :deposit do |relation|
     if administrator?
@@ -23,6 +25,11 @@ class CollectionPolicy < ApplicationPolicy
   sig { returns(T::Boolean) }
   def update?
     administrator? || manages_collection?(record)
+  end
+
+  sig { returns(T::Boolean) }
+  def deposit?
+    NO_DEPOSIT_STATUS.exclude? record.state
   end
 
   delegate :administrator?, :collection_creator?, to: :user_with_groups

--- a/spec/components/dashboard/collection_component_spec.rb
+++ b/spec/components/dashboard/collection_component_spec.rb
@@ -18,6 +18,34 @@ RSpec.describe Dashboard::CollectionComponent, type: :component do
     )
   end
 
+  context 'with a new, first draft collection' do
+    let(:collection) { create(:collection, :first_draft) }
+
+    it 'does not render the deposit button' do
+      expect(rendered.to_html).not_to include '+ Deposit to this collection'
+    end
+  end
+
+  context 'with a collection currently in the process of depositing' do
+    let(:collection) { create(:collection, :depositing) }
+
+    it 'does not render the deposit button' do
+      expect(rendered.to_html).not_to include '+ Deposit to this collection'
+    end
+  end
+
+  context 'with a deposit ready collection' do
+    before do
+      allow(controller).to receive_messages(allowed_to?: true)
+    end
+
+    let(:collection) { create(:collection) }
+
+    it 'does renders the deposit button' do
+      expect(rendered.to_html).to include '+ Deposit to this collection'
+    end
+  end
+
   context 'with 4 works' do
     before do
       create_list(:work, 4, collection: collection, depositor: user)

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     default_license { 'MyString' }
     email_when_participants_changed { false }
     managers { 'maya.aguirre, jcairns' }
+    state { 'deposited' }
     creator
   end
 

--- a/spec/features/create_new_collection_spec.rb
+++ b/spec/features/create_new_collection_spec.rb
@@ -1,0 +1,31 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Create a new collection', js: true do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user, groups: ['dlss:hydrus-app-collection-creators']
+  end
+
+  context 'when successful deposit' do
+    let(:collection_attrs) { attributes_for(:collection) }
+
+    it 'deposits and renders work show page' do
+      visit dashboard_path
+
+      click_link '+ Create a new collection'
+
+      fill_in 'Collection name', with: collection_attrs.fetch(:name)
+      fill_in 'Description', with: collection_attrs.fetch(:description)
+      fill_in 'Contact email', with: collection_attrs.fetch(:contact_email)
+
+      click_button 'Deposit'
+
+      expect(page).to have_content(collection_attrs.fetch(:name))
+      expect(page).not_to have_content('+ Deposit to this collection')
+    end
+  end
+end

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -3,8 +3,9 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Create a new collection and deposit to it', js: true do
+RSpec.describe 'Create a new work in a deposited collection', js: true do
   let(:user) { create(:user) }
+  let!(:collection) { create(:collection, depositors: [user]) }
 
   before do
     sign_in user, groups: ['dlss:hydrus-app-collection-creators']
@@ -16,14 +17,6 @@ RSpec.describe 'Create a new collection and deposit to it', js: true do
 
     it 'deposits and renders work show page' do
       visit dashboard_path
-
-      click_link '+ Create a new collection'
-
-      fill_in 'Collection name', with: collection_attrs.fetch(:name)
-      fill_in 'Description', with: collection_attrs.fetch(:description)
-      fill_in 'Contact email', with: collection_attrs.fetch(:contact_email)
-
-      click_button 'Deposit'
 
       click_button '+ Deposit to this collection' # , match: :first
 


### PR DESCRIPTION
## Why was this change made?

Fixes #514 by removing the deposit link if the collections status is `first_draft` or `depositing`.

<img width="1399" alt="Screen Shot 2020-11-23 at 3 56 46 PM" src="https://user-images.githubusercontent.com/2294288/100028799-8c7fbc00-2da4-11eb-85b4-b7f194fb996a.png">

## How was this change tested?

Unit and feature tests

## Which documentation and/or configurations were updated?

N/A

