### PR TITLE
Truncate titles over 150 characters

### DIFF
--- a/app/components/collections/work_row_component.html.erb
+++ b/app/components/collections/work_row_component.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td class="work-title"><%= link_to Works::DetailComponent.new(work: work).title, work %></td>
+  <%= render Works::LinkToShowComponent.new(work: work) %>
   <td>
     <% if allowed_to? :edit?, work %>
       <%= link_to [:edit, work], aria: { label: "Edit #{Works::DetailComponent.new(work: work).title}" } do %>

--- a/app/components/dashboard/approvals_component.html.erb
+++ b/app/components/dashboard/approvals_component.html.erb
@@ -14,7 +14,7 @@
     <tbody>
     <% approvals.each do |submission| %>
       <tr>
-        <td><%= link_to Works::DetailComponent.new(work: submission).title, work_path(submission) %></td>
+        <%= render Works::LinkToShowComponent.new(work: submission) %>
         <td><%= submission.depositor.sunetid %></td>
         <td><%= submission.collection.name %></td>
         <td><%= render Works::StateDisplayComponent.new(work: submission) %></td>

--- a/app/components/dashboard/collection_component.html.erb
+++ b/app/components/dashboard/collection_component.html.erb
@@ -16,7 +16,7 @@
     <tbody>
       <% visible_deposits.take(MAX_DEPOSITS_TO_SHOW).each do |work| %>
         <tr>
-          <td class="work-title"><%= link_to Works::DetailComponent.new(work: work).title, work %></td>
+          <%= render Works::LinkToShowComponent.new(work: work) %>
           <td>
             <% if allowed_to? :edit?, work %>
               <%= link_to [:edit, work], aria: { label: "Edit #{Works::DetailComponent.new(work: work).title}" } do %>

--- a/app/components/works/link_to_show_component.html.erb
+++ b/app/components/works/link_to_show_component.html.erb
@@ -1,0 +1,1 @@
+<td class="work-title"><%= link %></td>

--- a/app/components/works/link_to_show_component.rb
+++ b/app/components/works/link_to_show_component.rb
@@ -1,0 +1,21 @@
+# typed: false
+# frozen_string_literal: true
+
+module Works
+  # Draws the link to the show page
+  class LinkToShowComponent < ApplicationComponent
+    def initialize(work:)
+      @work = work
+    end
+
+    def link
+      link_to truncate(title, length: 150, separator: ' '), work, title: title
+    end
+
+    def title
+      @title ||= Works::DetailComponent.new(work: work).title
+    end
+
+    attr_reader :work
+  end
+end

--- a/spec/components/collections/works_component_spec.rb
+++ b/spec/components/collections/works_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Collections::WorksComponent, type: :component do
     end
 
     it 'renders the works detail table component' do
-      expect(rendered.css('table').to_html).to include('Test title').exactly(6).times
+      expect(rendered.css('table').to_html).to include('Test title').exactly(8).times
     end
   end
 end

--- a/spec/components/works/link_to_show_component_spec.rb
+++ b/spec/components/works/link_to_show_component_spec.rb
@@ -1,0 +1,20 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Works::LinkToShowComponent, type: :component do
+  let(:render) { render_inline(described_class.new(work: work)) }
+  let(:work) { build_stubbed(:work, title: title) }
+  let(:title) do
+    "Marfa gochujang 90's, normcore lomo chartreuse ethical man bun fashion axe " \
+    'palo santo asymmetrical post-ironic. Kitsch sriracha affogato wayfarers woke neutra.'
+  end
+
+  it 'truncates the link' do
+    expect(render.css('a').first['title']).to eq title
+    expect(render.css('a').text).to eq "Marfa gochujang 90's, normcore lomo " \
+      'chartreuse ethical man bun fashion axe palo santo asymmetrical post-ironic. ' \
+      'Kitsch sriracha affogato wayfarers...'
+  end
+end


### PR DESCRIPTION
And display the full title as a mouseover

## Why was this change made?
Fixes #802 
Fixes #803 
Fixes #804


## How was this change tested?

<img width="1116" alt="Screen Shot 2021-01-13 at 11 17 13 AM" src="https://user-images.githubusercontent.com/92044/104486580-91d1d980-5591-11eb-8c40-d4e0f89693a1.png">

<img width="1116" alt="Screen Shot 2021-01-13 at 11 17 39 AM" src="https://user-images.githubusercontent.com/92044/104486546-867eae00-5591-11eb-9bff-1a6de051e019.png">

## Which documentation and/or configurations were updated?



