### PR TITLE
track participant changes and send participant change email

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,7 +49,7 @@ RSpec/MultipleMemoizedHelpers:
   Max: 15
 
 RSpec/NestedGroups:
-  Max: 5
+  Max: 6
 
 RSpec/ScatteredSetup:
   Exclude:

--- a/app/components/collections/history_component.html.erb
+++ b/app/components/collections/history_component.html.erb
@@ -13,7 +13,7 @@
         <td><%= I18n.t event.event_type, scope: 'event.type' %></td>
         <td><%= event.user.sunetid %></td>
         <td><%= I18n.l(event.created_at, format: :abbr_month) %></td>
-        <td><%= event.description %></td>
+        <td><%= simple_format(event.description) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/mailers/collections_mailer.rb
+++ b/app/mailers/collections_mailer.rb
@@ -37,4 +37,10 @@ class CollectionsMailer < ApplicationMailer
 
     mail(to: @user.email, subject: "New activity in the #{@collection.name} collection")
   end
+
+  def participants_changed_email
+    @user = params[:user]
+    @collection = params[:collection]
+    mail(to: @user.email, subject: "Participant changes for the #{@collection.name} collection in the SDR")
+  end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -57,7 +57,6 @@ class Collection < ApplicationRecord
     end
 
     after_transition to: :version_draft, do: CollectionObserver.method(:after_update_published)
-    after_transition on: :update_metadata, do: CollectionObserver.method(:on_update_metadata)
 
     after_transition do |collection, transition|
       BroadcastCollectionChange.call(collection: collection, state: transition.to_name)

--- a/app/models/collection_change_set.rb
+++ b/app/models/collection_change_set.rb
@@ -12,6 +12,10 @@ class CollectionChangeSet
     @point2 = point2
   end
 
+  def added_managers
+    point2.managers - point1.managers
+  end
+
   def added_depositors
     point2.depositors - point1.depositors
   end
@@ -26,6 +30,25 @@ class CollectionChangeSet
 
   def removed_managers
     point1.managers - point2.managers
+  end
+
+  def removed_reviewers
+    point1.reviewers - point2.reviewers
+  end
+
+  def participants_changed?
+    added_managers.present? || added_depositors.present? || added_reviewers.present? ||
+      removed_managers.present? || removed_depositors.present? || removed_reviewers.present?
+  end
+
+  def participant_change_description
+    %i[added_managers added_depositors added_reviewers
+       removed_managers removed_depositors removed_reviewers].map do |field_name|
+      field_changes = send(field_name)
+      next if field_changes.blank?
+
+      "#{field_name.to_s.humanize}: #{field_changes.map(&:sunetid).join(', ')}"
+    end.compact.join("\n")
   end
 
   attr_reader :point1, :point2

--- a/app/services/collection_observer.rb
+++ b/app/services/collection_observer.rb
@@ -16,10 +16,6 @@ class CollectionObserver
     depositors_added(collection)
     depositors_removed(collection)
     reviewers_added(collection)
-  end
-
-  # Whenever metadata is updated
-  def self.on_update_metadata(collection, _transition)
     send_participant_change_emails(collection)
   end
 

--- a/app/views/collections_mailer/participants_changed_email.html.erb
+++ b/app/views/collections_mailer/participants_changed_email.html.erb
@@ -1,0 +1,8 @@
+<p>Dear <%= @user.name %>,</p>
+
+<p>Members have been either added to or removed from the <%= @collection.name %> collection. Please see the
+   history section at the bottom of the collection details page to see the changes made.</p>
+
+<p>If you have any questions, contact the SDR team at: <%= link_to contact_form_url, contact_form_url %></p>
+
+<p>The Stanford Digital Repository Team</p>

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -59,4 +59,8 @@ FactoryBot.define do
   trait :email_depositors_status_changed do
     email_depositors_status_changed { true }
   end
+
+  trait :email_when_participants_changed do
+    email_when_participants_changed { true }
+  end
 end

--- a/spec/mailers/collections_mailer_spec.rb
+++ b/spec/mailers/collections_mailer_spec.rb
@@ -91,4 +91,21 @@ RSpec.describe CollectionsMailer, type: :mailer do
       expect(mail.body.encoded).to match "in the #{collection.name} collection"
     end
   end
