### PR TITLE
[Refactor] Move state labels to i18n

### DIFF
--- a/app/components/works/state_display_component.rb
+++ b/app/components/works/state_display_component.rb
@@ -1,21 +1,9 @@
-# typed: strict
+# typed: false
 # frozen_string_literal: true
 
 module Works
   # Displays information about the current state of the deposit
   class StateDisplayComponent < ApplicationComponent
-    STATE_DISPLAY_LABELS = T.let(
-      {
-        'first_draft' => 'Draft - Not deposited',
-        'version_draft' => 'New version draft - Not deposited',
-        'pending_approval' => 'Pending approval - Not deposited',
-        'rejected' => 'Returned',
-        'depositing' => 'Deposit in progress <span class="fas fa-spinner fa-pulse"></span>'.html_safe,
-        'deposited' => 'Deposited'
-      }.freeze,
-      T::Hash[String, String]
-    )
-
     sig { params(work: Work).void }
     def initialize(work:)
       @work = work
@@ -26,7 +14,15 @@ module Works
 
     sig { returns(T.nilable(String)) }
     def call
-      STATE_DISPLAY_LABELS.fetch(work.state)
+      value = I18n.t(work.state, scope: 'work.state')
+      return value unless work.depositing?
+
+      safe_join([value, spinner], ' ')
+    end
+
+    sig { returns(String) }
+    def spinner
+      tag.span class: 'fas fa-spinner fa-pulse'
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,4 +16,12 @@ en:
     roles:
       person: Individual
       organization: Organization
+  work:
+    state:
+      first_draft: Draft - Not deposited
+      version_draft: New version draft - Not deposited
+      pending_approval: Pending approval - Not deposited
+      rejected: Returned
+      depositing: Deposit in progress
+      deposited: Deposited
   terms_of_use: User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -145,9 +145,9 @@ RSpec.describe 'Dashboard requests' do
     it 'shows statuses Pending Approval, Returned, First Draft' do
       get '/dashboard'
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include Works::StateDisplayComponent::STATE_DISPLAY_LABELS['pending_approval']
-      expect(response.body).to include Works::StateDisplayComponent::STATE_DISPLAY_LABELS['first_draft']
-      expect(response.body).to include Works::StateDisplayComponent::STATE_DISPLAY_LABELS['rejected']
+      expect(response.body).to include 'Pending approval - Not deposited'
+      expect(response.body).to include 'Draft - Not deposited'
+      expect(response.body).to include 'Returned'
     end
   end
 end


### PR DESCRIPTION


## Why was this change made?
This is consistent with how we are handling workflow events


## How was this change tested?



## Which documentation and/or configurations were updated?



