### PR TITLE
Install git package to fix failing Docker builds

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -9,7 +9,8 @@ RUN apk add --update --no-cache \
   postgresql-dev \
   postgresql-client \
   tzdata \
-  yarn
+  yarn \
+  git
 
 # Get bundler 2.0
 RUN gem install bundler

--- a/docker/workers/Dockerfile
+++ b/docker/workers/Dockerfile
@@ -9,7 +9,8 @@ RUN apk add --update --no-cache \
   postgresql-dev \
   postgresql-client \
   redis \
-  tzdata
+  tzdata \
+  git
 
 # Get bundler 2.0
 RUN gem install bundler


### PR DESCRIPTION
## Why was this change made?
Running `docker-compose build` locally fails because git is not installed in the base `ruby:2.7.2-alpine`


## How was this change tested?
Test suite


## Which documentation and/or configurations were updated?
Workers and app Dockerfiles updated


