### PR TITLE
Add missing headers to the collection details page

### DIFF
--- a/app/components/collections/history_component.html.erb
+++ b/app/components/collections/history_component.html.erb
@@ -2,8 +2,8 @@
   <thead class="table-light">
     <tr>
       <th scope="col" class="table-title col-3">History</th>
-      <th scope="col"></th>
-      <th scope="col"></th>
+      <th scope="col">Modified by</th>
+      <th scope="col">Date</th>
       <th scope="col"></th>
     </tr>
   </thead>


### PR DESCRIPTION



## Why was this change made?

Fixes #788

## How was this change tested?

<img width="1149" alt="Screen Shot 2021-01-13 at 1 54 46 PM" src="https://user-images.githubusercontent.com/92044/104503612-e92e7480-55a6-11eb-8579-3a683de3a4b9.png">

## Which documentation and/or configurations were updated?



