### PR TITLE
Update labels for version draft and pending approval states

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Lint/MissingSuper: # (new in 0.89)
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
-  ExcludedMethods:
+  IgnoredMethods:
     - state_machine
 
 Metrics/ClassLength:
@@ -112,6 +112,8 @@ Lint/ToEnumArguments: # (new in 1.1)
 Lint/TopLevelReturnWithArgument: # (new in 0.89)
   Enabled: true
 Lint/TrailingCommaInAttributeDeclaration: # (new in 0.90)
+  Enabled: true
+Lint/UnexpectedBlockArity: # (new in 1.5)
   Enabled: true
 Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
   Enabled: true

--- a/app/components/collections/form_component.html.erb
+++ b/app/components/collections/form_component.html.erb
@@ -117,11 +117,11 @@
 
     <!-- TODO: only display sunet entry field if reviewer workflow is enabled -->
     <p>Enter SUNet IDs of participants. Separate each one with a comma and a space. (e.g. janelath, lelandst)</p>
-    <div class="mb-3 row" data-controller="reviewer-sunets" data-action="error->reviewer-sunets#error" data-target="edit-collection.reviewerSunetsField">
+    <div class="mb-3 row" data-controller="reviewer-sunets" data-action="error->reviewer-sunets#error" data-edit-collection-target="reviewerSunetsField">
       <%= form.label :reviewer_sunets, 'Additional Reviewers', class: 'col-sm-2 col-form-label' %>
       <div class="col-sm-10 col-xl-8">
-        <%= form.text_field :reviewer_sunets, class: "form-control", required: false, data: { target: 'reviewer-sunets.container' } %> <!-- TODO: should prob have at least one required if enabled? -->
-        <div data-target="reviewer-sunets.error" class="invalid-feedback">You must provide reviewers</div>
+        <%= form.text_field :reviewer_sunets, class: "form-control", required: false, data: { reviewer_sunets_target: 'container' } %> <!-- TODO: should prob have at least one required if enabled? -->
+        <div data-reviewer-sunets-target="error" class="invalid-feedback">You must provide reviewers</div>
       </div>
     </div>
   </section>

--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -2,7 +2,7 @@
   <header>Add your files</header>
   <p>All file types are accepted. If you have a deposit that is over 10GB, or
     have any trouble with adding your files, contact us.</p>
