### PR TITLE
Remove email domain from display of email usernames

### DIFF
--- a/app/components/collections/information_component.html.erb
+++ b/app/components/collections/information_component.html.erb
@@ -16,7 +16,7 @@
     </tr>
     <tr>
       <th>Created by</th>
-      <td><%= creator %></td>
+      <td><%= creator.sunetid %></td>
     </tr>
     <tr>
       <th>Collection created</th>

--- a/app/components/collections/participants_component.rb
+++ b/app/components/collections/participants_component.rb
@@ -14,12 +14,12 @@ module Collections
 
     sig { returns(T.nilable(String)) }
     def depositors
-      collection.depositors.pluck(:email).join(', ')
+      collection.depositors.map(&:sunetid).join(', ')
     end
 
     sig { returns(T.nilable(String)) }
     def managers
-      collection.managers.pluck(:email).join(', ')
+      collection.managers.map(&:sunetid).join(', ')
     end
   end
 end

--- a/app/components/collections/workflow_review_component.rb
+++ b/app/components/collections/workflow_review_component.rb
@@ -19,7 +19,7 @@ module Collections
 
     sig { returns(T.nilable(String)) }
     def reviewers
-      collection.reviewers.pluck(:email).join(', ')
+      collection.reviewers.map(&:sunetid).join(', ')
     end
   end
 end

--- a/sorbet/rails-rbi/models/collection.rbi
+++ b/sorbet/rails-rbi/models/collection.rbi
@@ -214,6 +214,15 @@ module Collection::GeneratedAssociationMethods
   sig { params(value: T::Enumerable[::User]).void }
   def managers=(value); end
 
+  sig { returns(::RelatedLink::ActiveRecord_Associations_CollectionProxy) }
+  def related_links; end
+
+  sig { returns(T::Array[Integer]) }
+  def related_link_ids; end
+
+  sig { params(value: T::Enumerable[::RelatedLink]).void }
+  def related_links=(value); end
+
   sig { returns(::User::ActiveRecord_Associations_CollectionProxy) }
   def reviewers; end
 

--- a/sorbet/rails-rbi/models/related_link.rbi
+++ b/sorbet/rails-rbi/models/related_link.rbi
@@ -35,6 +35,24 @@ module RelatedLink::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def link_title?; end
 
+  sig { returns(T.nilable(Integer)) }
+  def linkable_id; end
+
+  sig { params(value: T.nilable(T.any(Numeric, ActiveSupport::Duration))).void }
+  def linkable_id=(value); end
+
+  sig { returns(T::Boolean) }
+  def linkable_id?; end
+
+  sig { returns(T.nilable(String)) }
+  def linkable_type; end
+
+  sig { params(value: T.nilable(T.any(String, Symbol))).void }
+  def linkable_type=(value); end
+
+  sig { returns(T::Boolean) }
+  def linkable_type?; end
+
   sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
@@ -52,32 +70,23 @@ module RelatedLink::GeneratedAttributeMethods
 
   sig { returns(T::Boolean) }
   def url?; end
-
-  sig { returns(Integer) }
-  def work_id; end
-
-  sig { params(value: T.any(Numeric, ActiveSupport::Duration)).void }
-  def work_id=(value); end
-
-  sig { returns(T::Boolean) }
-  def work_id?; end
 end
 
 module RelatedLink::GeneratedAssociationMethods
-  sig { returns(::Work) }
-  def work; end
+  sig { returns(T.untyped) }
+  def linkable; end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: ::Work).void)).returns(::Work) }
-  def build_work(*args, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: T.untyped).void)).returns(T.untyped) }
+  def build_linkable(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: ::Work).void)).returns(::Work) }
-  def create_work(*args, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: T.untyped).void)).returns(T.untyped) }
+  def create_linkable(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: ::Work).void)).returns(::Work) }
-  def create_work!(*args, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: T.untyped).void)).returns(T.untyped) }
+  def create_linkable!(*args, &block); end
 
-  sig { params(value: ::Work).void }
-  def work=(value); end
+  sig { params(value: T.untyped).void }
+  def linkable=(value); end
 end
 
 module RelatedLink::CustomFinderMethods

--- a/spec/components/collections/information_component_spec.rb
+++ b/spec/components/collections/information_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Collections::InformationComponent, type: :component do
 
   context 'when displaying a collection' do
     let(:version) { collection.version.to_s }
-    let(:creator) { collection.creator.to_s }
+    let(:creator) { collection.creator.sunetid }
     let(:collection) { build_stubbed(:collection) }
 
     it 'renders the information component' do

--- a/spec/components/collections/participants_component_spec.rb
+++ b/spec/components/collections/participants_component_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Collections::ParticipantsComponent, type: :component do
   let(:rendered) { render_inline(described_class.new(collection: collection)) }
 
   context 'when displaying a collection' do
-    let(:depositors) { collection.depositors.pluck(:email).join(', ') }
-    let(:managers) { collection.managers.pluck(:email).join(', ') }
+    let(:depositors) { collection.depositors.map(&:sunetid).join(', ') }
+    let(:managers) { collection.managers.map(&:sunetid).join(', ') }
     let(:collection) { build_stubbed(:collection, :with_managers, :with_depositors) }
 
     it 'renders the participant component' do

--- a/spec/components/collections/workflow_review_component_spec.rb
+++ b/spec/components/collections/workflow_review_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Collections::WorkflowReviewComponent, type: :component do
   let(:rendered) { render_inline(described_class.new(collection: collection)) }
 
   context 'when displaying a collection' do
-    let(:reviewers) { collection.reviewers.pluck(:email).join(', ') }
+    let(:reviewers) { collection.reviewers.map(&:sunetid).join(', ') }
     let(:collection) { build_stubbed(:collection, :with_reviewers) }
 
     it 'renders the workflow review component' do

--- a/spec/requests/show_collection_spec.rb
+++ b/spec/requests/show_collection_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe 'Show the collection detail page' do
 
   context 'with an admin user' do
     let(:user) { create(:user) }
-    let(:depositors) { collection.depositors.pluck(:email).join(', ') }
-    let(:managers) { collection.managers.pluck(:email).join(', ') }
-    let(:reviewers) { collection2.reviewers.pluck(:email).join(', ') }
+    let(:depositors) { collection.depositors.map(&:sunetid).join(', ') }
+    let(:managers) { collection.managers.map(&:sunetid).join(', ') }
+    let(:reviewers) { collection2.reviewers.map(&:sunetid).join(', ') }
 
     before do
       sign_in user, groups: [Settings.authorization_workgroup_names.administrators]


### PR DESCRIPTION
## Why was this change made?

Fixes #692 

Before:

<img width="1496" alt="Screen Shot 2020-12-08 at 2 35 12 PM" src="https://user-images.githubusercontent.com/2294288/101549507-a8698d00-3962-11eb-96ce-1796db2c1ea8.png">

After:

<img width="1505" alt="Screen Shot 2020-12-08 at 2 35 28 PM" src="https://user-images.githubusercontent.com/2294288/101549514-ac95aa80-3962-11eb-8dd0-6b77b48bf21f.png">


## How was this change tested?

Updated unit and request tests

## Which documentation and/or configurations were updated?



