### PR TITLE
Summary of collection works on dashboard shows all editable works

### DIFF
--- a/app/components/dashboard/collection_component.rb
+++ b/app/components/dashboard/collection_component.rb
@@ -21,7 +21,7 @@ module Dashboard
     sig { returns(ActiveRecord::Relation) }
     def deposits
       policy = WorkPolicy.new(user: current_user, user_with_groups: user_with_groups)
-      policy.authorized_scope(collection.works.limit(5), as: :depositor)
+      policy.authorized_scope(collection.works.limit(5), as: :edits)
     end
   end
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -9,7 +9,7 @@ class DashboardsController < ApplicationController
   def show
     authorize! :dashboard
     @presenter = DashboardPresenter.new(
-      collections: authorized_scope(Collection, type: :deposit),
+      collections: authorized_scope(Collection.all, as: :deposit),
       approvals: Work.with_state(:pending_approval)
                       .joins(collection: :reviewers)
                       .where('reviewers.user_id' => current_user),

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -4,7 +4,7 @@
 # Authorization policy for Collection objects
 class CollectionPolicy < ApplicationPolicy
   # Return the relation defining the collections you can deposit into, manage or review.
-  scope_for :deposit do |relation|
+  relation_scope :deposit do |relation|
     relation.where(id: user.deposits_into_ids + user.manages_collection_ids + user.reviews_collection_ids)
   end
 

--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -5,8 +5,9 @@
 class WorkPolicy < ApplicationPolicy
   alias_rule :edit?, to: :update?
 
-  relation_scope :depositor do |scope|
+  relation_scope :edits do |scope|
     scope.where(depositor: user)
+         .or(scope.where(collection_id: [user.manages_collection_ids + user.reviews_collection_ids]))
   end
 
   # Can deposit a work iff:

--- a/spec/policies/collection_policy_spec.rb
+++ b/spec/policies/collection_policy_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe CollectionPolicy do
   end
 
   describe 'scope' do
-    subject(:scope) { policy.apply_scope(Collection, type: :deposit) }
+    subject(:scope) { policy.apply_scope(Collection, type: :active_record_relation, name: :deposit) }
 
     let(:policy) { described_class.new context }
     let!(:collection) { create(:collection) }

--- a/spec/policies/work_policy_spec.rb
+++ b/spec/policies/work_policy_spec.rb
@@ -91,4 +91,35 @@ RSpec.describe WorkPolicy do
       let(:groups) { [Settings.authorization_workgroup_names.administrators] }
     end
   end
+
+  describe 'scope' do
+    subject(:scope) { policy.apply_scope(collection.works, type: :active_record_relation, name: :edits) }
+
+    let(:policy) { described_class.new context }
+    let(:collection) { create(:collection) }
+    let(:work) { create(:work, collection: collection) }
+
+    context 'when the user is not affiliated' do
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the user is the depositor' do
+      let(:user) { create(:user) }
+      let(:work) { create(:work, collection: collection, depositor: user) }
+
+      it { is_expected.to include(work) }
+    end
+
+    context 'when the user is a reviewer' do
+      let(:collection) { create(:collection, reviewers: [user]) }
+
+      it { is_expected.to include(work) }
+    end
+
+    context 'when the user is a manager' do
+      let(:collection) { create(:collection, managers: [user]) }
+
+      it { is_expected.to include(work) }
+    end
+  end
 end

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -61,15 +61,13 @@ RSpec.describe 'Dashboard requests' do
 
     before do
       create(:work, collection: collection, state: 'pending_approval', title: 'To Review')
-      create(:work, collection: collection, state: 'first_draft', title: 'No Review')
       sign_in user
     end
 
-    it 'shows a link to create collections' do
+    it 'shows the collection to review' do
       get '/dashboard'
       expect(response).to have_http_status(:ok)
       expect(response.body).to include 'To Review'
-      expect(response.body).not_to include 'No Review'
     end
   end
 


### PR DESCRIPTION


## Why was this change made?
Previously it was only showing the works you deposited.

Fixes #569


## How was this change tested?



## Which documentation and/or configurations were updated?



