### PR TITLE
Prevent update_metadata transition when it isn't allowed

### DIFF
--- a/app/components/buttons_component.html.erb
+++ b/app/components/buttons_component.html.erb
@@ -1,6 +1,6 @@
 <div class="row justify-content-end">
   <div class="col-auto">
     <%= form.submit 'Save as draft', class: 'btn btn-primary', id: 'save-draft-button' %>
-    <%= form.submit 'Deposit', class: 'btn btn-primary' if depositable? %>
+    <%= form.submit 'Deposit', class: 'btn btn-primary' %>
   </div>
 </div>

--- a/app/components/buttons_component.rb
+++ b/app/components/buttons_component.rb
@@ -8,8 +8,4 @@ class ButtonsComponent < ApplicationComponent
   end
 
   attr_reader :form
-
-  def depositable?
-    helpers.allowed_to?(:deposit?, form.object.model)
-  end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -54,7 +54,6 @@ class CollectionsController < ObjectsController
   sig { params(collection: Collection).void }
   def after_save(collection)
     if deposit_button_pushed?
-      authorize! collection, to: :deposit?
       collection.begin_deposit!
     else
       collection.update_metadata!

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -79,7 +79,6 @@ class WorksController < ObjectsController
   sig { params(work: Work).void }
   def after_save(work)
     if deposit_button_pushed?
-      authorize! work, to: :deposit?
       if work.collection.review_enabled?
         work.submit_for_review!
       else

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -22,13 +22,9 @@ class CollectionPolicy < ApplicationPolicy
 
   sig { returns(T::Boolean) }
   def update?
-    administrator? || manages_collection?(record)
-  end
+    return false unless record.can_update_metadata?
 
-  # Can this collection be deposited
-  sig { returns(T::Boolean) }
-  def deposit?
-    record.can_begin_deposit?
+    administrator? || manages_collection?(record)
   end
 
   delegate :administrator?, :collection_creator?, to: :user_with_groups

--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -25,6 +25,8 @@ class WorkPolicy < ApplicationPolicy
   # Only the depositor may edit/update a work if it is not in review
   sig { returns(T::Boolean) }
   def update?
+    return false unless record.can_update_metadata?
+
     !record.pending_approval? && (administrator? || record.depositor == user)
   end
 
@@ -32,12 +34,6 @@ class WorkPolicy < ApplicationPolicy
   sig { returns(T::Boolean) }
   def review?
     record.pending_approval? && (administrator? || record.collection.reviewers.include?(user))
-  end
-
-  # Can this work be deposited
-  sig { returns(T::Boolean) }
-  def deposit?
-    record.can_begin_deposit? || record.can_update_metadata?
   end
 
   delegate :administrator?, to: :user_with_groups

--- a/spec/components/buttons_component_spec.rb
+++ b/spec/components/buttons_component_spec.rb
@@ -10,23 +10,11 @@ RSpec.describe ButtonsComponent do
   let(:work_form) { WorkForm.new(work) }
   let(:rendered) { render_inline(component) }
 
-  before do
-    allow(controller).to receive(:allowed_to?).and_return(depositable)
+  it 'renders the deposit button' do
+    expect(rendered.css('input[value="Deposit"]')).to be_present
   end
 
-  context 'when allowed to deposit' do
-    let(:depositable) { true }
-
-    it 'renders the deposit button' do
-      expect(rendered.css('input[value="Deposit"]')).to be_present
-    end
-  end
-
-  context 'when not allowed to deposit' do
-    let(:depositable) { false }
-
-    it "doesn't render the deposit button" do
-      expect(rendered.css('input[value="Deposit"]')).not_to be_present
-    end
+  it 'renders the save draft button' do
+    expect(rendered.css('input[value="Save as draft"]')).to be_present
   end
 end

--- a/spec/policies/collection_policy_spec.rb
+++ b/spec/policies/collection_policy_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe CollectionPolicy do
       let(:record) { build_stubbed(:collection, managers: [user]) }
     end
 
+    failed 'when user is a collection manager and status is depositing' do
+      let(:record) { build_stubbed :collection, :depositing, managers: [user] }
+    end
+
     succeed 'when user is an admin' do
       let(:groups) { [Settings.authorization_workgroup_names.administrators] }
     end

--- a/spec/policies/work_policy_spec.rb
+++ b/spec/policies/work_policy_spec.rb
@@ -50,8 +50,12 @@ RSpec.describe WorkPolicy do
       let(:record) { build_stubbed :work, depositor: user }
     end
 
-    failed 'when user is the depositor and status is pending_approval' do
+    failed 'when user is a depositor and status is pending_approval' do
       let(:record) { build_stubbed :work, :pending_approval, depositor: user }
+    end
+
+    failed 'when user is a depositor and status is depositing' do
+      let(:record) { build_stubbed :work, :depositing, depositor: user }
     end
 
     succeed 'when user is an admin and status is not pending_approval' do


### PR DESCRIPTION
## Why was this change made?
Presently it's possible to attempt to save a draft of a depositing collection, which causes an invalid state transition.  This change prevents that from happening

Fixes #626

## How was this change tested?



## Which documentation and/or configurations were updated?



