### PR TITLE
Use a properly formatted date as input to edtf

### DIFF
--- a/spec/validators/created_in_past_validator_spec.rb
+++ b/spec/validators/created_in_past_validator_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe CreatedInPastValidator do
         let(:month) { tomorrow.month }
         let(:day) { tomorrow.day }
 
-        let(:value) { EDTF.parse("#{year}-#{month}-#{day}") }
+        let(:value) { EDTF.parse(format('%<year>d-%<month>02d-%<day>02d', year: year, month: month, day: day)) }
 
         it 'has errors' do
           expect(record.errors.full_messages).to eq ['Created edtf must be in the past']


### PR DESCRIPTION


## Why was this change made?
EDTF days and months must be zero padded
Fixes #614



## How was this change tested?



## Which documentation and/or configurations were updated?



