### PR TITLE
Update float classes for bootstrap 5

### DIFF
--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -1,7 +1,7 @@
 <div class="row inner-container" data-controller="contributors" data-action="error->contributors#error" data-edit-deposit-target="contributorsField">
   <div class="contributors-container col-md-12" data-contributors-target="container">
     <% if not_first_contributor? %>
-      <%= button_tag type: 'button', class: 'btn btn-sm float-right', aria: { label: 'Remove' },
+      <%= button_tag type: 'button', class: 'btn btn-sm float-end', aria: { label: 'Remove' },
                      data: { action: "click->nested-form#removeAssociation" } do %>
         <span class="far fa-trash-alt"></span>
       <% end %>

--- a/app/components/works/related_link_row_component.html.erb
+++ b/app/components/works/related_link_row_component.html.erb
@@ -8,7 +8,7 @@
     </div>
 
     <div class="col-md-1">
-      <%= button_tag type: 'button', class: 'btn btn-sm float-right', aria: { label: 'Remove' },
+      <%= button_tag type: 'button', class: 'btn btn-sm float-end', aria: { label: 'Remove' },
        data: { action: "click->nested-form#removeAssociation" } do %>
         <span class="far fa-trash-alt"></span>
       <% end %>

--- a/app/components/works/related_work_row_component.html.erb
+++ b/app/components/works/related_work_row_component.html.erb
@@ -8,7 +8,7 @@
     </div>
 
     <div class="col-md-1">
-      <%= button_tag type: 'button', class: 'btn btn-sm float-right', aria: { label: 'Remove' },
+      <%= button_tag type: 'button', class: 'btn btn-sm float-end', aria: { label: 'Remove' },
        data: { action: "click->nested-form#removeAssociation" } do %>
         <span class="far fa-trash-alt"></span>
       <% end %>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -15,7 +15,7 @@
     <section data-controller="work-type">
       <header>Your collections
         <% if allowed_to?(:create?, Collection) %>
-          <%= link_to '+ Create a new collection', new_collection_path, class: "btn btn-outline-primary float-right" %>
+          <%= link_to '+ Create a new collection', new_collection_path, class: "btn btn-outline-primary float-end" %>
         <% end %>
       </header>
       <% if @presenter.collections.present? %>


### PR DESCRIPTION
## Why was this change made?

Keeps the create a collection button floating to the right. Bootstrap changed the class name to be compliant with RTL languages.



## How was this change tested?

After
<img width="1156" alt="Screen Shot 2020-12-08 at 4 58 08 PM" src="https://user-images.githubusercontent.com/92044/101551440-98f43f00-3976-11eb-8c57-a8d928c46cb0.png">

Before
<img width="1168" alt="Screen Shot 2020-12-08 at 4 57 48 PM" src="https://user-images.githubusercontent.com/92044/101551442-998cd580-3976-11eb-84c8-801ec137050e.png">



## Which documentation and/or configurations were updated?



