### PR TITLE
for collections with no title, render the default title in the deposits in progress

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -4,7 +4,7 @@
       <header>Deposits in progress</header>
       <% @presenter.drafts.each do |draft| %>
         <div>
-          <%= draft.collection.name %> &gt; <%= link_to Works::DetailComponent.new(work: draft).title, edit_work_path(draft) %>
+          <%= Dashboard::CollectionComponent.new(collection: draft.collection).name %> &gt; <%= link_to Works::DetailComponent.new(work: draft).title, edit_work_path(draft) %>
         </div>
       <% end %>
     </section>


### PR DESCRIPTION
## Why was this change made?

Small follow on for #641 ... one spot on the dashboard that will not show the name of a collection if it is in draft and blank ... this fixes it 

**Before:**

![Screen Shot 2020-12-03 at 11 20 35 AM](https://user-images.githubusercontent.com/47137/101077664-001a8980-355a-11eb-90e2-1608d6b70d99.png)

**After:**

![Screen Shot 2020-12-03 at 11 20 55 AM](https://user-images.githubusercontent.com/47137/101077719-11fc2c80-355a-11eb-9826-217eba3dc137.png)


## How was this change tested?

Browser


## Which documentation and/or configurations were updated?



