### PR TITLE
[DRAFT] Select current values when rendering the form

### DIFF
--- a/app/components/works/dates_component.html.erb
+++ b/app/components/works/dates_component.html.erb
@@ -12,7 +12,7 @@
 
   <div class="mb-3 row">
     <div class="col-sm-2">
-      <%= form.radio_button :created_type, 'single', class: 'form-check-input' %>
+      <%= form.radio_button :created_type, 'single', radio_button_options(type: 'single') %>
       <%= form.label :created_type_single, 'Single date' %>
     </div>
     <div data-controller="date-validation" class="col-sm-10">
@@ -35,8 +35,8 @@
 
   <div class="mb-3 row">
     <div class="col-md-2">
-      <%= form.radio_button :created_type, 'range', class: 'form-check-input' %>
-       <%= form.label :created_type_range, 'Date range' %>
+      <%= form.radio_button :created_type, 'range', radio_button_options(type: 'range') %>
+      <%= form.label :created_type_range, 'Date range' %>
     </div>
 
     <div class="col-md-10 date-range">

--- a/app/components/works/dates_component.rb
+++ b/app/components/works/dates_component.rb
@@ -80,5 +80,12 @@ module Works
     def reform
       form.object
     end
+
+    def radio_button_options(type:)
+      { class: 'form-check-input' }.tap do |options|
+        options[:checked] = true if (type == 'range' && created_interval) ||
+                                    (type == 'single' && created_edtf)
+      end
+    end
   end
 end

--- a/app/components/works/embargo_component.html.erb
+++ b/app/components/works/embargo_component.html.erb
@@ -6,7 +6,7 @@
 
   <div class="mb-3 row">
     <div class="col-sm-10 release-option">
-      <%= form.radio_button :release, 'immediate', class: 'form-check-input' %>
+      <%= form.radio_button :release, 'immediate', radio_button_options %>
       <%= form.label :release_immediate, 'Immediately once deposit is completed' %>
     </div>
   </div>
@@ -14,7 +14,7 @@
   <div class="embargo-date" data-controller="embargo-date" data-action="error->embargo-date#error" data-edit-deposit-target="embargo-dateField">
     <div class="mb-5 row" data-embargo-date-target="container">
       <div class="col-sm-10 release-option">
-        <%= form.radio_button :release, 'embargo', class: 'form-check-input' %>
+        <%= form.radio_button :release, 'embargo', radio_button_options %>
         <%= form.label :release_embargo, 'On this date' %>
 
         <div class="year">

--- a/app/components/works/embargo_component.rb
+++ b/app/components/works/embargo_component.rb
@@ -16,6 +16,12 @@ module Works
       form.object
     end
 
+    def radio_button_options
+      { class: 'form-check-input' }.tap do |options|
+        options[:checked] = true if embargo_date.present?
+      end
+    end
+
     def year_field
       select_year embargo_year,
                   {

--- a/app/components/works/license_component.html.erb
+++ b/app/components/works/license_component.html.erb
@@ -4,7 +4,7 @@
     <%= form.label :license, class: 'col-sm-2 col-form-label' %>
     <div class="col-sm-10">
       <%= form.select :license,
-                      grouped_options_for_select(License.grouped_options),
+                      grouped_options_for_select(License.grouped_options, license),
                       {}, class: "form-select" %>
     </div>
   </div>

--- a/app/components/works/license_component.rb
+++ b/app/components/works/license_component.rb
@@ -9,5 +9,11 @@ module Works
     end
 
     attr_reader :form
+
+    delegate :license, to: :reform
+
+    def reform
+      form.object
+    end
   end
 end

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -22,9 +22,8 @@ class DraftWorkForm < Reform::Form
   property :agree_to_terms
   property :created_edtf, edtf: true, range: true
   property :published_edtf, edtf: true
-
   property :release, virtual: true, default: 'immediate'
-  property :embargo_date, embargo_date: true, assign_if: ->(params) { params['release'] == 'embargo' }
+  property :embargo_date, embargo_date: true
 
   validates :created_edtf, created_in_past: true
   validates :published_edtf, created_in_past: true

--- a/app/forms/embargo_date_params_filter.rb
+++ b/app/forms/embargo_date_params_filter.rb
@@ -9,7 +9,7 @@ class EmbargoDateParamsFilter
       next unless dfn[:embargo_date]
 
       name = dfn[:name]
-      date_attributes[name] = deserialize(params, name) if dfn[:assign_if].call(params)
+      date_attributes[name] = params['release'] == 'embargo' ? deserialize(params, name) : nil
     end
 
     params.merge(date_attributes)

--- a/app/services/collection_observer.rb
+++ b/app/services/collection_observer.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 # Actions that happen when something happens to a collection

--- a/sorbet/rails-rbi/mailers/collections_mailer.rbi
+++ b/sorbet/rails-rbi/mailers/collections_mailer.rbi
@@ -3,6 +3,9 @@
 # Please rerun bundle exec rake rails_rbi:mailers to regenerate.
 class CollectionsMailer
   sig { returns(ActionMailer::MessageDelivery) }
+  def self.collection_activity; end
+
+  sig { returns(ActionMailer::MessageDelivery) }
   def self.deposit_access_removed_email; end
 
   sig { returns(ActionMailer::MessageDelivery) }


### PR DESCRIPTION
Fixes #771

## Why was this change made?

It appears the app currently lacks code to select the current value for the embargo date, the license, and the created date range. This PR fixes all three. I can now toggle back and forth with expected results.

## How was this change tested?

CI (forthcoming, haven't written tests yet)

## Which documentation and/or configurations were updated?

None