+
+  describe '#participants_changed_email' do
+    let(:user) { build(:user) }
+    let(:mail) { described_class.with(user: user, collection: collection).participants_changed_email }
+    let(:collection) { build(:collection) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq "Participant changes for the #{collection.name} collection in the SDR"
+      expect(mail.to).to eq [user.email]
+      expect(mail.from).to eq ['no-reply@sdr.stanford.edu']
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to match 'Members have been either added to or removed from the ' \
+                                         "#{collection.name} collection."
+    end
+  end
 end

--- a/spec/mailers/previews/collections_mailer_preview.rb
+++ b/spec/mailers/previews/collections_mailer_preview.rb
@@ -5,7 +5,8 @@
 # Preview these emails at http://localhost:3000/rails/mailers/collections_mailer
 class CollectionsMailerPreview < ActionMailer::Preview
   delegate :invitation_to_deposit_email, :deposit_access_removed_email,
-           :review_access_granted_email, to: :mailer_with_collection
+           :review_access_granted_email, :participants_changed_email,
+           to: :mailer_with_collection
 
   private
 

--- a/spec/requests/edit_collection_spec.rb
+++ b/spec/requests/edit_collection_spec.rb
@@ -120,6 +120,78 @@ RSpec.describe 'Updating an existing collection' do
             expect(method).to have_received(:call)
           end
         end
+
+        context 'when depositors or reviewers are removed from a collection' do
+          let(:reviewer) { create(:user, email: 'v.stern@stanford.edu') }
+          let(:reviewer2) { create(:user, email: 'w.a.sterner@stanford.edu') }
+          let!(:removed_depositor) { collection.depositors.second } # needs to be instantiated before collection edit
+          let(:collection) do
+            create(:collection, :deposited, :with_depositors, :email_when_participants_changed,
+                   depositor_count: 2, managers: [user], reviewers: [reviewer, reviewer2])
+          end
+          let(:collection_params) do
+            {
+              name: 'My Test Collection',
+              description: 'This is a very good collection.',
+              contact_email: user.email,
+              access: 'world',
+              manager_sunets: user.sunetid,
+              depositor_sunets: collection.depositors.first.sunetid,
+              email_depositors_status_changed: true,
+              review_enabled: 'true',
+              reviewer_sunets: 'v.stern'
+            }
+          end
+
+          it 'sends emails to the managers' do
+            expect do
+              patch "/collections/#{collection.id}",
+                    params: { collection: collection_params, commit: save_draft_button }
+            end.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
+              'CollectionsMailer', 'participants_changed_email', 'deliver_now',
+              { params: { user: user, collection: collection }, args: [] }
+            )
+          end
+
+          it 'sends emails to the reviewers' do
+            expect do
+              patch "/collections/#{collection.id}",
+                    params: { collection: collection_params, commit: save_draft_button }
+            end.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
+              'CollectionsMailer', 'participants_changed_email', 'deliver_now',
+              { params: { user: collection.reviewers.first, collection: collection }, args: [] }
+            )
+          end
+
+          it 'logs the changes in the event description' do
+            patch "/collections/#{collection.id}",
+                  params: { collection: collection_params, commit: save_draft_button }
+            event_description = collection.reload.events.order(created_at: :desc).take.description
+            expect(event_description).to match(/Removed reviewers: w.a.sterner/)
+            expect(event_description).to match(/Removed depositors: #{removed_depositor.sunetid}/)
+          end
+
+          context 'when participant change emails are off' do
+            let(:no_notification_param) { collection_params.merge(email_when_participants_changed: false) }
+
+            it 'does not send notification about the participant change' do
+              expect do
+                patch "/collections/#{collection.id}",
+                      params: { collection: no_notification_param, commit: save_draft_button }
+              end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
+                'CollectionsMailer', 'participants_changed_email', anything, anything
+              )
+            end
+
+            it 'still logs the changes in the event description' do
+              patch "/collections/#{collection.id}",
+                    params: { collection: collection_params, commit: save_draft_button }
+              event_description = collection.reload.events.order(created_at: :desc).take.description
+              expect(event_description).to match(/Removed reviewers: w.a.sterner/)
+              expect(event_description).to match(/Removed depositors: #{removed_depositor.sunetid}/)
+            end
+          end
+        end
       end
 
       context 'when collection fails to save' do

--- a/spec/requests/edit_collection_spec.rb
+++ b/spec/requests/edit_collection_spec.rb
@@ -143,26 +143,6 @@ RSpec.describe 'Updating an existing collection' do
             }
           end
 
-          it 'sends emails to the managers' do
-            expect do
-              patch "/collections/#{collection.id}",
-                    params: { collection: collection_params, commit: save_draft_button }
-            end.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
-              'CollectionsMailer', 'participants_changed_email', 'deliver_now',
-              { params: { user: user, collection: collection }, args: [] }
-            )
-          end
-
-          it 'sends emails to the reviewers' do
-            expect do
-              patch "/collections/#{collection.id}",
-                    params: { collection: collection_params, commit: save_draft_button }
-            end.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
-              'CollectionsMailer', 'participants_changed_email', 'deliver_now',
-              { params: { user: collection.reviewers.first, collection: collection }, args: [] }
-            )
-          end
-
           it 'logs the changes in the event description' do
             patch "/collections/#{collection.id}",
                   params: { collection: collection_params, commit: save_draft_button }
@@ -173,15 +153,6 @@ RSpec.describe 'Updating an existing collection' do
 
           context 'when participant change emails are off' do
             let(:no_notification_param) { collection_params.merge(email_when_participants_changed: false) }
-
-            it 'does not send notification about the participant change' do
-              expect do
-                patch "/collections/#{collection.id}",
-                      params: { collection: no_notification_param, commit: save_draft_button }
-              end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
-                'CollectionsMailer', 'participants_changed_email', anything, anything
-              )
-            end
 
             it 'still logs the changes in the event description' do
               patch "/collections/#{collection.id}",


### PR DESCRIPTION
## Why was this change made?

close #596 
close #781 

## How was this change tested?

unit tests, manual testing on local instance (see screenshots)

<img width="1113" alt="Screen Shot 2021-01-14 at 8 45 46 PM" src="https://user-images.githubusercontent.com/7741604/104682604-f4b69400-56a9-11eb-9e24-9203dd20580e.png">
<img width="1187" alt="Screen Shot 2021-01-14 at 8 46 17 PM" src="https://user-images.githubusercontent.com/7741604/104682607-f6805780-56a9-11eb-8b97-1840c02a10c1.png">


## Which documentation and/or configurations were updated?

n/a