### PR TITLE
[DRAFT] Add basic table sorting and disable unsortable columns

### DIFF
--- a/app/components/collections/works_component.html.erb
+++ b/app/components/collections/works_component.html.erb
@@ -1,11 +1,11 @@
-<table class="table sortable">
+<table id="works" class="table sortable">
 <thead class="table-light">
-  <tr>
-    <th><%= I18n.t 'collection.deposits' %></th>
+  <tr class="work-headers">
+    <th width="18%"><%= I18n.t 'collection.deposits' %></th>
     <th><span class="visually-hidden"><%= I18n.t 'collection.actions' %></span></th>
-    <th><%= I18n.t 'collection.depositor' %></th>
-    <th><%= I18n.t 'collection.deposit_status' %></th>
-    <th><%= I18n.t 'collection.last_modified' %></th>
+    <th width="10%"><%= I18n.t 'collection.depositor' %></th>
+    <th width="18%"><%= I18n.t 'collection.deposit_status' %></th>
+    <th width="10%"><%= I18n.t 'collection.last_modified' %></th>
     <th><%= I18n.t 'collection.number_of_files' %></th>
     <th><%= I18n.t 'collection.deposit_size' %></th>
     <th><%= I18n.t 'collection.persistent_link' %></th>

--- a/app/components/collections/works_component.html.erb
+++ b/app/components/collections/works_component.html.erb
@@ -1,4 +1,4 @@
-<table class="table">
+<table class="table sortable">
 <thead class="table-light">
   <tr>
     <th><%= I18n.t 'collection.deposits' %></th>
@@ -35,3 +35,5 @@
   <% end %>
 </tbody>
 </table>
+<%= javascript_pack_tag 'data-table', 'data-turbolinks-track': 'reload' %>
+

--- a/app/javascript/packs/data-table.js
+++ b/app/javascript/packs/data-table.js
@@ -9,46 +9,73 @@ var tables = document.querySelectorAll("table.sortable"),
     i,
     j;
 
-var disabledColumns = [4, 5, 6, 7, 8]
+var disabledColumns = [1, 5, 6, 7, 8]
 
 for (i = 0; i < tables.length; i++) {
-    table = tables[i];
+  setTableHeaders(tables[i], true);
+}
 
