### PR TITLE
Refactor how dashboard collection component determines how many works to show

### DIFF
--- a/app/components/dashboard/collection_component.html.erb
+++ b/app/components/dashboard/collection_component.html.erb
@@ -19,7 +19,7 @@
       </tr>
     </thead>
     <tbody>
-      <% deposits.take(4).each do |work| %>
+      <% visible_deposits.each do |work| %>
         <tr>
           <td class="work-title"><%= link_to Works::DetailComponent.new(work: work).title, work %></td>
           <td>
@@ -40,7 +40,7 @@
     </tbody>
   </table>
 
-  <% if deposits.size == 5 %>
+  <% if total_deposits_count > MAX_DEPOSITS_TO_SHOW %>
     <div class="mb-3"><%= link_to 'See all deposits', collection_works_path(collection) %></div>
   <% end %>
 

--- a/app/components/dashboard/collection_component.rb
+++ b/app/components/dashboard/collection_component.rb
@@ -4,6 +4,8 @@
 module Dashboard
   # Renders a collection and a summary table of works in the collection
   class CollectionComponent < ApplicationComponent
+    MAX_DEPOSITS_TO_SHOW = 4
+
     sig { params(collection: Collection).void }
     def initialize(collection:)
       @collection = collection
@@ -19,9 +21,20 @@ module Dashboard
     end
 
     sig { returns(ActiveRecord::Relation) }
-    def deposits
-      policy = WorkPolicy.new(user: current_user, user_with_groups: user_with_groups)
-      policy.authorized_scope(collection.works.limit(5), as: :edits)
+    def visible_deposits
+      policy.authorized_scope(collection.works.limit(MAX_DEPOSITS_TO_SHOW), as: :edits)
+    end
+
+    sig { returns(Integer) }
+    def total_deposits_count
+      policy.authorized_scope(collection.works, as: :edits).count
+    end
+
+    private
+
+    sig { returns(WorkPolicy) }
+    def policy
+      WorkPolicy.new(user: current_user, user_with_groups: user_with_groups)
     end
   end
 end


### PR DESCRIPTION

## Why was this change made?

This disentangles the relation that is used to display works and the one that is used to determine whether to render a link to view more works, and gives more names to things vs. relying on integers (primitive obsession).


## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None

