### PR TITLE
Add the collection events to the show page

### DIFF
--- a/app/components/collections/history_component.html.erb
+++ b/app/components/collections/history_component.html.erb
@@ -1,0 +1,20 @@
+<table class="table table-sm mb-5" id="events">
+  <thead class="table-light">
+    <tr>
+      <th scope="col" class="table-title col-3">History</th>
+      <th scope="col"></th>
+      <th scope="col"></th>
+      <th scope="col"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% events.each do |event| %>
+      <tr>
+        <td><%= I18n.t event.event_type, scope: 'event.type' %></td>
+        <td><%= event.user.sunetid %></td>
+        <td><%= I18n.l(event.created_at, format: :abbr_month) %></td>
+        <td><%= event.description %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/components/collections/history_component.rb
+++ b/app/components/collections/history_component.rb
@@ -1,0 +1,17 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Collections
+  # Renders the history section of the collection (show page)
+  class HistoryComponent < ApplicationComponent
+    sig { params(collection: Collection).void }
+    def initialize(collection:)
+      @collection = collection
+    end
+
+    sig { returns(Collection) }
+    attr_reader :collection
+
+    delegate :events, to: :collection
+  end
+end

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -10,6 +10,7 @@
       <%= render Collections::TermsOfUseComponent.new(collection: @collection) %>
       <%= render Collections::ParticipantsComponent.new(collection: @collection) %>
       <%= render Collections::WorkflowReviewComponent.new(collection: @collection) %>
+      <%= render Collections::HistoryComponent.new(collection: @collection) %>
     </section>
   </div>
 </main>

--- a/sorbet/rails-rbi/mailers/notification_mailer.rbi
+++ b/sorbet/rails-rbi/mailers/notification_mailer.rbi
@@ -3,5 +3,11 @@
 # Please rerun bundle exec rake rails_rbi:mailers to regenerate.
 class NotificationMailer
   sig { returns(ActionMailer::MessageDelivery) }
+  def self.approved_email; end
+
+  sig { returns(ActionMailer::MessageDelivery) }
   def self.reject_email; end
+
+  sig { returns(ActionMailer::MessageDelivery) }
+  def self.submitted_for_review_email; end
 end

--- a/sorbet/rails-rbi/models/collection.rbi
+++ b/sorbet/rails-rbi/models/collection.rbi
@@ -214,6 +214,15 @@ module Collection::GeneratedAssociationMethods
   sig { params(value: T::Enumerable[::User]).void }
   def managers=(value); end
 
+  sig { returns(::RelatedLink::ActiveRecord_Associations_CollectionProxy) }
+  def related_links; end
+
+  sig { returns(T::Array[Integer]) }
+  def related_link_ids; end
+
+  sig { params(value: T::Enumerable[::RelatedLink]).void }
+  def related_links=(value); end
+
   sig { returns(::User::ActiveRecord_Associations_CollectionProxy) }
   def reviewers; end
 

--- a/sorbet/rails-rbi/models/related_link.rbi
+++ b/sorbet/rails-rbi/models/related_link.rbi
@@ -35,6 +35,24 @@ module RelatedLink::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def link_title?; end
 
+  sig { returns(T.nilable(Integer)) }
+  def linkable_id; end
+
+  sig { params(value: T.nilable(T.any(Numeric, ActiveSupport::Duration))).void }
+  def linkable_id=(value); end
+
+  sig { returns(T::Boolean) }
+  def linkable_id?; end
+
+  sig { returns(T.nilable(String)) }
+  def linkable_type; end
+
+  sig { params(value: T.nilable(T.any(String, Symbol))).void }
+  def linkable_type=(value); end
+
+  sig { returns(T::Boolean) }
+  def linkable_type?; end
+
   sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 
@@ -52,32 +70,23 @@ module RelatedLink::GeneratedAttributeMethods
 
   sig { returns(T::Boolean) }
   def url?; end
-
-  sig { returns(Integer) }
-  def work_id; end
-
-  sig { params(value: T.any(Numeric, ActiveSupport::Duration)).void }
-  def work_id=(value); end
-
-  sig { returns(T::Boolean) }
-  def work_id?; end
 end
 
 module RelatedLink::GeneratedAssociationMethods
-  sig { returns(::Work) }
-  def work; end
+  sig { returns(T.untyped) }
+  def linkable; end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: ::Work).void)).returns(::Work) }
-  def build_work(*args, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: T.untyped).void)).returns(T.untyped) }
+  def build_linkable(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: ::Work).void)).returns(::Work) }
-  def create_work(*args, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: T.untyped).void)).returns(T.untyped) }
+  def create_linkable(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: ::Work).void)).returns(::Work) }
-  def create_work!(*args, &block); end
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: T.untyped).void)).returns(T.untyped) }
+  def create_linkable!(*args, &block); end
 
-  sig { params(value: ::Work).void }
-  def work=(value); end
+  sig { params(value: T.untyped).void }
+  def linkable=(value); end
 end
 
 module RelatedLink::CustomFinderMethods

--- a/spec/components/collections/history_component_spec.rb
+++ b/spec/components/collections/history_component_spec.rb
@@ -1,0 +1,16 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Collections::HistoryComponent, type: :component do
+  let(:rendered) { render_inline(described_class.new(collection: collection)) }
+
+  context 'when viewing a collection' do
+    let(:collection) { build_stubbed(:collection) }
+
+    it 'renders the history component' do
+      expect(rendered.css('table').to_html).to include('History')
+    end
+  end
+end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -47,4 +47,12 @@ FactoryBot.define do
 
     depositors { build_list(:user, depositor_count) }
   end
+
+  trait :with_events do
+    transient do
+      event_count { 3 }
+    end
+
+    events { build_list(:event, event_count) }
+  end
 end

--- a/spec/requests/show_collection_spec.rb
+++ b/spec/requests/show_collection_spec.rb
@@ -4,7 +4,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Show the collection detail page' do
-  let(:collection) { create(:collection, :with_managers, :with_depositors) }
+  let(:collection) { create(:collection, :with_managers, :with_depositors, :with_events) }
   let(:collection2) { create(:collection, :with_reviewers) }
 
   context 'with an admin user' do
@@ -24,6 +24,8 @@ RSpec.describe 'Show the collection detail page' do
       expect(response.body).to include depositors
       expect(response.body).to include managers
       expect(response.body).to include 'Off'
+      expect(response.body).to include 'History'
+      expect(response.body).to include(/Updated by user/).exactly(3).times # verifies event history is rendered
     end
 
     it 'displays the collection detail page with reviews enabled' do


### PR DESCRIPTION
## Why was this change made?

Fixes #700 
Adds the history table:

<img width="1488" alt="Screen Shot 2020-12-08 at 3 10 43 PM" src="https://user-images.githubusercontent.com/2294288/101552357-93432d00-3967-11eb-838c-413b321f1d66.png">


## How was this change tested?

Unit.

## Which documentation and/or configurations were updated?



