### PR TITLE
Send a mail when deposit access is revoked

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -29,8 +29,6 @@ class CollectionsController < ObjectsController
 
     @form = collection_form(collection)
     if @form.validate(collection_params) && @form.save
-      # for the first time creation of a collection, send notifications to all depositors
-      send_depositor_notifications(collection, collection.depositors)
       after_save(collection)
     else
       # Send form errors to client in JSON format to be parsed and rendered there
@@ -45,9 +43,7 @@ class CollectionsController < ObjectsController
     @form = collection_form(collection)
     if @form.validate(collection_params) && @form.save
       collection.update_metadata!
-      # for an update of an existing collection, we will send notifications to only newly added depositors
-      send_depositor_notifications(collection, collection.depositors - previous_depositors)
-      after_save(collection)
+      after_save(collection, context: { new_depositors: collection.depositors - previous_depositors })
     else
       # Send form errors to client in JSON format to be parsed and rendered there
       render 'errors', status: :bad_request
@@ -70,29 +66,15 @@ class CollectionsController < ObjectsController
 
   private
 
-  sig { params(collection: Collection).void }
-  def after_save(collection)
-    collection.event_context = { user: current_user }
+  sig { params(collection: Collection, context: Hash).void }
+  def after_save(collection, context: {})
+    collection.event_context = context.merge(user: current_user)
     if deposit_button_pushed?
       collection.begin_deposit!
       redirect_to dashboard_path
     else
       collection.update_metadata!
       redirect_to collection_path(collection)
-    end
-  end
-
-  def send_depositor_notifications(collection, depositors)
-    # we only send notifications if we press submit deposit
-    # (i.e. not saving as a draft) OR if this >v1 of the collection
-    # this allows us to save/update drafts of a brand new collection *without* sending notifications
-    # until the user deposits for the first time, and also allows us to send notifications for
-    # newly added depositors on *any* save (draft or deposit) of future versions
-    return unless deposit_button_pushed? || collection.version_draft?
-
-    depositors.each do |depositor|
-      CollectionsMailer.with(collection: collection, user: depositor)
-                       .invitation_to_deposit_email.deliver_later
     end
   end
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -47,9 +47,6 @@ class WorksController < ObjectsController
 
     @form = work_form(work)
     if @form.validate(work_params) && @form.save
-      work.event_context = { user: current_user }
-      work.update_metadata!
-
       after_save(work)
     else
       # Send form errors to client in JSON format to be parsed and rendered there
@@ -97,6 +94,8 @@ class WorksController < ObjectsController
 
   sig { params(work: Work).void }
   def after_save(work)
+    work.event_context = { user: current_user }
+    work.update_metadata!
     if deposit_button_pushed?
       if work.collection.review_enabled?
         work.submit_for_review!

--- a/app/mailers/collections_mailer.rb
+++ b/app/mailers/collections_mailer.rb
@@ -8,4 +8,11 @@ class CollectionsMailer < ApplicationMailer
     @collection = params[:collection]
     mail(to: @user.email, subject: "Invitation to deposit to the #{@collection.name} collection in the SDR")
   end
+
+  def deposit_access_removed_email
+    @user = params[:user]
+    @collection = params[:collection]
+    mail(to: @user.email, subject: "Your Depositor permissions for the #{@collection.name} " \
+      'collection in the SDR have been removed')
+  end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -34,11 +34,29 @@ class Collection < ApplicationRecord
 
   state_machine initial: :first_draft do
     before_transition do |collection, transition|
-      collection.events.build(collection.event_context.merge(event_type: transition.event))
+      # filters out bits of the context that don't go into the event, e.g.: :new_depositor
+      event_params = collection.event_context.slice(:user)
+      collection.events.build(event_params.merge(event_type: transition.event))
     end
 
-    after_transition on: :begin_deposit do |collection, _transition|
+    after_transition on: :begin_deposit do |collection, transition|
+      if transition.from == 'first_draft'
+        collection.depositors.each do |depositor|
+          CollectionsMailer.with(collection: collection, user: depositor)
+                           .invitation_to_deposit_email.deliver_later
+        end
+      end
       DepositCollectionJob.perform_later(collection)
