### PR TITLE
Display events on the deposit show page

### DIFF
--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -222,4 +222,26 @@
     </tr>
     </tbody>
   </table>
+
+  <table class="table table-sm mb-5" id="events">
+    <thead class="table-light">
+      <tr>
+        <th scope="col" class="table-title col-3">History</th>
+        <th scope="col">Modified by</th>
+        <th scope="col">Last modified</th>
+        <th scope="col">Description of changes</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% events.each do |event| %>
+        <tr>
+          <td><%= I18n.t event.event_type, scope: 'event.type' %></td>
+          <td><%= event.user.sunetid %></td>
+          <td><%= I18n.l(event.created_at, format: :abbr_month) %></td>
+
+          <td><%= event.description %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 </section>

--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -16,7 +16,7 @@ module Works
              :contact_email,  :abstract, :citation,
              :published_edtf, :created_edtf,
              :depositor, :attached_files, :contributors,
-             :related_works, :related_links,
+             :related_works, :related_links, :events,
              to: :work
 
     sig { returns(String) }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,3 +2,10 @@ en:
   date:
     formats:
       abbr_month: '%b %d, %Y'
+  time:
+    formats:
+      abbr_month: '%b %d, %Y %-I:%M %p'
+  event:
+    type:
+      return: Changes requested
+      begin_deposit: Deposited

--- a/spec/components/works/detail_component_spec.rb
+++ b/spec/components/works/detail_component_spec.rb
@@ -47,4 +47,12 @@ RSpec.describe Works::DetailComponent, type: :component do
       end
     end
   end
+
+  describe 'events' do
+    let(:work) { build_stubbed(:work, events: [build_stubbed(:event, description: 'Add more keywords')]) }
+
+    it 'renders the event' do
+      expect(rendered.css('#events').to_html).to include 'Add more keywords'
+    end
+  end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     description { 'MyString' }
     event_type { 'MyString' }
     work { nil }
-    user { nil }
+    user
   end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #536 

## How was this change tested?
<img width="1089" alt="Screen Shot 2020-11-24 at 3 11 04 PM" src="https://user-images.githubusercontent.com/92044/100157824-d7670580-2e70-11eb-82c9-01a1255bf6b5.png">



## Which documentation and/or configurations were updated?



