### PR TITLE
remove blank <th> column for accessibility

### DIFF
--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -23,8 +23,7 @@
   <table class="table table-sm mb-5">
     <thead class="table-light">
     <tr>
-      <th scope="col" class="table-title col-3">Details</th>
-      <th scope="col"></th>
+      <th scope="col" colspan="2" class="table-title col-3">Details</th>
     </tr>
     </thead>
     <tbody>
@@ -93,8 +92,7 @@
   <table class="table table-sm mb-5">
     <thead class="table-light">
     <tr>
-      <th scope="col" class="table-title col-3">Title and contact<%= edit_link 'title', 'Edit title and contact' %></th>
-      <th scope="col"></th>
+      <th scope="col" colspan="2" class="table-title col-3">Title and contact<%= edit_link 'title', 'Edit title and contact' %></th>
     </tr>
     </thead>
     <tbody>
@@ -112,8 +110,7 @@
   <table class="table table-sm">
     <thead class="table-light">
     <tr>
-      <th scope="col" class="table-title col-3">Authors and contributors<%= edit_link 'author', 'Edit authors and contributors' %></th>
-      <th scope="col"></th>
+      <th scope="col" colspan="2" class="table-title col-3">Authors and contributors<%= edit_link 'author', 'Edit authors and contributors' %></th>
     </tr>
     </thead>
     <tbody>
@@ -133,8 +130,7 @@
   <table class="table table-sm mb-5">
     <thead class="table-light">
     <tr>
-      <th scope="col" class="table-title col-3">Dates<%= edit_link 'dates', 'Edit dates' %></th>
-      <th scope="col"></th>
+      <th scope="col" colspan="2" class="table-title col-3">Dates<%= edit_link 'dates', 'Edit dates' %></th>
     </tr>
     </thead>
     <tbody>
@@ -152,8 +148,7 @@
   <table class="table table-sm mb-5">
     <thead class="table-light">
     <tr>
-      <th scope="col" class="table-title col-3">Description<%= edit_link 'description', 'Edit description' %></th>
-      <th scope="col"></th>
+      <th scope="col" colspan="2" class="table-title col-3">Description<%= edit_link 'description', 'Edit description' %></th>
     </tr>
     </thead>
     <tbody>
@@ -195,8 +190,7 @@
   <table class="table table-sm mb-5">
     <thead class="table-light">
     <tr>
-      <th scope="col" class="table-title col-3">Release data and visibility<%= edit_link 'release', 'Edit release data and visibility' %></th>
-      <th scope="col"></th>
+      <th scope="col" colspan="2' class="table-title col-3">Release data and visibility<%= edit_link 'release', 'Edit release data and visibility' %></th>
     </tr>
     </thead>
     <tbody>
@@ -214,8 +208,7 @@
   <table class="table table-sm mb-5">
     <thead class="table-light">
     <tr>
-      <th scope="col" class="table-title col-3">Terms of use and license<%= edit_link 'license', 'Edit terms of use and license' %></th>
-      <th scope="col"></th>
+      <th scope="col" colspan="2" class="table-title col-3">Terms of use and license<%= edit_link 'license', 'Edit terms of use and license' %></th>
     </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
## Why was this change made?

Fix #668 (remove empty <th> column and just make first column span the table)


## How was this change tested?

Local browser


## Which documentation and/or configurations were updated?



