### PR TITLE
Create a unique policy cache key for non-persisted objects

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -103,4 +103,11 @@ class Work < ApplicationRecord
   def created_edtf
     EDTF.parse(super)
   end
+
+  # This ensures that action-policy doesn't think that every 'Work.new' is the same.
+  # This supports the following:
+  #   allowed_to :create?, Work.new(collection:collection)
+  def policy_cache_key
+    persisted? ? cache_key : object_id
+  end
 end


### PR DESCRIPTION

## Why was this change made?

This prevents action-policy from checking if we can create a work in one collection and caching that value and applying it to all places.


## How was this change tested?



## Which documentation and/or configurations were updated?



