### PR TITLE
update dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    action_policy (0.5.3)
+    action_policy (0.5.4)
       ruby-next-core (>= 0.10.3)
     actioncable (6.0.3.4)
       actionpack (= 6.0.3.4)
@@ -112,6 +112,7 @@ GEM
       capybara (>= 1.0, < 4)
       launchy
     chronic (0.10.2)
+    cocina-models (0.44.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -119,13 +120,12 @@ GEM
       openapi_parser
       thor
       zeitwerk (~> 2.1)
-    cocina-models (0.44.0)
     commander (4.5.2)
       highline (~> 2.0.0)
     commonmarker (0.21.0)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.7)
-    config (2.2.1)
+    config (2.2.3)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
     connection_pool (2.2.3)
@@ -372,7 +372,7 @@ GEM
     rspec-support (3.10.0)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.5.2)
+    rubocop (1.6.1)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
@@ -386,10 +386,10 @@ GEM
     rubocop-performance (1.9.1)
       rubocop (>= 0.90.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rails (2.8.1)
+    rubocop-rails (2.9.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
-      rubocop (>= 0.87.0)
+      rubocop (>= 0.90.0, < 2.0)
     rubocop-rspec (2.0.1)
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
@@ -431,7 +431,7 @@ GEM
       parser (>= 2.7)
       sorbet-coerce (>= 0.2.6)
       sorbet-runtime (>= 0.5)
-    sorbet-runtime (0.5.6134)
+    sorbet-runtime (0.5.6145)
     sorbet-static (0.5.5981-universal-darwin-14)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
@@ -471,7 +471,7 @@ GEM
       thread_safe (~> 0.1)
     uber (0.1.0)
     unicode-display_width (1.7.0)
-    view_component (2.22.1)
+    view_component (2.23.1)
       activesupport (>= 5.0.0, < 7.0)
     warden (1.2.9)
       rack (>= 2.0.9)


### PR DESCRIPTION
## Why was this change made?
Fixes (probably a bad rebase?):
```
00:39 bundler:install
      01 /usr/local/rvm/bin/rvm default do bundle install --jobs 4 --quiet
      01 Downloading cocina-models-0.44.0 revealed dependencies not in the API or the
      01 lockfile (activesupport (>= 0), dry-struct (~> 1.0), dry-types (~> 1.1),
      01 openapi3_parser (>= 0), openapi_parser (>= 0), thor (>= 0), zeitwerk (~> 2.1)).
      01 Either installing with `--full-index` or running `bundle update cocina-models`
      01 should fix the problem.
```

## How was this change tested?



## Which documentation and/or configurations were updated?



