### PR TITLE
Add improved support for organizations in auto citation

### DIFF
--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -35,7 +35,11 @@
   </div>
   <div class="col-md-8" data-target="contributors.organizationName">
     <%= form.label :full_name, 'Name', class: 'form-label' %>
-    <%= form.text_field :full_name, class: 'form-control', data: { action: 'change->contributors#inputChanged', target: 'contributors.organizationNameInput' }, required: true %>
+    <%= form.text_field :full_name, class: 'form-control',
+        data: {
+          action: 'change->contributors#inputChanged change->auto-citation#updateDisplay',
+          target: 'contributors.organizationNameInput auto-citation.contributorOrg'
+        }, required: true %>
     <div class="invalid-feedback">You must provide a name</div>
   </div>
   <div data-target="contributors.error" class="invalid-feedback"></div>

--- a/app/components/works/contributor_row_component.rb
+++ b/app/components/works/contributor_row_component.rb
@@ -17,13 +17,15 @@ module Works
       form.index != 0
     end
 
+    delegate :grouped_collection_select, to: :form
+
     def select_role
-      form.grouped_collection_select :role_term, grouped_options, :roles, :label, :key, :label,
-                                     {}, class: 'form-select',
-                                         data: {
-                                           action: 'change->contributors#typeChanged',
-                                           target: 'contributors.role auto-citation.contributorRole'
-                                         }
+      grouped_collection_select :role_term, grouped_options, :roles, :label, :key, :label,
+                                {}, class: 'form-select',
+                                    data: {
+                                      action: 'change->contributors#typeChanged change->auto-citation#updateDisplay',
+                                      target: 'contributors.role auto-citation.contributorRole'
+                                    }
     end
 
     # Represents the type of contributor top level option for the role select

--- a/app/javascript/controllers/auto_citation_controller.js
+++ b/app/javascript/controllers/auto_citation_controller.js
@@ -1,8 +1,9 @@
 import { Controller } from "stimulus";
 
 export default class extends Controller {
-  static targets = ["titleField", "contributorFirst", "contributorLast", "contributorRole",
-    "year", "month", "day", "manual", "auto", "switch"];
+  static targets = ["titleField", "manual", "auto", "switch",
+    "contributorFirst", "contributorLast", "contributorRole", "contributorOrg",
+    "year", "month", "day"];
 
   connect() {
     this.purl = this.data.get("purl") || ":link:" // Use a real purl on a persisted item or a placeholder
@@ -32,10 +33,12 @@ export default class extends Controller {
 
   get authors() {
     return this.contributorRoleTargets.map((roleField, index) => {
-      const firstInitial = `${this.contributorFirstTargets[index].value.charAt(0)}.`
-      const surname = this.contributorLastTargets[index].value
-
-      return `${surname}, ${firstInitial}`
+      if (roleField.value.startsWith('person')) {
+        const firstInitial = `${this.contributorFirstTargets[index].value.charAt(0)}.`
+        const surname = this.contributorLastTargets[index].value
+        return `${surname}, ${firstInitial}`
+      }
+      return this.contributorOrgTargets[index].value
     })
   }
 

--- a/spec/components/works/contributor_row_component_spec.rb
+++ b/spec/components/works/contributor_row_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Works::ContributorRowComponent do
 
     it 'makes groups with headings' do
       expected = <<~HTML
-        <select class="form-select" data-action="change-&gt;contributors#typeChanged" data-target="contributors.role auto-citation.contributorRole" name="role_term" id="role_term"><optgroup label="Individual"><option value="person|Author">Author</option>
+        <select class="form-select" data-action="change-&gt;contributors#typeChanged change-&gt;auto-citation#updateDisplay" data-target="contributors.role auto-citation.contributorRole" name="role_term" id="role_term"><optgroup label="Individual"><option value="person|Author">Author</option>
         <option value="person|Composer">Composer</option>
         <option value="person|Contributing author">Contributing author</option>
         <option value="person|Copyright holder">Copyright holder</option>


### PR DESCRIPTION
## Why was this change made?
Follows on #230 

Organization names were not displaying as authors.


## How was this change tested?
Before:
<img width="1249" alt="Screen Shot 2020-12-01 at 12 49 37 PM" src="https://user-images.githubusercontent.com/92044/100783696-b738c880-33d3-11eb-8419-d7b8e34d91af.png">


After
<img width="1251" alt="Screen Shot 2020-12-01 at 12 38 27 PM" src="https://user-images.githubusercontent.com/92044/100783557-8ce70b00-33d3-11eb-9e8f-943404ab4d0e.png">




## Which documentation and/or configurations were updated?



