### PR TITLE
Prevent removing the top-most contributor in the work form

### DIFF
--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -1,10 +1,12 @@
 <div class="row inner-container" data-controller="contributors" data-action="error->contributors#error" data-target="edit-deposit.contributorsField">
   <div class="contributors-container col-md-12" data-target="contributors.container">
-    <%= button_tag type: 'button', class: 'btn btn-sm float-right', aria: { label: 'Remove' },
-        data: { action: "click->nested-form#removeAssociation" } do %>
-      <span class="far fa-trash-alt"></span>
+    <% if not_first_contributor? %>
+      <%= button_tag type: 'button', class: 'btn btn-sm float-right', aria: { label: 'Remove' },
+                     data: { action: "click->nested-form#removeAssociation" } do %>
+        <span class="far fa-trash-alt"></span>
+      <% end %>
+      <%= form.hidden_field :_destroy %>
     <% end %>
-    <%= form.hidden_field :_destroy %>
   </div>
   <div class="col-md-3">
     <%= form.label :role_term, class: 'form-label' %>

--- a/app/components/works/contributor_row_component.rb
+++ b/app/components/works/contributor_row_component.rb
@@ -11,5 +11,10 @@ module Works
 
     sig { returns(ActionView::Helpers::FormBuilder) }
     attr_reader :form
+
+    sig { returns(T::Boolean) }
+    def not_first_contributor?
+      form.index != 0
+    end
   end
 end

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe 'Create a new collection and deposit to it', js: true do
       fill_in 'First name', with: 'Contributor First Name'
       fill_in 'Last name', with: 'Contributor Last Name'
 
+      # This is the div that contains the contributor remove button. The button
+      # should NOT be rendered since there's one and only one contributor at
+      # this point, which is not removable.
+      within('div.contributors-container') do
+        expect(page).not_to have_selector('button')
+      end
+
       select 'Publisher', from: 'Role term'
       fill_in 'Name', with: 'Best Publisher'
 


### PR DESCRIPTION

Fixes #519

## Why was this change made?

This is the behavior specified in the design documentation and has been signed off on by the P.O.

![Screenshot from 2020-11-23 15-02-48](https://user-images.githubusercontent.com/131982/100026179-25133d80-2d9f-11eb-9096-3b3a4342e67a.png)

## How was this change tested?

CI and local browser

## Which documentation and/or configurations were updated?

None

