### PR TITLE
Prevent no route matches {} error

### DIFF
--- a/app/jobs/deposit_status_job.rb
+++ b/app/jobs/deposit_status_job.rb
@@ -22,6 +22,11 @@ class DepositStatusJob < BaseDepositJob
   def complete_deposit(object, druid)
     object.druid = druid
     object.add_purl_to_citation if object.respond_to?(:add_purl_to_citation)
+    # Force a save because state_machine-activerecord wraps its update in a transaction.
+    # The transaction includes the after_transition callbacks, which may enqueue mailer jobs.
+    # It's possible the mailer job is started before the transaction in the main thread is completed,
+    # which means the mailer may not have access to the druid.
+    object.save!
     object.deposit_complete!
   end
 


### PR DESCRIPTION
I'm pretty sure this occurs because state-machine has a transaction that doesn't complete until all the after hooks run, so it's possible a job is picking up the email before the work is saved.

## Why was this change made?


Fixes #734
Fixes #744
Fixes #746
Fixes #751


## How was this change tested?



## Which documentation and/or configurations were updated?



