### PR TITLE
Allow empty collections to appear in All Collections

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ inherit_from: .rubocop_todo.yml
 #### Local Settings
 
 AllCops:
+  TargetRubyVersion: 2.7
   Exclude:
     - db/**/*
     - node_modules/**/*

--- a/app/services/stat_builder.rb
+++ b/app/services/stat_builder.rb
@@ -1,33 +1,24 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # Runs queries and builds the data structure for the summary table.
 class StatBuilder
   extend T::Sig
 
-  sig { returns(T::Hash[Collection, Hash]) }
+  sig { returns(T::Hash[Collection, T::Hash[String, Integer]]) }
   def self.build_stats
-    collections_by_id = Collection.all.index_by(&:id)
+    works = Work.all.group(:collection_id, :state).count
 
-    by_state.each_with_object({}) do |(id, val), obj|
-      obj[collections_by_id.fetch(id)] = val.merge('total' => total.fetch(id))
+    # We only use a few fields from the collection, so don't waste time
+    # pulling back the other attributes.
+    Collection.select(:id, :name, :updated_at).index_with do |collection|
+      works
+        # filter works to those that belong to the collection in the current iteration of the block
+        .select { |(collection_id, _state), _count| collection_id == collection.id }
+        # change keys via `#group` above from `[80, "rejected"]=>1` to `"rejected"=>1`
+        .transform_keys { |(_collection_id, state)| state }
+        # inject totals into hash
+        .tap { |counts| counts['total'] = counts.values.sum }
     end
   end
-
-  sig { returns(T::Hash[Integer, T::Hash[String, Integer]]) }
-  def self.by_state
-    Work.all.group(:collection_id, :state).count.each_with_object({}) do |((id, state), count), obj|
-      obj[id] ||= {}
-      obj[id][state] = count
-    end
-  end
-  private_class_method :by_state
-
-  sig { returns(T::Hash[Integer, Integer]) }
-  def self.total
-    Work.all.group(:collection_id).count.each_with_object({}) do |(id, count), obj|
-      obj[id] = count
-    end
-  end
-  private_class_method :total
 end

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -60,15 +60,16 @@ RSpec.describe 'Dashboard requests' do
   end
 
   context 'when user is an application admin' do
-    let(:collection) { create(:collection, creator: user, updated_at: '2020-12-02') }
+    let(:workful_collection) { create(:collection, creator: user, updated_at: '2020-12-02') }
+    let!(:workless_collection) { create(:collection, creator: user, updated_at: '2020-12-03') }
 
     before do
       sign_in user, groups: ['dlss:hydrus-app-administrators']
-      create(:work, :deposited, collection: collection, depositor: user)
-      create(:work, :first_draft, collection: collection, depositor: user)
-      create(:work, :version_draft, collection: collection, depositor: user)
-      create(:work, :pending_approval, collection: collection, depositor: user)
-      create(:work, :rejected, collection: collection, depositor: user)
+      create(:work, :deposited, collection: workful_collection, depositor: user)
+      create(:work, :first_draft, collection: workful_collection, depositor: user)
+      create(:work, :version_draft, collection: workful_collection, depositor: user)
+      create(:work, :pending_approval, collection: workful_collection, depositor: user)
+      create(:work, :rejected, collection: workful_collection, depositor: user)
     end
 
     it 'shows a link to create collections and the all collections table' do
@@ -78,7 +79,7 @@ RSpec.describe 'Dashboard requests' do
       expect(response.body).to include '+ Create a new collection'
       expect(response.body).to include <<-HTML
       <tr>
-        <td><a href=\"#{collection_path(collection)}\">MyString</a></td>
+        <td><a href=\"#{collection_path(workful_collection)}\">MyString</a></td>
         <td>5</td>
         <td>1</td>
         <td>1</td>
@@ -86,6 +87,18 @@ RSpec.describe 'Dashboard requests' do
         <td>1</td>
         <td>1</td>
         <td>Dec 02, 2020</td>
+      </tr>
+      HTML
+      expect(response.body).to include <<-HTML
+      <tr>
+        <td><a href=\"#{collection_path(workless_collection)}\">MyString</a></td>
+        <td>0</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td>Dec 03, 2020</td>
       </tr>
       HTML
     end


### PR DESCRIPTION
Fixes #776

## Why was this change made?

This refactoring of StatBuilder allows all collections to render in the All Collections component within the dashboard. To my eyes, the class is now also easier to grok.

## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None

