### PR TITLE
Deposit: clear stale server-side form validation errors after valid data is entered

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -7,7 +7,7 @@
                         data: { dropzone_target: 'input',
                                 edit_deposit_target: 'fileField',
                                 'progress-step': 'file',
-                                action: "change->progress#check error->files#error" } %>
+                                action: "change->progress#check change->files#clearErrors error->files#error" } %>
     <div class="dz-message needsclick text-secondary">
       <p>Drop files here</p>
     </div>

--- a/app/javascript/controllers/edit_deposit_controller.js
+++ b/app/javascript/controllers/edit_deposit_controller.js
@@ -31,6 +31,7 @@ export default class extends Controller {
     const [data, _status, xhr] = event.detail;
     switch (xhr.status) {
       case 400:
+        this.clearErrors()
         this.parseErrors(data)
         break
       default:
@@ -42,12 +43,27 @@ export default class extends Controller {
   parseErrors(data) {
     for (const [fieldName, errorList] of Object.entries(data)) {
       const key = `${fieldName}Field`
-      const target = this.targets.find(key)
-      if (target)
-        target.dispatchEvent(new CustomEvent('error', { detail: errorList }))
-      else
-        console.error(`unable to find target for ${key}`)
+      this.dispatchError(key, errorList)
     }
     window.scrollTo(0, 80)
+  }
+
+  clearErrors() {
+    const clearErrorsTargets = ["titleField", "fileField",
+                                "keywordsField", "contributorsField",
+                                "embargo-dateField"];
+
+    for (const key of clearErrorsTargets) {
+      this.dispatchError(key, [])
+    }
+  }
+
+  dispatchError(key, errorList) {
+    const target = this.targets.find(key)
+    if (target)
+      target.dispatchEvent(new CustomEvent('error', { detail: errorList }))
+    else
+      console.error(`unable to find target for ${key}`)
+
   }
 }

--- a/app/javascript/controllers/files_controller.js
+++ b/app/javascript/controllers/files_controller.js
@@ -5,7 +5,12 @@ export default class extends Controller  {
 
   // Triggered when edit-deposit controller sends an error event
   error(e) {
-    this.containerTarget.classList.add('is-invalid')
-    this.errorTarget.innerHTML = e.detail.join(' ')
+    if (e.detail === null || e.detail.length == 0) {
+      this.containerTarget.classList.remove('is-invalid')
+      this.errorTarget.innerHTML = ''
+    } else {
+      this.containerTarget.classList.add('is-invalid')
+      this.errorTarget.innerHTML = e.detail.join(' ')
+    }
   }
 }

--- a/app/javascript/controllers/files_controller.js
+++ b/app/javascript/controllers/files_controller.js
@@ -6,11 +6,19 @@ export default class extends Controller  {
   // Triggered when edit-deposit controller sends an error event
   error(e) {
     if (e.detail === null || e.detail.length == 0) {
-      this.containerTarget.classList.remove('is-invalid')
-      this.errorTarget.innerHTML = ''
+      this.clearErrors()
     } else {
-      this.containerTarget.classList.add('is-invalid')
-      this.errorTarget.innerHTML = e.detail.join(' ')
+      this.setErrors(e.detail)
     }
+  }
+
+  clearErrors() {
+    this.containerTarget.classList.remove('is-invalid')
+    this.errorTarget.innerHTML = ''
+  }
+
+  setErrors(detail) {
+    this.containerTarget.classList.add('is-invalid')
+    this.errorTarget.innerHTML = detail.join(' ')
   }
 }

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
   end
 
   context 'when successful deposit' do
-    let(:collection_attrs) { attributes_for(:collection) }
-
     it 'deposits and renders work show page' do
       visit dashboard_path
 
@@ -35,7 +33,7 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
       expect(page).to have_content 'Deposit your content'
 
       # Test client-side validation messages
-      fill_in 'Publication year', with: '2021'
+      fill_in 'Publication year', with: '2049'
       fill_in 'Created year', with: '999'
       click_button 'Deposit'
       expect(page).to have_content(
@@ -86,7 +84,6 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
       fill_in 'Abstract', with: 'Whatever'
       check 'Musical notation'
 
-      # fill_in 'Citation', with: 'Whatever'
       check 'I agree to the SDR Terms of Deposit'
 
       # Test remote form validation which only happens once client-side validation passes
@@ -125,7 +122,6 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
       expect(page).to have_content(user.email)
       expect(page).to have_content('sound')
       expect(page).to have_content('Course/instruction, Musical notation, Poetry reading')
-      expect(page).to have_content(user.email)
       expect(page).to have_content('Best Publisher')
       expect(page).to have_content('2020-03-06/2020-10-30')
       expect(page).to have_content('Whatever')


### PR DESCRIPTION
## Why was this change made?

fixes #560

## How was this change tested?

Manually on my laptop.  I was unable to get a feature test working for this, and jcoyne mentioned that writing one might be a pain and not worth the trouble, so i'm omitting it from this PR (but will write more detailed steps to reproduce on the ticket, should someone want to test, and i'm happy to also test on stage myself).  Though in trying to write that test, I found a couple seemingly easy touchups I could make to the test code i was using as a guide, and I left those changes in.

## Which documentation and/or configurations were updated?

n/a