### PR TITLE
Label all checkboxes

### DIFF
--- a/app/components/works/description_component.html.erb
+++ b/app/components/works/description_component.html.erb
@@ -37,7 +37,7 @@
         <div class="col-sm-4">
           <div class="form-check">
             <%= form.check_box :subtype, { multiple: true, class: 'form-check-input' }, subtype, nil %>
-            <%= form.label "subtype_#{subtype.parameterize(separator: '_')}", subtype, class: 'form-check-label' %>
+            <%= form.label "subtype_#{sanitized_value(subtype)}", subtype, class: 'form-check-label' %>
           </div>
         </div>
       <% end %>

--- a/app/components/works/description_component.rb
+++ b/app/components/works/description_component.rb
@@ -21,5 +21,10 @@ module Works
     def other_type?
       work_type == 'other'
     end
+
+    def sanitized_value(value)
+      # This is how the rails check_box tag with multiple values creates its labels:
+      ActionView::Helpers::Tags::Base.new(nil, nil, nil).send(:sanitized_value, value)
+    end
   end
 end

--- a/spec/components/works/description_component_spec.rb
+++ b/spec/components/works/description_component_spec.rb
@@ -4,12 +4,18 @@
 require 'rails_helper'
 
 RSpec.describe Works::DescriptionComponent do
-  let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
-  let(:work) { build(:work) }
+  let(:form) { ActionView::Helpers::FormBuilder.new('work', work_form, controller.view_context, {}) }
+  let(:work) { build_stubbed(:work) }
   let(:work_form) { WorkForm.new(work) }
+  let(:rendered) { render_inline(described_class.new(form: form)) }
 
   it 'renders the component' do
     expect(render_inline(described_class.new(form: form)).to_html)
       .to include('Describe your deposit')
+  end
+
+  it 'has a checkbox with a label' do
+    expect(rendered.css('#work_subtype_journalperiodical')).to be_present
+    expect(rendered.css("label[for='work_subtype_journalperiodical']")).to be_present
   end
 end


### PR DESCRIPTION
## Why was this change made?

One of the labels did not have the proper id for the checkbox, resulting in an unlabeled input component; an accessability cocncern.

## How was this change tested?



## Which documentation and/or configurations were updated?