-    if (thead = table.querySelector("thead")) {
-        headers = thead.querySelectorAll("th");
+function setTableHeaders(table, withEvent) {
+  if (thead = table.querySelector("thead")) {
+    headers = thead.querySelectorAll("th");
 
-        for (j = 0; j < headers.length; j++) {
-          if (disabledColumns.includes(j)) { continue; }
-          else { headers[j].innerHTML = "<a href='#'>" + headers[j].innerText + "</a>"; }
-        }
-
-        thead.addEventListener("click", sortTableFunction(table));
+    for (j = 0; j < headers.length; j++) {
+      if (disabledColumns.includes(j)) { continue; }
+      else { headers[j].innerHTML = "<a href='#'>" + headers[j].innerText + "</a>"; }
     }
+
+    if (withEvent) {
+      console.log("1")
+      thead.addEventListener("click", sortTableFunction(table));
+    }
+  }
 }
 
 /**
  * Create a function to sort the given table.
  */
 function sortTableFunction(table) {
-    return function(ev) {
-      if (ev.target.tagName.toLowerCase() == 'a') {
-            sortRows(table, siblingIndex(ev.target.parentNode), reverseSort(ev.target));
-            ev.preventDefault();
-            setIndicator(ev.target.parentNode)
-        }
-    };
+  return function(ev) {
+    if (ev.target.tagName.toLowerCase() == 'a') {
+      target = ev.target
+      indicator = getNextIndicator(target)
+      sortRows(table, siblingIndex(target.parentNode), reverseSort(indicator));
+      // clearIndicators(table); // restetting table headers here causes a null exception
+      setIndicator(target.parentNode, indicator)
+      ev.preventDefault();
+    }
+  };
 }
 
-function setIndicator(target) {
+// function clearIndicators(table) {
+//   var headers = table.getElementsByTagName("th")
+//   for (i = 0; i < headers.length; i++) {
+//     icon = headers[i].getElementsByTagName("i")
+//       console.log("ICON");
+//       console.dir(icon[0]);
+//     }
+// }
+
+/**
+ * Get the existing sort indicator, used to determin sort direction
+ */
+function getNextIndicator(target) {
   if(target.innerHTML.includes('fa-angle-down')) {
-    target.innerHTML = "<a href='#'>" + target.innerText + " <i class=\"fa fa-angle-up\"></i></a>";
+    return 'up';
   } else {
-    target.innerHTML = "<a href='#'>" + target.innerText + " <i class=\"fa fa-angle-down\"></i></a>";
+    return 'down';
   }
 }
 
-function reverseSort(target) {
-  if(target.innerHTML.includes('fa-angle-down')) {
+ /**
+ * Uses existing sort indicastor to set the proper font-awesome indicator based on sort direction
+ */
+function setIndicator(target, indicator) {
+  target.innerHTML = "<a href='#'>" + target.innerText + " <i class=\"fa fa-angle-" + indicator + "\"></i></a>";
+}
+
+function reverseSort(direction) {
+  if(direction == 'up') {
     return true;
   }
   return false;

--- a/app/javascript/packs/data-table.js
+++ b/app/javascript/packs/data-table.js
@@ -31,11 +31,27 @@ for (i = 0; i < tables.length; i++) {
  */
 function sortTableFunction(table) {
     return function(ev) {
-        if (ev.target.tagName.toLowerCase() == 'a') {
-            sortRows(table, siblingIndex(ev.target.parentNode));
+      if (ev.target.tagName.toLowerCase() == 'a') {
+            sortRows(table, siblingIndex(ev.target.parentNode), reverseSort(ev.target));
             ev.preventDefault();
+            setIndicator(ev.target.parentNode)
         }
     };
+}
+
+function setIndicator(target) {
+  if(target.innerHTML.includes('fa-angle-down')) {
+    target.innerHTML = "<a href='#'>" + target.innerText + " <i class=\"fa fa-angle-up\"></i></a>";
+  } else {
+    target.innerHTML = "<a href='#'>" + target.innerText + " <i class=\"fa fa-angle-down\"></i></a>";
+  }
+}
+
+function reverseSort(target) {
+  if(target.innerHTML.includes('fa-angle-down')) {
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -55,7 +71,7 @@ function siblingIndex(node) {
 /**
  * Sort the given table by the numbered column (0 is the first column, etc.)
  */
-function sortRows(table, columnIndex) {
+function sortRows(table, columnIndex, desc) {
     var rows = table.querySelectorAll("tbody tr"),
         sel = "thead th:nth-child(" + (columnIndex + 1) + ")",
         sel2 = "td:nth-child(" + (columnIndex + 1) + ")",
@@ -101,8 +117,14 @@ function sortRows(table, columnIndex) {
         values.sort(sortTextVal);
     }
 
-    for (var idx = 0; idx < values.length; idx++) {
+    if (desc) { // sort ascending
+      for (var idx = values.length-1; idx >= 0; idx--) {
         table.querySelector("tbody").appendChild(values[idx].row);
+      }
+    } else {
+      for (var idx = 0; idx < values.length; idx++) {
+          table.querySelector("tbody").appendChild(values[idx].row);
+      }
     }
 }
 

--- a/app/javascript/packs/data-table.js
+++ b/app/javascript/packs/data-table.js
@@ -1,0 +1,150 @@
+/**
+ * Inject hyperlinks, into the column headers of sortable tables, which sort
+ * the corresponding column when clicked.
+ */
+var tables = document.querySelectorAll("table.sortable"),
+    table,
+    thead,
+    headers,
+    i,
+    j;
+
+var disabledColumns = [4, 5, 6, 7, 8]
+
+for (i = 0; i < tables.length; i++) {
+    table = tables[i];
+
+    if (thead = table.querySelector("thead")) {
+        headers = thead.querySelectorAll("th");
+
+        for (j = 0; j < headers.length; j++) {
+          if (disabledColumns.includes(j)) { continue; }
+          else { headers[j].innerHTML = "<a href='#'>" + headers[j].innerText + "</a>"; }
+        }
+
+        thead.addEventListener("click", sortTableFunction(table));
+    }
+}
+
+/**
+ * Create a function to sort the given table.
+ */
+function sortTableFunction(table) {
+    return function(ev) {
+        if (ev.target.tagName.toLowerCase() == 'a') {
+            sortRows(table, siblingIndex(ev.target.parentNode));
+            ev.preventDefault();
+        }
+    };
+}
+
+/**
+ * Get the index of a node relative to its siblings — the first (eldest) sibling
+ * has index 0, the next index 1, etc.
+ */
+function siblingIndex(node) {
+    var count = 0;
+
+    while (node = node.previousElementSibling) {
+        count++;
+    }
+
+    return count;
+}
+
+/**
+ * Sort the given table by the numbered column (0 is the first column, etc.)
+ */
+function sortRows(table, columnIndex) {
+    var rows = table.querySelectorAll("tbody tr"),
+        sel = "thead th:nth-child(" + (columnIndex + 1) + ")",
+        sel2 = "td:nth-child(" + (columnIndex + 1) + ")",
+        classList = table.querySelector(sel).classList,
+        values = [],
+        cls = "",
+        allNum = true,
+        val,
+        index,
+        node;
+
+    if (classList) {
+        if (classList.contains("date")) {
+            cls = "date";
+        } else if (classList.contains("number")) {
+            cls = "number";
+        }
+    }
+
+    for (index = 0; index < rows.length; index++) {
+        node = rows[index].querySelector(sel2);
+        val = node.innerText;
+
+        if (isNaN(val)) {
+            allNum = false;
+        } else {
+            val = parseFloat(val);
+        }
+
+        values.push({ value: val, row: rows[index] });
+    }
+
+    if (cls == "" && allNum) {
+        cls = "number";
+    }
+
+    if (cls == "number") {
+        values.sort(sortNumberVal);
+        values = values.reverse();
+    } else if (cls == "date") {
+        values.sort(sortDateVal);
+    } else {
+        values.sort(sortTextVal);
+    }
+
+    for (var idx = 0; idx < values.length; idx++) {
+        table.querySelector("tbody").appendChild(values[idx].row);
+    }
+}
+
+/**
+ * Compare two 'value objects' numerically
+ */
+function sortNumberVal(a, b) {
+    return sortNumber(a.value, b.value);
+}
+
+/**
+ * Numeric sort comparison
+ */
+function sortNumber(a, b) {
+    return a - b;
+}
+
+/**
+ * Compare two 'value objects' as dates
+ */
+function sortDateVal(a, b) {
+    var dateA = Date.parse(a.value),
+        dateB = Date.parse(b.value);
+
+    return sortNumber(dateA, dateB);
+}
+
+/**
+ * Compare two 'value objects' as simple text; case-insensitive
+ */
+function sortTextVal(a, b) {
+    var textA = (a.value + "").toUpperCase();
+    var textB = (b.value + "").toUpperCase();
+
+    if (textA < textB) {
+        return -1;
+    }
+
+    if (textA > textB) {
+        return 1;
+    }
+
+    return 0;
+}
+

--- a/app/javascript/stylesheets/collection.scss
+++ b/app/javascript/stylesheets/collection.scss
@@ -47,3 +47,8 @@
     }
   }
 }
+
+#works {
+  // a smller font on the works table helps maintain alignment
+  font-size: .85rem;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,7 +31,7 @@ en:
     depositor: Depositor
     deposits: Deposits in collection
     deposit_status: Deposit status
-    deposit_size: Deposit size
-    last_modified: Last modified
-    number_of_files: '# of files'
+    deposit_size: Size
+    last_modified: Modified
+    number_of_files: 'Files'
     persistent_link: Persistent link


### PR DESCRIPTION
## Why was this change made?

Option #2 for table sorting based on comments in other PR.

Default display without any sort indicators:

<img width="1499" alt="Screen Shot 2021-01-12 at 3 17 16 PM" src="https://user-images.githubusercontent.com/2294288/104386225-92af3080-54e9-11eb-8767-f4250fee3fb3.png">

Once a heading has been clicked showing a sort indicator:

<img width="1482" alt="Screen Shot 2021-01-12 at 3 17 22 PM" src="https://user-images.githubusercontent.com/2294288/104386262-a22e7980-54e9-11eb-9e55-2fbfced65477.png">

And clicked again, the indicator changes direction:

<img width="1509" alt="Screen Shot 2021-01-12 at 3 17 28 PM" src="https://user-images.githubusercontent.com/2294288/104386287-b6727680-54e9-11eb-9480-e1882f671c84.png">

One area where I am currently blocked is the ability to clear the existing sort indicator without causing problems with the event due to reloading of the dom (see: https://stackoverflow.com/questions/5113105/manipulating-innerhtml-removes-the-event-handler-of-a-child-element):

<img width="1509" alt="Screen Shot 2021-01-12 at 3 17 35 PM" src="https://user-images.githubusercontent.com/2294288/104386377-e883d880-54e9-11eb-89e3-49d43163b818.png">


## How was this change tested?



## Which documentation and/or configurations were updated?



