### PR TITLE
Display reason and status for Returned reviews

### DIFF
--- a/app/components/dashboard/collection_component.html.erb
+++ b/app/components/dashboard/collection_component.html.erb
@@ -29,7 +29,7 @@
               <% end %>
             <% end %>
           </td>
-          <td><%= work.state.humanize %></td>
+          <td><%= render Works::StateDisplayComponent.new(work: work) %></td>
           <td><%= I18n.l(work.updated_at.to_date, format: :abbr_month) %></td>
           <td><%= link_to work.purl, work.purl if work.purl %></td>
           <td><span class="fas fa-quote-left"></span> Cite</td>

--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -5,6 +5,14 @@
       <button type="button" class="btn-close" data-dismiss="alert" aria-label="Close"></button>
     </div>
   <% end %>
+  <% if work.rejected? %>
+    <div class="alert alert-danger alert-dismissible text-dark" role="alert">
+      <h3>Approver has returned your deposit</h3>
+      <p>Fix the following and then submit it again for approval.</p>
+      <div class="p-3"><%= rejection_reason %></div>
+      <button type="button" class="btn-close" data-dismiss="alert" aria-label="Close"></button>
+    </div>
+  <% end %>
 
   <header class="title">
     <span class="header-text"><%= title %></span>
@@ -81,7 +89,6 @@
       <% end %>
     </tbody>
   </table>
-
 
   <table class="table table-sm mb-5">
     <thead class="table-light">

--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -65,5 +65,10 @@ module Works
     def display_approval?
       work.pending_approval? && !helpers.allowed_to?(:review?, work)
     end
+
+    sig { returns(String) }
+    def rejection_reason
+      work.events.reverse.find { |e| e.event_type == 'rejected' }.description
+    end
   end
 end

--- a/app/components/works/state_display_component.rb
+++ b/app/components/works/state_display_component.rb
@@ -9,6 +9,7 @@ module Works
         'first_draft' => 'Draft - Not deposited',
         'version_draft' => 'New version draft - Not deposited',
         'pending_approval' => 'Pending approval - Not deposited',
+        'rejected' => 'Returned',
         'depositing' => 'Deposit in progress <span class="fas fa-spinner fa-pulse"></span>'.html_safe,
         'deposited' => 'Deposited'
       }.freeze,

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -48,6 +48,9 @@ class Work < ApplicationRecord
       BroadcastWorkChange.call(work: work, state: transition.to_name)
     end
 
+    # NOTE: there is no approval "event" because when a work is approved in review, it goes
+    # directly to begin_deposit event, which will transition it to depositing
+
     event :begin_deposit do
       transition %i[first_draft version_draft pending_approval] => :depositing
     end
@@ -57,12 +60,11 @@ class Work < ApplicationRecord
     end
 
     event :submit_for_review do
-      transition %i[first_draft version_draft] => :pending_approval
+      transition %i[first_draft version_draft rejected] => :pending_approval
     end
 
     event :reject do
-      transition pending_approval: :first_draft, if: ->(work) { work.druid.blank? }
-      transition pending_approval: :version_draft, if: ->(work) { work.druid.present? }
+      transition pending_approval: :rejected
     end
 
     event :update_metadata do

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -69,7 +69,7 @@ class Work < ApplicationRecord
 
     event :update_metadata do
       transition deposited: :version_draft
-      transition %i[first_draft version_draft] => same
+      transition %i[first_draft version_draft rejected] => same
     end
   end
 

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -29,7 +29,7 @@
               <td><%= link_to submission.title, work_path(submission) %></td>
               <td><%= submission.depositor.sunetid %></td>
               <td><%= submission.collection.name %></td>
-              <td><%= submission.state.humanize %></td>
+              <td><%= render Works::StateDisplayComponent.new(work: submission) %></td>
               <td><%= I18n.l(submission.updated_at.to_date, format: :abbr_month) %></td>
             </tr>
           <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,12 @@ en:
     type:
       return: Changes requested
       begin_deposit: Deposited
+      rejected: Changes requested
+      pending_approval: Waiting for review
+      first_draft: First draft
+      version_draft: Version draft
+      depositing: Deposited
+      deposited: Deposited
   contributor:
     roles:
       person: Individual

--- a/spec/components/works/detail_component_spec.rb
+++ b/spec/components/works/detail_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Works::DetailComponent, type: :component do
     end
   end
 
-  context 'when deposted' do
+  context 'when deposited' do
     let(:work) { build_stubbed(:work, state: 'deposited') }
 
     it 'renders the draft title' do
@@ -45,6 +45,23 @@ RSpec.describe Works::DetailComponent, type: :component do
       it 'renders the messge about review' do
         expect(rendered.css('.alert-warning').to_html).to be_blank
       end
