### PR TITLE
Use remote forms consistently across app

### DIFF
--- a/app/components/collections/form_component.html.erb
+++ b/app/components/collections/form_component.html.erb
@@ -1,5 +1,5 @@
 <header>All fields are required, unless otherwise noted.</header>
-<%= form_with model: collection_form,
+<%= form_with model: collection_form, remote: true,
     data: {
       controller: 'edit-collection',
       action: 'ajax:error->edit-collection#displayErrors'

--- a/app/components/dashboard/collection_component.html.erb
+++ b/app/components/dashboard/collection_component.html.erb
@@ -1,14 +1,13 @@
 <section>
-  <header><%= link_to name, collection %>
-    <% if allowed_to?(:edit?, collection) %>
-      <%= link_to edit_collection_path(collection), aria: { label: "Edit #{name}"} do %>
-        <span class="fas fa-pencil-alt"></span>
-      <% end %>
-    <% end %>
-    <%= render Collections::DeleteComponent.new(collection: collection) %>
-  </header>
-
   <table class="table">
+    <caption><%= link_to name, collection %>
+      <% if allowed_to?(:edit?, collection) %>
+        <%= link_to edit_collection_path(collection), aria: { label: "Edit #{name}"} do %>
+          <span class="fas fa-pencil-alt"></span>
+        <% end %>
+      <% end %>
+      <%= render Collections::DeleteComponent.new(collection: collection) %>
+    </caption>
     <thead class="table-light">
       <tr>
         <th>Deposits in collection</th>

--- a/app/components/help/form_component.html.erb
+++ b/app/components/help/form_component.html.erb
@@ -7,7 +7,7 @@
       </div>
       <div class="modal-body" data-controller="help">
         <%= form_with(url: help_path,
-                      method: 'post',
+                      remote: true,
                       data: {
                         help_target: 'form',
                         action: 'ajax:success->help#displaySuccess'

--- a/app/components/works/approval_component.html.erb
+++ b/app/components/works/approval_component.html.erb
@@ -1,5 +1,5 @@
 <section class="approve mb-4" data-controller="approval">
-  <%= form_for work, url: work_review_path(work), method: :post, html: { class: "details" } do %>
+  <%= form_with url: work_review_path(work), remote: true, html: { class: "details" } do %>
     <header class="mb-3">Review all details below, then approve or return this deposit</header>
     <div class="row mb-4">
       <div class="col-md-2"></div>

--- a/app/components/works/work_form_component.html.erb
+++ b/app/components/works/work_form_component.html.erb
@@ -1,6 +1,6 @@
 <div id="editor">
   <h1 class="row"><%= page_title %></h1>
-  <%= form_with model: work_form, url: url,
+  <%= form_with model: work_form, url: url, remote: true,
       data: {
         controller: 'edit-deposit auto-citation',
         action: 'ajax:error->edit-deposit#displayErrors',

--- a/spec/features/mediated_deposit_versioning_spec.rb
+++ b/spec/features/mediated_deposit_versioning_spec.rb
@@ -57,8 +57,10 @@ RSpec.describe 'Edit a new version of a work in a collection using mediated depo
       find('label', text: 'Approve and deposit').click
       click_button 'Submit'
 
-      expect(page).to have_link(newest_work_title)
-      click_link(newest_work_title)
+      within_table(collection.name) do
+        expect(page).to have_link(newest_work_title)
+        click_link(newest_work_title)
+      end
       expect(page).to have_content('Deposit in progress')
     end
   end


### PR DESCRIPTION

## Why was this change made?

Consistency is good. In doing this work, I replaced a single usage of `form_for` with `form_with` so the app does not use a mix of local and remote forms, and removed the model argument to this call which is/was unused. This commit also explicitly marks all of our forms as remote forms for future-proofing, as we know an upcoming Rails 6.1 change will make `form_with` default back to local forms.

I found that the mediated deposit versioning spec was flappy locally because there can be two links on the page with the work title, so I changed the spec to look for the link only in the scope of the collection name (the deposits in progress section). To do this, I moved the collection name from a section header to a table caption. I do not notice any UI difference with this change.


## How was this change tested?

CI, local browser testing

## Which documentation and/or configurations were updated?

None

