### PR TITLE
[Refactor] Split the works spec into three separate specs

### DIFF
--- a/spec/requests/edit_work_spec.rb
+++ b/spec/requests/edit_work_spec.rb
@@ -1,0 +1,76 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Updating an existing work' do
+  let(:work) { create(:work) }
+  let(:collection) { create(:collection) }
+
+  before do
+    allow(Settings).to receive(:allow_sdr_content_changes).and_return(true)
+  end
+
+  context 'with an authenticated user' do
+    let(:user) { create(:user) }
+
+    before do
+      sign_in user, groups: ['dlss:hydrus-app-collection-creators']
+    end
+
+    describe 'update work' do
+      context 'with an attachment' do
+        let(:work) { create(:work, :with_attached_file, state: 'deposited') }
+        let(:user) { work.depositor }
+        let(:work_params) do
+          {
+            title: 'New title',
+            work_type: 'text',
+            contact_email: 'io@io.io',
+            abstract: 'test abstract',
+            attached_files_attributes: {
+              '0' => { 'label' => 'two', '_destroy' => '', 'hide' => '0', 'id' => work.attached_files.first.id }
+            },
+            keywords_attributes: {
+              '0' => { '_destroy' => 'false', 'label' => 'Feminism', 'uri' => 'http://id.worldcat.org/fast/922671' }
+            },
+            license: 'CC0-1.0',
+            release: 'immediate'
+          }
+        end
+
+        it 'redirects to the work page' do
+          patch "/works/#{work.id}", params: { work: work_params }
+          expect(work.reload).to be_version_draft
+          expect(response).to redirect_to(work)
+        end
+      end
+
+      context 'with a validation problem' do
+        let(:work) { create(:work) }
+        let(:user) { work.depositor }
+        let(:work_params) do
+          {
+            title: '',
+            work_type: 'text',
+            contact_email: 'io@io.io',
+            abstract: 'test abstract',
+            keywords_attributes: {
+              '0' => { '_destroy' => 'false', 'label' => 'Feminism', 'uri' => 'http://id.worldcat.org/fast/922671' }
+            },
+            license: 'CC0-1.0',
+            release: 'immediate'
+          }
+        end
+
+        it 'returns a validation error in JSON format' do
+          patch "/works/#{work.id}", params: { work: work_params, format: :json, commit: 'Deposit' }
+          expect(response).to have_http_status(:bad_request)
+          json = JSON.parse(response.body)
+          expect(json['title']).to include("can't be blank")
+          expect(json['file']).to eq ['Please add at least one file.']
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/show_work_spec.rb
+++ b/spec/requests/show_work_spec.rb
@@ -1,0 +1,34 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Show a work detail' do
+  let(:work) { create(:work) }
+  let(:collection) { create(:collection) }
+
+  context 'with unauthenticated user' do
+    before do
+      sign_out
+    end
+
+    it 'redirects from /works/:work_id to login URL' do
+      get "/works/#{work.id}"
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  context 'with an authenticated user' do
+    let(:user) { create(:user) }
+
+    before do
+      sign_in user, groups: ['dlss:hydrus-app-collection-creators']
+    end
+
+    it 'displays the work' do
+      get "/works/#{work.id}"
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include work.title
+    end
+  end
+end


### PR DESCRIPTION
One for each create, update and show

## Why was this change made?
Pure refactor, this makes the specs easier to read.  This enabled me to remove a duplicate spec we had hiding among the pile.


## How was this change tested?



## Which documentation and/or configurations were updated?



