### PR TITLE
Add labels for the citation and the auto-citation fields

### DIFF
--- a/app/components/works/description_component.html.erb
+++ b/app/components/works/description_component.html.erb
@@ -25,7 +25,7 @@
     </div>
   </div>
 
-  <div class="mb-3 row">
+  <div class="mb-5 row">
     <% if other_type? %>
       <%= form.label :subtype, 'Other', class: 'col-sm-2 col-form-label' %>
       <div class="col-sm-10">
@@ -44,42 +44,43 @@
     <% end %>
   </div>
 
-  <div class="mb-3 row">
-    <%= form.label :citation, 'Citation for this deposit (optional)', class: 'h5' %>
-  </div>
-  <p>This is the text that others can use when they want to cite this deposit. We highly recommend that you provide the text of that citation here to make it easier for them to cite your work and give you proper credit.</p>
+  <fieldset class="mb-5">
+    <legend class='h5'>Citation for this deposit (optional)</legend>
 
-  <div class="mb-3 row">
-    <%= form.label :default_citation, 'Use default citation', class: "form-check-label col-sm-2" %>
+    <p>This is the text that others can use when they want to cite this deposit. We highly recommend that you provide the text of that citation here to make it easier for them to cite your work and give you proper credit.</p>
 
-    <div class="col-sm-3">
-      <div class="form-check form-switch">
-        <%= form.check_box :default_citation,
-              {
-                data: {
-                  action: 'change->auto-citation#switchChanged',
-                  auto_citation_target: 'switch'
+    <div class="mb-3 row">
+      <%= form.label :default_citation, 'Use default citation', class: "form-check-label col-sm-2" %>
+
+      <div class="col-sm-3">
+        <div class="form-check form-switch">
+          <%= form.check_box :default_citation,
+                {
+                  data: {
+                    action: 'change->auto-citation#switchChanged',
+                    auto_citation_target: 'switch'
+                  },
+                  class: 'form-check-input'
                 },
-                class: 'form-check-input'
-              },
-              'true', 'false' %>
+                'true', 'false' %>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="mb-3 row">
-    <div class='col-sm-2'></div>
-    <div class="col-sm-10">
-      <%= form.text_area :citation, class: "form-control",
-                         data: { auto_citation_target: 'manual' } %>
-      <%= form.text_area :citation_auto,
-                         class: "form-control", disabled: true,
-                         data: { auto_citation_target: 'auto' } %>
+    <div class="mb-3 row">
+      <div class='col-sm-2'></div>
+      <div class="col-sm-10">
+        <%= form.text_area :citation, class: "form-control",
+                           aria: { label: 'Provided citation' },
+                           data: { auto_citation_target: 'manual' } %>
+        <%= form.text_area :citation_auto,
+                           class: "form-control", disabled: true,
+                           aria: { label: 'Automatically generated citation' },
+                           data: { auto_citation_target: 'auto' } %>
+      </div>
     </div>
-  </div>
-  <div class="mb-5 row">
-    <div class="col-sm-10">
-    </div>
-  </div>
+  </fieldset>
+
+
   <%= render Works::RelatedWorkComponent.new(form: form) %>
 
   <%= render Works::RelatedLinkComponent.new(form: form) %>

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
       # End of remote form validation
 
       uncheck 'Use default citation'
-      fill_in 'Citation for this deposit (optional)', with: 'Whatever'
+      fill_in 'Provided citation', with: 'Whatever'
 
       click_link 'Terms of Deposit'
       expect(page).to have_content(


### PR DESCRIPTION
## Why was this change made?

Fixes #669

## How was this change tested?
Tested locally by using the Firefox accessability tool. There are no user visible changes aside from margins below the subtypes, which more closely resemble the mockups:

<img width="1253" alt="Screen Shot 2020-12-05 at 10 03 32 AM" src="https://user-images.githubusercontent.com/92044/101247838-36cedc00-36e1-11eb-8de7-e4dc87a061bc.png">


Before:

<img width="1262" alt="Screen Shot 2020-12-05 at 10 05 59 AM" src="https://user-images.githubusercontent.com/92044/101247884-844b4900-36e1-11eb-90bb-9da2fda74c18.png">


## Which documentation and/or configurations were updated?