+    end
+  end
+
+  context 'when rejected' do
+    let(:rejection_reason) { 'Why did you die your hair chartreuse?' }
+    let(:work) do
+      build_stubbed(:work,
+                    state: 'rejected',
+                    events: [build_stubbed(:event, description: rejection_reason, event_type: 'rejected')])
+    end
+
+    before do
+      allow(controller).to receive(:allowed_to?).and_return(true)
+    end
+
+    it 'renders the rejection alert' do
+      expect(rendered.css('.alert-danger').to_html).to include(rejection_reason)
     end
   end
 

--- a/spec/factories/object_states.rb
+++ b/spec/factories/object_states.rb
@@ -17,4 +17,8 @@ FactoryBot.define do
   trait :deposited do
     state { 'deposited' }
   end
+
+  trait :rejected do
+    state { 'rejected' }
+  end
 end

--- a/spec/features/mediated_deposit_versioning_spec.rb
+++ b/spec/features/mediated_deposit_versioning_spec.rb
@@ -6,6 +6,8 @@ require 'rails_helper'
 RSpec.describe 'Edit a new version of a work in a collection using mediated deposit', js: true do
   let(:collection) { create(:collection, reviewers: [user], depositors: [user]) }
   let(:new_work_title) { 'I Appear To Have Changed' }
+  let(:rejection_reason) { 'I do not like the color' }
+  let(:newest_work_title) { 'Indigo is preferred' }
   let(:user) { create(:user) }
   # Work (and collection) needs to exist before user hits dashboard
   let!(:work) do
@@ -14,12 +16,11 @@ RSpec.describe 'Edit a new version of a work in a collection using mediated depo
            collection: collection)
   end
 
-  context 'when reviewer approves work' do
+  context 'when reviewer rejects, then approves work' do
     it 'works as expected' do
       sign_in user
       visit dashboard_path
       find("a[aria-label='Edit #{work.title}']").click
-
       fill_in 'Title of deposit', with: new_work_title
       check 'I agree to the SDR Terms of Deposit'
       click_button 'Deposit'
@@ -32,11 +33,33 @@ RSpec.describe 'Edit a new version of a work in a collection using mediated depo
         click_link(new_work_title)
       end
       expect(page).to have_content('Review all details below, then approve or return this deposit')
+      find('label', text: 'Return').click
+      fill_in 'reason', with: rejection_reason
+      click_button('Submit')
+
+      visit dashboard_path
+      click_link new_work_title
+      expect(page).to have_content(rejection_reason)
+
+      # TODO: ask Amy if rejection should show up on the edit page
+      find("a[aria-label='Edit #{new_work_title}']").click
+      fill_in 'Title of deposit', with: newest_work_title
+      check 'I agree to the SDR Terms of Deposit'
+      click_button 'Deposit'
+
+      expect(page).to have_content(newest_work_title)
+      expect(page).to have_content('Pending approval - Not deposited')
+
+      visit dashboard_path
+      within_table('Approvals') do
+        click_link(newest_work_title)
+      end
+      expect(page).to have_content('Review all details below, then approve or return this deposit')
       find('label', text: 'Approve and deposit').click
       click_button('Submit')
 
-      expect(page).to have_link(new_work_title)
-      click_link(new_work_title)
+      expect(page).to have_link(newest_work_title)
+      click_link(newest_work_title)
       expect(page).to have_content('Deposit in progress')
     end
   end

--- a/spec/requests/reviews_spec.rb
+++ b/spec/requests/reviews_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Works requests' do
         expect(response).to redirect_to(dashboard_path)
         expect(DepositJob).not_to have_received(:perform_later)
 
-        expect(work.reload).to be_first_draft
+        expect(work.reload).to be_rejected
         expect(work.events.last.description).to eq 'Add more stuff'
       end
     end


### PR DESCRIPTION
Fixes #576
Fixes #581

## Why was this change made?

For #576:  display appropriate status for work rejected by reviewer

### Before

![Screen Shot 2020-11-23 at 5.57.21 PM.png](https://images.zenhubusercontent.com/5e9e06e81c23039800e23efc/07cd82a1-b03c-4421-8fad-d3a144d8fff8)

### After

![image](https://user-images.githubusercontent.com/96775/100815610-3260a580-33f9-11eb-8490-85f785b5777e.png)

For #581:  display comments from reviewer if work was rejected

### Before

![image](https://user-images.githubusercontent.com/96775/100815727-7eabe580-33f9-11eb-9919-c2f00126e4ab.png)

### After

![image](https://user-images.githubusercontent.com/96775/100815713-73f15080-33f9-11eb-8bc3-e20ad6c56bcd.png)

 
## How was this change tested?

Amy reviewed the changes for #581 in stage;   tests added for both issues with their commits.

## Which documentation and/or configurations were updated?



