### PR TITLE
Avoid month 13

### DIFF
--- a/spec/validators/created_in_past_validator_spec.rb
+++ b/spec/validators/created_in_past_validator_spec.rb
@@ -43,10 +43,11 @@ RSpec.describe CreatedInPastValidator do
       end
 
       context 'with a date after the current month' do
-        let(:year) { today.year }
-        let(:month) { today.month + 1 }
+        let(:next_month) { 1.month.from_now }
+        let(:year) { next_month.year }
+        let(:month) { next_month.month }
 
-        let(:value) { EDTF.parse("#{year}-#{month}") }
+        let(:value) { EDTF.parse(format('%<year>d-%<month>02d', year: year, month: month)) }
 
         it 'has errors' do
           expect(record.errors.full_messages).to eq ['Created edtf must be in the past']


### PR DESCRIPTION


## Why was this change made?

This test was too simple and simply adding one to the month.  Now it gets a date one month from now.

## How was this change tested?



## Which documentation and/or configurations were updated?



