### PR TITLE
Extract WorkObserver from work

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -27,49 +27,20 @@ class Work < ApplicationRecord
   }
 
   state_machine initial: :new do
-    before_transition do |work, transition|
-      work.events.build(work.event_context.merge(event_type: transition.event))
-    end
+    before_transition WorkObserver.method(:before_transition)
 
-    after_transition on: :begin_deposit do |work, _transition|
-      DepositJob.perform_later(work)
-    end
+    after_transition WorkObserver.method(:after_transition)
+    after_transition on: :begin_deposit, do: WorkObserver.method(:after_begin_deposit)
+    after_transition on: :reject, do: WorkObserver.method(:after_rejected)
+    after_transition on: :submit_for_review, do: WorkObserver.method(:after_submit_for_review)
+    after_transition on: :deposit_complete, do: WorkObserver.method(:after_deposit_complete)
 
     after_transition except_from: :first_draft, to: :first_draft, do: CollectionObserver.method(:collection_activity)
     after_transition except_from: :version_draft, to: :version_draft,
                      do: CollectionObserver.method(:collection_activity)
 
-    after_transition on: :deposit_complete do |work, _transition|
-      mailer = WorksMailer.with(user: work.depositor, work: work)
-      job = if work.collection.review_enabled?
-              mailer.approved_email
-            elsif work.version > 1
-              mailer.new_version_deposited_email
-            else
-              mailer.deposited_email
-            end
-      job.deliver_later
-    end
-
-    after_transition do |work, transition|
-      BroadcastWorkChange.call(work: work, state: transition.to_name)
-    end
-
-    after_transition on: :reject do |work, _transition|
-      WorksMailer.with(user: work.depositor, work: work)
-                 .reject_email.deliver_later
-    end
-
-    after_transition on: :submit_for_review do |work, _transition|
-      (work.collection.reviewers + work.collection.managers - [work.depositor]).each do |recipient|
-        ReviewersMailer.with(user: recipient, work: work).submitted_email.deliver_later
-      end
-      WorksMailer.with(user: work.depositor, work: work).submitted_email.deliver_later
-    end
-
     # NOTE: there is no approval "event" because when a work is approved in review, it goes
     # directly to begin_deposit event, which will transition it to depositing
-
     event :begin_deposit do
       transition %i[first_draft version_draft pending_approval] => :depositing
     end

--- a/app/services/work_observer.rb
+++ b/app/services/work_observer.rb
@@ -1,0 +1,52 @@
+# typed: false
+# frozen_string_literal: true
+
+# Actions that happen when something happens to a work
+class WorkObserver
+  def self.before_transition(work, transition)
+    work.events.build(work.event_context.merge(event_type: transition.event))
+  end
+
+  def self.after_transition(work, transition)
+    BroadcastWorkChange.call(work: work, state: transition.to_name)
+  end
+
+  def self.after_begin_deposit(work, _transition)
+    DepositJob.perform_later(work)
+  end
+
+  def self.after_work_rejected(work, _transition)
+    work_mailer(work).reject_email.deliver_later
+  end
+
+  def self.after_deposit_complete(work, _transition)
+    mailer = work_mailer(work)
+    job = if work.collection.review_enabled?
+            mailer.approved_email
+          elsif work.version > 1
+            mailer.new_version_deposited_email
+          else
+            mailer.deposited_email
+          end
+    job.deliver_later
+  end
+
+  def self.after_rejected(work, _transition)
+    work_mailer(work).reject_email.deliver_later
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def self.after_submit_for_review(work, _transition)
+    work_mailer(work).reject_email.deliver_later
+    (work.collection.reviewers + work.collection.managers - [work.depositor]).each do |recipient|
+      ReviewersMailer.with(user: recipient, work: work).submitted_email.deliver_later
+    end
+    work_mailer(work).submitted_email.deliver_later
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def self.work_mailer(work)
+    WorksMailer.with(user: work.depositor, work: work)
+  end
+  private_class_method :work_mailer
+end


### PR DESCRIPTION


## Why was this change made?

This contains business logic that is triggered when state transitions occur. Business logic should not be in the model class.

## How was this change tested?



## Which documentation and/or configurations were updated?



