### PR TITLE
Extract shared traits into their own factory

### DIFF
--- a/spec/factories/object_states.rb
+++ b/spec/factories/object_states.rb
@@ -1,0 +1,20 @@
+# typed: false
+# frozen_string_literal: true
+
+FactoryBot.define do
+  trait :pending_approval do
+    state { 'pending_approval' }
+  end
+
+  trait :first_draft do
+    state { 'first_draft' }
+  end
+
+  trait :depositing do
+    state { 'depositing' }
+  end
+
+  trait :deposited do
+    state { 'deposited' }
+  end
+end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -23,22 +23,6 @@ FactoryBot.define do
     embargo_date { '2040-09-03' }
   end
 
-  trait :pending_approval do
-    state { 'pending_approval' }
-  end
-
-  trait :first_draft do
-    state { 'first_draft' }
-  end
-
-  trait :depositing do
-    state { 'depositing' }
-  end
-
-  trait :deposited do
-    state { 'deposited' }
-  end
-
   trait :with_creation_date_range do
     created_edtf { EDTF.parse('2020-03-04/2020-10-31') }
   end


### PR DESCRIPTION
## Why was this change made?

Trait definitions in FactoryBot are global. This extracts the object state traits into it's own file for clarity.

## How was this change tested?

N/A

## Which documentation and/or configurations were updated?

N/A

