### PR TITLE
Refactor the help mailer to send in the background

### DIFF
--- a/app/controllers/helps_controller.rb
+++ b/app/controllers/helps_controller.rb
@@ -4,14 +4,12 @@
 # The endpoint for the help modal
 class HelpsController < ApplicationController
   def create
-    name = params[:name]
-    email = params[:email]
-    affiliation = params[:affiliation]
-    help_how = params[:help_how]
-    why_contact = params[:why_contact]
-    body = "#{name} #{affiliation}\n#{why_contact}"
-
-    HelpsMailer.new.send_jira(email, help_how, body)
+    HelpsMailer.with(name: params[:name],
+                     email: params[:email],
+                     affiliation: params[:affiliation],
+                     help_how: params[:help_how],
+                     why_contact: params[:why_contact])
+               .jira_email.deliver_later
     render json: { status: 'success' }
   end
 end

--- a/app/mailers/helps_mailer.rb
+++ b/app/mailers/helps_mailer.rb
@@ -3,11 +3,16 @@
 
 # The endpoint for the help modal
 class HelpsMailer < ApplicationMailer
-  def send_jira(email, subject, body)
-    message = mail(to: 'sdr-support@jirasul.stanford.edu',
-                   from: email,
-                   subject: subject,
-                   body: body)
-    message.deliver!
+  def jira_email
+    email = params[:email]
+    subject = params[:help_how]
+
+    @name = params[:name]
+    @affiliation = params[:affiliation]
+    @why_contact = params[:why_contact]
+
+    mail(to: 'sdr-support@jirasul.stanford.edu',
+         from: email,
+         subject: subject)
   end
 end

--- a/app/views/helps_mailer/jira_email.text.erb
+++ b/app/views/helps_mailer/jira_email.text.erb
@@ -1,0 +1,2 @@
+<%= @name %> <%= @affiliation %>
+<%= @why_contact %>

--- a/spec/mailers/helps_mailer_spec.rb
+++ b/spec/mailers/helps_mailer_spec.rb
@@ -1,0 +1,27 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HelpsMailer, type: :mailer do
+  describe 'jira_email' do
+    let(:mail) do
+      described_class.with(name: 'Barbara Seville',
+                           email: 'razor@haircuts.it',
+                           affiliation: 'Music School',
+                           help_how: 'who should marry Rosina?',
+                           why_contact: 'Don Basilio! – Cosa veggo!').jira_email
+    end
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq 'who should marry Rosina?'
+      expect(mail.to).to eq ['sdr-support@jirasul.stanford.edu']
+      expect(mail.from).to eq ['razor@haircuts.it']
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to include 'Barbara Seville Music School'
+      expect(mail.body.encoded).to include 'Don Basilio! – Cosa veggo!'
+    end
+  end
+end

--- a/spec/mailers/previews/helps_mailer_preview.rb
+++ b/spec/mailers/previews/helps_mailer_preview.rb
@@ -1,0 +1,13 @@
+# typed: false
+# frozen_string_literal: true
+
+# Preview all emails at http://localhost:3000/rails/mailers/notification_mailer
+class HelpsMailerPreview < ActionMailer::Preview
+  def jira_email
+    HelpsMailer.with(name: 'Barbara Seville',
+                     email: 'razor@haircuts.it',
+                     affiliation: 'Music School',
+                     help_how: 'who should marry Rosina?',
+                     why_contact: 'Don Basilio! – Cosa veggo!').jira_email
+  end
+end


### PR DESCRIPTION
## Why was this change made?

The HelpsMailer should be used in the idiomatic way, that is, by using deliver_later.

## How was this change tested?



## Which documentation and/or configurations were updated?



