### PR TITLE
remove merge conflict markers and guess at which part to keep

### DIFF
--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -29,11 +29,7 @@
     <tbody>
       <tr>
         <th scope="row">Persistent link</th>
-<<<<<<< HEAD
-        <td data-work-updates-target="purl">
-=======
         <td data-state-updates-target="purl">
->>>>>>> Update collection state using actioncable
           <% if purl %>
             <%= link_to purl, purl %>
           <% else %>


### PR DESCRIPTION
## Why was this change made?

remove what appear to be stray/leftover conflict markers from a rebase git couldn't merge automatically.

reported by @amyehodge on slack:
<img width="1361" alt="Screen Shot 2020-12-11 at 3 59 42 PM" src="https://user-images.githubusercontent.com/7741604/101965646-47dc8900-3bca-11eb-953f-0273bd4446b0.png">


## How was this change tested?

unit tests, manual testing of the page locally.

before:
<img width="1344" alt="Screen Shot 2020-12-11 at 4 34 42 PM" src="https://user-images.githubusercontent.com/7741604/101967008-deab4480-3bce-11eb-8984-c5c8f0231411.png">


after:
<img width="1381" alt="Screen Shot 2020-12-11 at 4 35 04 PM" src="https://user-images.githubusercontent.com/7741604/101967012-e4a12580-3bce-11eb-8188-c80b994aca3f.png">


not totally sure i chose the correct thing to keep, so would appreciate a look from @jcoyne 

## Which documentation and/or configurations were updated?

n/a