### PR TITLE
Use Rubyish way to get hostname

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -32,4 +32,4 @@ file_uploads_root: tmp/uploads
 
 purl_url: https://purl.stanford.edu
 
-host: <%= (`echo $HOSTNAME`) %>
+host: <%= Socket.gethostname %>


### PR DESCRIPTION

## Why was this change made?

Instead of depending on an environment variable that may or may not be set.

## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None
