### PR TITLE
The create work policy depends on the collections state

### DIFF
--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -27,6 +27,7 @@ class CollectionPolicy < ApplicationPolicy
     administrator? || manages_collection?(record)
   end
 
+  # Can works be deposited into this collection
   sig { returns(T::Boolean) }
   def deposit?
     NO_DEPOSIT_STATUS.exclude? record.state

--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -15,7 +15,8 @@ class WorkPolicy < ApplicationPolicy
     return true if administrator?
 
     collection = record.collection
-    collection.depositor_ids.include?(user.id) || manages_collection?(collection)
+    allowed_to?(:deposit?, collection) &&
+      (collection.depositor_ids.include?(user.id) || manages_collection?(collection))
   end
 
   # Only the depositor may edit/update a work if it is not in review

--- a/spec/policies/work_policy_spec.rb
+++ b/spec/policies/work_policy_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe WorkPolicy do
       before { collection.depositors = [user] }
     end
 
+    failed 'when user is a depositor but the collection is depositing' do
+      let(:collection) { build_stubbed :collection, state: 'depositing' }
+
+      before { collection.depositors = [user] }
+    end
+
     succeed 'when user is a collection manager' do
       before { collection.managers = [user.sunetid] }
     end


### PR DESCRIPTION


## Why was this change made?

Don't allow deposits into collections that are depositing

## How was this change tested?



## Which documentation and/or configurations were updated?



