### PR TITLE
Set the cocina content type to object if user selected text

### DIFF
--- a/app/models/work_type.rb
+++ b/app/models/work_type.rb
@@ -141,7 +141,7 @@ class WorkType
   def self.all
     [
       new(id: 'text', label: 'Text', icon: 'book-open', subtypes: TEXT_TYPES,
-          cocina_type: Cocina::Models::Vocab.document),
+          cocina_type: Cocina::Models::Vocab.object),
       new(id: 'data', label: 'Data', icon: 'chart-bar', subtypes: DATA_TYPES,
           cocina_type: Cocina::Models::Vocab.object),
       new(id: 'software, multimedia', label: 'Software or Code', icon: 'mouse', subtypes: SOFTWARE_TYPES,

--- a/spec/services/request_generator_spec.rb
+++ b/spec/services/request_generator_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe RequestGenerator do
       end
       let(:expected_model) do
         {
-          type: 'http://cocina.sul.stanford.edu/models/document.jsonld',
+          type: 'http://cocina.sul.stanford.edu/models/object.jsonld',
           label: 'Test title',
           version: 0,
           access: { access: 'world', download: 'world' },
@@ -115,7 +115,7 @@ RSpec.describe RequestGenerator do
       let(:expected_model) do
         {
           externalIdentifier: 'druid:bk123gh4567',
-          type: 'http://cocina.sul.stanford.edu/models/document.jsonld',
+          type: 'http://cocina.sul.stanford.edu/models/object.jsonld',
           label: 'Test title',
           version: 0,
           access: { access: 'world', download: 'world' },
@@ -191,7 +191,7 @@ RSpec.describe RequestGenerator do
       end
       let(:expected_model) do
         {
-          type: 'http://cocina.sul.stanford.edu/models/document.jsonld',
+          type: 'http://cocina.sul.stanford.edu/models/object.jsonld',
           label: 'Test title',
           version: 1,
           access: { access: 'world', download: 'world' },
@@ -271,7 +271,7 @@ RSpec.describe RequestGenerator do
       end
       let(:expected_model) do
         {
-          type: 'http://cocina.sul.stanford.edu/models/document.jsonld',
+          type: 'http://cocina.sul.stanford.edu/models/object.jsonld',
           label: 'Test title',
           version: 1,
           externalIdentifier: 'druid:bk123gh4567',


### PR DESCRIPTION


## Why was this change made?
Andrew says the "document" option will only work if they upload a single PDF.


## How was this change tested?



## Which documentation and/or configurations were updated?



