### PR TITLE
small CollectionChangeSet refactor

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -39,10 +39,10 @@ class CollectionsController < ObjectsController
   def update
     collection = Collection.find(params[:id])
     authorize! collection
-    change_set = CollectionChangeSet.from(collection)
+    point1 = CollectionChangeSet::PointInTime.new(collection)
     @form = collection_form(collection)
     if @form.validate(collection_params) && @form.save
-      after_save(collection, context: { change_set: change_set.to(collection) })
+      after_save(collection, context: { change_set: point1.diff(collection) })
     else
       # Send form errors to client in JSON format to be parsed and rendered there
       render 'errors', status: :bad_request

--- a/app/models/collection_change_set.rb
+++ b/app/models/collection_change_set.rb
@@ -1,46 +1,58 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # Represents the difference in a Collection before and after an update.
 class CollectionChangeSet
+  extend T::Sig
+
+  sig { params(collection: Collection).returns(PointInTime) }
   def self.from(collection)
     PointInTime.new(collection)
   end
 
+  sig { params(point1: PointInTime, point2: PointInTime).void }
   def initialize(point1, point2)
     @point1 = point1
     @point2 = point2
   end
 
+  sig { returns(T::Array[User]) }
   def added_managers
     point2.managers - point1.managers
   end
 
+  sig { returns(T::Array[User]) }
   def added_depositors
     point2.depositors - point1.depositors
   end
 
+  sig { returns(T::Array[User]) }
   def added_reviewers
     point2.reviewers - point1.reviewers
   end
 
+  sig { returns(T::Array[User]) }
   def removed_depositors
     point1.depositors - point2.depositors
   end
 
+  sig { returns(T::Array[User]) }
   def removed_managers
     point1.managers - point2.managers
   end
 
+  sig { returns(T::Array[User]) }
   def removed_reviewers
     point1.reviewers - point2.reviewers
   end
 
+  sig { returns(T::Boolean) }
   def participants_changed?
     added_managers.present? || added_depositors.present? || added_reviewers.present? ||
       removed_managers.present? || removed_depositors.present? || removed_reviewers.present?
   end
 
+  sig { returns(String) }
   def participant_change_description
     %i[added_managers added_depositors added_reviewers
        removed_managers removed_depositors removed_reviewers].map do |field_name|
@@ -51,20 +63,26 @@ class CollectionChangeSet
     end.compact.join("\n")
   end
 
+  sig { returns(PointInTime) }
   attr_reader :point1, :point2
 
   # Represents a collection at a fixed point in time
   class PointInTime
+    extend T::Sig
+
+    sig { params(collection: Collection).void }
     def initialize(collection)
       # Need to read these associations and cache them because the
       # underlying data in the database is mutable
-      @depositors = collection.depositors.to_a
-      @reviewers = collection.reviewers.to_a
-      @managers = collection.managers.to_a
+      @depositors = T.let(collection.depositors.to_a, T::Array[User])
+      @reviewers = T.let(collection.reviewers.to_a, T::Array[User])
+      @managers = T.let(collection.managers.to_a, T::Array[User])
     end
 
+    sig { returns(T::Array[User]) }
     attr_reader :depositors, :reviewers, :managers
 
+    sig { params(collection: Collection).returns(CollectionChangeSet) }
     def to(collection)
       CollectionChangeSet.new(self, PointInTime.new(collection))
     end

--- a/app/models/collection_change_set.rb
+++ b/app/models/collection_change_set.rb
@@ -5,11 +5,6 @@
 class CollectionChangeSet
   extend T::Sig
 
-  sig { params(collection: Collection).returns(PointInTime) }
-  def self.from(collection)
-    PointInTime.new(collection)
-  end
-
   sig { params(point1: PointInTime, point2: PointInTime).void }
   def initialize(point1, point2)
     @point1 = point1
@@ -83,7 +78,7 @@ class CollectionChangeSet
     attr_reader :depositors, :reviewers, :managers
 
     sig { params(collection: Collection).returns(CollectionChangeSet) }
-    def to(collection)
+    def diff(collection)
       CollectionChangeSet.new(self, PointInTime.new(collection))
     end
   end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Collection do
 
     describe 'an update_metadata event' do
       let(:collection) { create(:collection, :deposited) }
-      let(:change_set) { CollectionChangeSet.from(collection).to(collection) }
+      let(:change_set) { CollectionChangeSet::PointInTime.new(collection).diff(collection) }
 
       before do
         collection.event_context = { user: collection.creator, change_set: change_set }

--- a/spec/services/collection_observer_spec.rb
+++ b/spec/services/collection_observer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CollectionObserver do
   describe '.after_update_published' do
     subject(:action) { described_class.after_update_published(collection, nil) }
 
-    let(:change_set) { CollectionChangeSet.from(collection).to(collection_after) }
+    let(:change_set) { CollectionChangeSet::PointInTime.new(collection).diff(collection_after) }
 
     before do
       collection.event_context = { user: collection.creator, change_set: change_set }


### PR DESCRIPTION
## Why was this change made?

slightly clearer code, hopefully?  in particular, i was briefly confused by the fact that `CollectionChangeSet.from` returned a `PointInTime` (i expected a `CollectionChangeSet` based on the method name).

hopefully the type annotations, and the method and var renaming make things a bit more obvious.

## How was this change tested?

type checker and unit tests

## Which documentation and/or configurations were updated?

type annotations