+    end
+
+    after_transition on: :update_metadata do |collection, transition|
+      if transition.to == 'version_draft'
+        new_depositors = collection.event_context.fetch(:new_depositors)
+        new_depositors.each do |depositor|
+          CollectionsMailer.with(collection: collection, user: depositor)
+                           .invitation_to_deposit_email.deliver_later
+        end
+      end
     end
 
     after_transition do |collection, transition|

--- a/app/views/collections_mailer/deposit_access_removed_email.html.erb
+++ b/app/views/collections_mailer/deposit_access_removed_email.html.erb
@@ -1,0 +1,16 @@
+<p>Dear <%= @user.name %>,</p>
+
+<p>A Manager of the <%= @collection.name %> collection has updated the permissions
+   for this collection and removed you as a Depositor. You no longer have permission
+   to deposit to this collection. Please contact the collection Managers below
+   if you have questions about this change.</p>
+
+<p>Collection Managers:<br>
+  <% @collection.managers.each do |manager| %>
+    <%= manager.email %><br>
+  <% end %>
+</p>
+
+<p>If you have any questions, contact the SDR team at: <%= link_to contact_form_url, contact_form_url %></p>
+
+<p>The Stanford Digital Repository Team</p>

--- a/spec/mailers/collections_mailer_spec.rb
+++ b/spec/mailers/collections_mailer_spec.rb
@@ -4,19 +4,36 @@
 require 'rails_helper'
 
 RSpec.describe CollectionsMailer, type: :mailer do
-  describe 'invitation_to_deposit_email' do
+  describe '#invitation_to_deposit_email' do
     let(:user) { collection.depositors.first }
     let(:mail) { described_class.with(user: user, collection: collection).invitation_to_deposit_email }
     let(:collection) { create(:collection, :with_depositors) }
 
     it 'renders the headers' do
       expect(mail.subject).to eq "Invitation to deposit to the #{collection.name} collection in the SDR"
-      expect(mail.to).to eq [collection.depositors.first.email]
+      expect(mail.to).to eq [user.email]
       expect(mail.from).to eq ['no-reply@sdr.stanford.edu']
     end
 
     it 'renders the body' do
       expect(mail.body.encoded).to match("You have been invited to deposit to the #{collection.name} collection")
+    end
+  end
+
+  describe '#deposit_access_removed_email' do
+    let(:user) { build(:user) }
+    let(:mail) { described_class.with(user: user, collection: collection).deposit_access_removed_email }
+    let(:collection) { build(:collection) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq "Your Depositor permissions for the #{collection.name} " \
+        'collection in the SDR have been removed'
+      expect(mail.to).to eq [user.email]
+      expect(mail.from).to eq ['no-reply@sdr.stanford.edu']
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to match("A Manager of the #{collection.name} collection has updated the permissions")
     end
   end
 end

--- a/spec/mailers/previews/collections_mailer_preview.rb
+++ b/spec/mailers/previews/collections_mailer_preview.rb
@@ -4,8 +4,12 @@
 # Preview all emails at http://localhost:3000/rails/mailers
 # Preview these emails at http://localhost:3000/rails/mailers/collections_mailer
 class CollectionsMailerPreview < ActionMailer::Preview
-  def invitation_to_deposit_email
+  delegate :invitation_to_deposit_email, :deposit_access_removed_email, to: :mailer_with_collection
+
+  private
+
+  def mailer_with_collection
     collection = Collection.first
-    CollectionsMailer.with(user: collection.creator, collection: collection).invitation_to_deposit_email
+    CollectionsMailer.with(user: collection.creator, collection: collection)
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe Collection do
     describe 'an update_metadata event' do
       let(:collection) { create(:collection, :deposited) }
 
+      before do
+        collection.event_context = { user: collection.creator, new_depositors: [] }
+      end
+
       it 'transitions to version draft' do
         expect { collection.update_metadata! }
           .to change(collection, :state)

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Collection do
       let(:collection) { create(:collection, :deposited) }
 
       before do
-        collection.event_context = { user: collection.creator, new_depositors: [] }
+        collection.event_context = { user: collection.creator, added_depositors: [], removed_depositors: [] }
       end
 
       it 'transitions to version draft' do


### PR DESCRIPTION
## Why was this change made?

For consistency with where other mails are sent from.

## How was this change tested?
Test suite.


## Which documentation and/or configurations were updated?



