### PR TITLE
Send an email notification when the work is rejected

### DIFF
--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -73,7 +73,7 @@ module Works
 
     sig { returns(String) }
     def rejection_reason
-      work.events.reverse.find { |e| e.event_type == 'rejected' }.description
+      work.last_rejection_description
     end
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,6 +3,6 @@
 
 # Base class for all mailers in the application.
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'no-reply@sdr.stanford.edu'
   layout 'mailer'
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,0 +1,11 @@
+# typed: false
+# frozen_string_literal: true
+
+# Sends email notifications about works
+class NotificationMailer < ApplicationMailer
+  def reject_email
+    @user = params[:user]
+    @work = params[:work]
+    mail(to: @user.email, subject: 'Your deposit has been reviewed and returned')
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,4 +30,10 @@ class User < ApplicationRecord
   def sunetid
     email.delete_suffix('@stanford.edu')
   end
+
+  sig { returns(String) }
+  # TODO: replace when doing https://github.com/sul-dlss/happy-heron/issues/671
+  def name
+    '[preferred name in directory]'
+  end
 end

--- a/app/views/notification_mailer/reject_email.html.erb
+++ b/app/views/notification_mailer/reject_email.html.erb
@@ -1,0 +1,12 @@
+<p>Dear <%= @user.name %>,</p>
+
+<p>Your deposit, “<%= @work.title %>” to the <%= @work.collection_name %>
+  collection in the Stanford Digital Repository, has been returned to you with the following comments:</p>
+
+<p><%= @work.last_rejection_description %></p>
+
+<p>Click <%= link_to edit_work_url(@work), edit_work_url(@work) %> to revisit your deposit.</p>
+
+<p>If you have any questions, contact the SDR team at: <%= link_to contact_form_url, contact_form_url %></p>
+
+<p>The Stanford Digital Repository Team</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,7 @@ module HappyHeron
 
     # Mount the ActionCable server at a known path
     config.action_cable.mount_path = '/cable'
+
+    config.action_mailer.default_url_options = { host: Settings.host }
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,4 +51,7 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  # Use the test adapter as the queuing backend for ActiveJob
+  config.active_job.queue_adapter = :test
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
     end
   end
 
+  # TODO: fix in https://github.com/sul-dlss/happy-heron/issues/672
+  get 'contact_form', to: 'welcome#show'
   resource :help, only: :create
 
   # @note Only admins should be able to access the Sidekiq web UI.  But this is accomplished by Puppet

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -31,3 +31,5 @@ authorization_workgroup_names:
 file_uploads_root: tmp/uploads
 
 purl_url: https://purl.stanford.edu
+
+host: <%= (`echo $HOSTNAME`) %>

--- a/spec/factories/object_states.rb
+++ b/spec/factories/object_states.rb
@@ -20,5 +20,6 @@ FactoryBot.define do
 
   trait :rejected do
     state { 'rejected' }
+    events { [build(:event, event_type: 'rejected', description: 'Add something to make it pop.')] }
   end
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -1,0 +1,22 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NotificationMailer, type: :mailer do
+  describe 'reject_email' do
+    let(:user) { work.depositor }
+    let(:mail) { described_class.with(user: user, work: work).reject_email }
+    let(:work) { build_stubbed(:work, :rejected) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq 'Your deposit has been reviewed and returned'
+      expect(mail.to).to eq [work.depositor.email]
+      expect(mail.from).to eq ['no-reply@sdr.stanford.edu']
+    end
+
+    it 'renders the reason' do
+      expect(mail.body.encoded).to match('Add something to make it pop.')
+    end
+  end
+end

--- a/spec/mailers/previews/notification_mailer_preview.rb
+++ b/spec/mailers/previews/notification_mailer_preview.rb
@@ -1,0 +1,10 @@
+# typed: false
+# frozen_string_literal: true
+
+# Preview all emails at http://localhost:3000/rails/mailers/notification_mailer
+class NotificationMailerPreview < ActionMailer::Preview
+  def reject_email
+    work = Work.first
+    NotificationMailer.with(user: work.depositor, work: work).reject_email
+  end
+end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -284,6 +284,10 @@ RSpec.describe Work do
         expect { work.reject! }
           .to change(work, :state)
           .to('rejected')
+          .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
+                 'NotificationMailer', 'reject_email', 'deliver_now',
+                 { params: { user: work.depositor, work: work }, args: [] }
+               ))
         expect(WorkUpdatesChannel).to have_received(:broadcast_to)
           .with(work, state: 'Returned')
       end


### PR DESCRIPTION
## Why was this change made?
fixes #594


## How was this change tested?
Using mailer previews (e.g. http://localhost:3000/rails/mailers/notification_mailer/reject_email) and the test suite.

<img width="690" alt="Screen Shot 2020-12-04 at 9 36 35 AM" src="https://user-images.githubusercontent.com/92044/101182800-3583ad80-3614-11eb-8b49-475493d25f89.png">



## Which documentation and/or configurations were updated?



