### PR TITLE
Differentiate between test and dev database names

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,6 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  database: "<%= ENV.fetch('DATABASE_NAME', 'h2') %>"
   username: "<%= ENV.fetch('DATABASE_USERNAME', 'postgres') %>"
   password: "<%= ENV.fetch('DATABASE_PASSWORD', 'postgres') %>"
   host: "<%= ENV.fetch('DATABASE_HOSTNAME', 'localhost') %>"
@@ -11,9 +10,12 @@ default: &default
 
 development:
   <<: *default
+  database: "<%= ENV.fetch('DATABASE_NAME', 'h2_development') %>"
 
 test:
   <<: *default
+  database: "<%= ENV.fetch('DATABASE_NAME', 'h2_test') %>"
 
 production:
   <<: *default
+  database: "<%= ENV.fetch('DATABASE_NAME', 'h2_production') %>"


### PR DESCRIPTION
## Why was this change made?

This prevents Rails from warning the developer about using the same database for both dev and test, which most of us developers are straddling frequently. This **does not affect deployed environments** because the checked-in `config/database.yml` is overwritten with a file that is managed via Puppet. This is intended to remove drag on development.

## How was this change tested?

CI, locally

## Which documentation and/or configurations were updated?

See above.

