### PR TITLE
Update capybara to 3.34

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,10 +33,7 @@ end
 
 group :test do
   gem 'apparition'
-  # Pinned to git until 3.34.0 is released which disables smooth scrolling
-  # Using smooth scrolling is a feature of bootstrap 5.0.0-alpha3, which causes
-  # capybara to be unable to find elements below the fold.
-  gem 'capybara', github: 'teamcapybara/capybara'
+  gem 'capybara', '~> 3.34'
   gem 'capybara-screenshot'
   gem 'rspec-sorbet'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: https://github.com/teamcapybara/capybara.git
-  revision: 8510765c68913ccd3ce8e4d89cefe514ee187087
-  specs:
-    capybara (3.34.0)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (>= 1.5, < 3.0)
-      xpath (~> 3.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -113,6 +100,14 @@ GEM
       capistrano (~> 3.0)
       sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
+    capybara (3.34.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
     capybara-screenshot (1.0.25)
       capybara (>= 1.0, < 4)
       launchy
@@ -341,7 +336,7 @@ GEM
     reform-rails (0.2.1)
       activemodel (>= 5.0)
       reform (>= 2.3.1, < 3.0.0)
-    regexp_parser (2.0.0)
+    regexp_parser (1.8.2)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -508,7 +503,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-rvm
-  capybara!
+  capybara (~> 3.34)
   capybara-screenshot
   config (~> 2.2)
   devise (~> 4.7)


### PR DESCRIPTION
## Why was this change made?
So we use a released version.


## How was this change tested?



## Which documentation and/or configurations were updated?



