### PR TITLE
Display currently selected license in work form

### DIFF
--- a/app/components/works/license_component.html.erb
+++ b/app/components/works/license_component.html.erb
@@ -4,7 +4,7 @@
     <%= form.label :license, class: 'col-sm-2 col-form-label' %>
     <div class="col-sm-10">
       <%= form.select :license,
-                      grouped_options_for_select(License.grouped_options),
+                      grouped_options_for_select(License.grouped_options, license),
                       {}, class: "form-select" %>
     </div>
   </div>

--- a/app/components/works/license_component.rb
+++ b/app/components/works/license_component.rb
@@ -9,5 +9,11 @@ module Works
     end
 
     attr_reader :form
+
+    delegate :license, to: :reform
+
+    def reform
+      form.object
+    end
   end
 end

--- a/spec/components/works/license_component_spec.rb
+++ b/spec/components/works/license_component_spec.rb
@@ -4,10 +4,22 @@
 require 'rails_helper'
 
 RSpec.describe Works::LicenseComponent do
-  let(:form) { instance_double(ActionView::Helpers::FormBuilder, label: nil, select: nil) }
+  let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
+  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:work) { build(:work) }
+  let(:work_form) { WorkForm.new(work) }
 
-  it 'renders the component' do
-    expect(render_inline(described_class.new(form: form)).to_html)
-      .to include('Select a license')
+  context 'with no license selected' do
+    it 'renders the component' do
+      expect(rendered.to_html).to include('Select a license')
+    end
+  end
+
+  context 'with a license selected' do
+    let(:work) { build(:work, license: 'ODbL-1.0') }
+
+    it 'renders the component with the correct license selected' do
+      expect(rendered.to_html).to include('<option selected value="ODbL-1.0">')
+    end
   end
 end


### PR DESCRIPTION

## Why was this change made?

This fixes a bug where the topmost license is always presented as the currently selected one.


## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None

