### PR TITLE
label Deposit/Submit for Approval button as appropriate

### DIFF
--- a/app/components/buttons_component.html.erb
+++ b/app/components/buttons_component.html.erb
@@ -1,6 +1,6 @@
 <div class="row justify-content-end">
   <div class="col-auto">
     <%= form.submit 'Save as draft', class: 'btn btn-primary', id: 'save-draft-button' %>
-    <%= form.submit 'Deposit', class: 'btn btn-primary' %>
+    <%= form.submit submit_button_label, class: 'btn btn-primary' %>
   </div>
 </div>

--- a/app/components/buttons_component.rb
+++ b/app/components/buttons_component.rb
@@ -8,4 +8,16 @@ class ButtonsComponent < ApplicationComponent
   end
 
   attr_reader :form
+
+  def submit_button_label
+    work_in_reviewed_coll? ? 'Submit for approval' : 'Deposit'
+  end
+
+  private
+
+  def work_in_reviewed_coll?
+    return false if form.object.instance_of?(CollectionForm)
+
+    form.object.model.collection.review_enabled?
+  end
 end

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -6,6 +6,6 @@ class ObjectsController < ApplicationController
   protected
 
   def deposit_button_pushed?
-    params[:commit] == 'Deposit'
+    params[:commit] == 'Deposit' || params[:commit] == 'Submit for approval'
   end
 end

--- a/app/javascript/modules/validate-forms.js
+++ b/app/javascript/modules/validate-forms.js
@@ -1,4 +1,4 @@
-// Example starter JavaScript for disabling form submissions if there are invalid fields
+// JavaScript to disable form submissions if there are invalid fields
 (function () {
   'use strict'
   window.addEventListener('turbolinks:load', function() {

--- a/spec/components/buttons_component_spec.rb
+++ b/spec/components/buttons_component_spec.rb
@@ -10,8 +10,18 @@ RSpec.describe ButtonsComponent do
   let(:work_form) { WorkForm.new(work) }
   let(:rendered) { render_inline(component) }
 
-  it 'renders the deposit button' do
-    expect(rendered.css('input[value="Deposit"]')).to be_present
+  context 'when collection does not require reviews' do
+    it 'renders submit button as "Deposit"' do
+      expect(rendered.css('input[value="Deposit"]')).to be_present
+    end
+  end
+
+  context 'when collection requires reviews' do
+    let(:work) { build(:work, collection: build(:collection, :with_reviewers, id: 8)) }
+
+    it 'renders submit button as "Submit for approval"' do
+      expect(rendered.css('input[value="Submit for approval"]')).to be_present
+    end
   end
 
   it 'renders the save draft button' do

--- a/spec/features/mediated_deposit_versioning_spec.rb
+++ b/spec/features/mediated_deposit_versioning_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Edit a new version of a work in a collection using mediated depo
       find("a[aria-label='Edit #{work.title}']").click
       fill_in 'Title of deposit', with: new_work_title
       check 'I agree to the SDR Terms of Deposit'
-      click_button 'Deposit'
+      click_button 'Submit for approval'
 
       expect(page).to have_content(new_work_title)
       expect(page).to have_content('Pending approval - Not deposited')
@@ -41,11 +41,10 @@ RSpec.describe 'Edit a new version of a work in a collection using mediated depo
       click_link new_work_title
       expect(page).to have_content(rejection_reason)
 
-      # TODO: ask Amy if rejection should show up on the edit page
       find("a[aria-label='Edit #{new_work_title}']").click
       fill_in 'Title of deposit', with: newest_work_title
       check 'I agree to the SDR Terms of Deposit'
-      click_button 'Deposit'
+      click_button 'Submit for approval'
 
       expect(page).to have_content(newest_work_title)
       expect(page).to have_content('Pending approval - Not deposited')
@@ -56,7 +55,7 @@ RSpec.describe 'Edit a new version of a work in a collection using mediated depo
       end
       expect(page).to have_content('Review all details below, then approve or return this deposit')
       find('label', text: 'Approve and deposit').click
-      click_button('Submit')
+      click_button 'Submit'
 
       expect(page).to have_link(newest_work_title)
       click_link(newest_work_title)


### PR DESCRIPTION
## Why was this change made?

Fixes #544 - the "Deposit" button for a work should be "Submit for approval" for works in collections with an approval process.

### Before

![image](https://user-images.githubusercontent.com/96775/100940034-1ec24700-34ac-11eb-90cc-3332e0ff8fef.png)

### After

(only for works in collections with review process)

![image](https://user-images.githubusercontent.com/96775/100939904-ee7aa880-34ab-11eb-8e16-bf545268dd49.png)


## How was this change tested?

unit tests, Amy reviewed it in qa environment.

## Which documentation and/or configurations were updated?



