### PR TITLE
Set the mail asset host

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,6 +69,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "happy_heron_production"
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.asset_host = "https://#{Settings.host}"
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION

## Why was this change made?
So that images link back to our server and aren't relative
Fixes #729 


## How was this change tested?

Tested on QA

## Which documentation and/or configurations were updated?