-  <div class="dropzone dropzone-default" data-target="files.container">
+  <div class="dropzone dropzone-default" data-files-target="container">
     <%= form.file_field :files, multiple: true, direct_upload: true,
                         data: { dropzone_target: 'input',
                                 edit_deposit_target: 'fileField',
@@ -25,5 +25,4 @@
       <%= render Works::FileRowComponent.new(form: file_form) %>
     <% end %>
   </template>
-
 </section>

--- a/app/components/works/contributors_component.html.erb
+++ b/app/components/works/contributors_component.html.erb
@@ -2,7 +2,7 @@
   <header>List authors and contributors</header>
   <p>Enter the name(s) of people, organizations or events responsible for producing the deposit.</p>
 
-  <template data-target='nested-form.template'>
+  <template data-nested-form-target='template'>
     <%= form.fields_for :contributors, Contributor.new, child_index: 'TEMPLATE_RECORD' do |contributor_form| %>
       <%= render Works::ContributorRowComponent.new(form: contributor_form) %>
     <% end %>
@@ -12,8 +12,7 @@
     <%= render Works::ContributorRowComponent.new(form: contributor_form) %>
   <% end %>
 
-  <div data-target="nested-form.add_item">
+  <div data-nested-form-target="add_item">
     <%= button_tag '+ Add another author/contributor', type: 'button', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
   </div>
-
 </section>

--- a/app/components/works/embargo_component.html.erb
+++ b/app/components/works/embargo_component.html.erb
@@ -12,7 +12,7 @@
   </div>
 
   <div class="embargo-date" data-controller="embargo-date" data-action="error->embargo-date#error" data-edit-deposit-target="embargo-dateField">
-    <div class="mb-5 row" data-target="embargo-date.container">
+    <div class="mb-5 row" data-embargo-date-target="container">
       <div class="col-sm-10 release-option">
         <%= form.radio_button :release, 'embargo', class: 'form-check-input' %>
         <%= form.label :release_embargo, 'On this date' %>
@@ -33,7 +33,7 @@
         </div>
       </div>
     </div>
-    <div data-target="embargo-date.error" class="invalid-feedback"></div>
+    <div data-embargo-date-target="error" class="invalid-feedback"></div>
   </div>
 
   <p>Select which audience you would like to have access to download your files once they are available.</p>

--- a/app/components/works/related_link_component.html.erb
+++ b/app/components/works/related_link_component.html.erb
@@ -2,7 +2,7 @@
   <legend class="h5">Links to related content (optional)</legend>
 
   <div class="mb-3" data-controller="nested-form">
-    <template data-target='nested-form.template'>
+    <template data-nested-form-target='template'>
       <%= form.fields_for :related_links, RelatedLink.new, child_index: 'TEMPLATE_RECORD' do |link_form| %>
         <%= render Works::RelatedLinkRowComponent.new(form: link_form) %>
       <% end %>
@@ -12,7 +12,7 @@
       <%= render Works::RelatedLinkRowComponent.new(form: link_form) %>
     <% end %>
 
-    <div data-target="nested-form.add_item">
+    <div data-nested-form-target="add_item">
       <%= button_tag '+ Add another link', type: 'button', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
     </div>
   </div>

--- a/app/components/works/related_work_component.html.erb
+++ b/app/components/works/related_work_component.html.erb
@@ -2,7 +2,7 @@
   <legend class="h5">Related works (optional)</legend>
 
   <div class="mb-3" data-controller="nested-form">
-    <template data-target='nested-form.template'>
+    <template data-nested-form-target='template'>
       <%= form.fields_for :related_works, RelatedWork.new, child_index: 'TEMPLATE_RECORD' do |contributor_form| %>
         <%= render Works::RelatedWorkRowComponent.new(form: contributor_form) %>
       <% end %>
@@ -12,7 +12,7 @@
       <%= render Works::RelatedWorkRowComponent.new(form: contributor_form) %>
     <% end %>
 
-    <div data-target="nested-form.add_item">
+    <div data-nested-form-target="add_item">
       <%= button_tag '+ Add another related work', type: 'button', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,8 +19,8 @@ en:
   work:
     state:
       first_draft: Draft - Not deposited
-      version_draft: New version draft - Not deposited
-      pending_approval: Pending approval - Not deposited
+      version_draft: New version in draft
+      pending_approval: Pending approval
       rejected: Returned
       depositing: Deposit in progress
       deposited: Deposited

--- a/sorbet/rails-rbi/routes.rbi
+++ b/sorbet/rails-rbi/routes.rbi
@@ -112,13 +112,6 @@ module GeneratedUrlHelpers
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
   def collection_url(*args, **kwargs); end
 
-  # Sigs for route /contact_form(.:format)
-  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
-  def contact_form_path(*args, **kwargs); end
-
-  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
-  def contact_form_url(*args, **kwargs); end
-
   # Sigs for route /help(.:format)
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
   def help_path(*args, **kwargs); end

--- a/spec/features/mediated_deposit_spec.rb
+++ b/spec/features/mediated_deposit_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Create a work in a collection using mediated deposit', js: true 
       click_button 'Deposit'
 
       expect(page).to have_content(work_title)
-      expect(page).to have_content('Pending approval - Not deposited')
+      expect(page).to have_content('Pending approval')
 
       visit dashboard_path
       within_table('Approvals') do

--- a/spec/features/mediated_deposit_versioning_spec.rb
+++ b/spec/features/mediated_deposit_versioning_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Edit a new version of a work in a collection using mediated depo
       click_button 'Submit for approval'
 
       expect(page).to have_content(new_work_title)
-      expect(page).to have_content('Pending approval - Not deposited')
+      expect(page).to have_content('Pending approval')
 
       visit dashboard_path
       within_table('Approvals') do
@@ -47,7 +47,7 @@ RSpec.describe 'Edit a new version of a work in a collection using mediated depo
       click_button 'Submit for approval'
 
       expect(page).to have_content(newest_work_title)
-      expect(page).to have_content('Pending approval - Not deposited')
+      expect(page).to have_content('Pending approval')
 
       visit dashboard_path
       within_table('Approvals') do

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe Work do
           .from('deposited').to('version_draft')
           .and change(Event, :count).by(1)
         expect(WorkUpdatesChannel).to have_received(:broadcast_to)
-          .with(work, state: 'New version draft - Not deposited')
+          .with(work, state: 'New version in draft')
       end
     end
 
@@ -259,7 +259,7 @@ RSpec.describe Work do
             .to('pending_approval')
             .and change(Event, :count).by(1)
           expect(WorkUpdatesChannel).to have_received(:broadcast_to)
-            .with(work, state: 'Pending approval - Not deposited')
+            .with(work, state: 'Pending approval')
         end
       end
 
@@ -272,7 +272,7 @@ RSpec.describe Work do
             .to('pending_approval')
             .and change(Event, :count).by(1)
           expect(WorkUpdatesChannel).to have_received(:broadcast_to)
-            .with(work, state: 'Pending approval - Not deposited')
+            .with(work, state: 'Pending approval')
         end
       end
     end

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe 'Dashboard requests' do
     it 'shows statuses Pending Approval, Returned, First Draft' do
       get '/dashboard'
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include 'Pending approval - Not deposited'
+      expect(response.body).to include 'Pending approval'
       expect(response.body).to include 'Draft - Not deposited'
       expect(response.body).to include 'Returned'
     end


### PR DESCRIPTION
Fixes #707

## Why was this change made?

This changes the app to use labels approved by the P.O.

Also includes:
* Avoid deprecation warnings by using Stimulus 2-style data targets
* Avoid Rubocop warnings

## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None

