### PR TITLE
Render work form creation & embargo date radio buttons based on current values

### DIFF
--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -25,8 +25,10 @@ class DraftWorkForm < Reform::Form
   end)
   property :created_edtf, edtf: true, range: true
   property :published_edtf, edtf: true
-  property :release, virtual: true, default: 'immediate'
-  property :embargo_date, embargo_date: true, assign_if: ->(params) { params['release'] == 'embargo' }
+  property :release, virtual: true, prepopulator: (proc do |*|
+    self.release = embargo_date.present? ? 'embargo' : 'immediate'
+  end)
+  property :embargo_date, embargo_date: true
 
   validates :created_edtf, created_in_past: true
   validates :published_edtf, created_in_past: true

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -20,9 +20,11 @@ class DraftWorkForm < Reform::Form
   property :access
   property :license
   property :agree_to_terms
+  property :created_type, virtual: true, prepopulator: (proc do |*|
+    self.created_type = created_edtf.is_a?(EDTF::Interval) ? 'range' : 'single'
+  end)
   property :created_edtf, edtf: true, range: true
   property :published_edtf, edtf: true
-
   property :release, virtual: true, default: 'immediate'
   property :embargo_date, embargo_date: true, assign_if: ->(params) { params['release'] == 'embargo' }
 

--- a/app/forms/edtf.rb
+++ b/app/forms/edtf.rb
@@ -24,7 +24,6 @@ module Edtf
       property "#{prop_name}_range(4i)", virtual: true
       property "#{prop_name}_range(5i)", virtual: true
       property "#{prop_name}_range(6i)", virtual: true
-      property "#{prop_name}_type", virtual: true, default: 'single'
     end
   end
 

--- a/app/forms/embargo_date_params_filter.rb
+++ b/app/forms/embargo_date_params_filter.rb
@@ -9,7 +9,11 @@ class EmbargoDateParamsFilter
       next unless dfn[:embargo_date]
 
       name = dfn[:name]
-      date_attributes[name] = deserialize(params, name) if dfn[:assign_if].call(params)
+      date_attributes[name] = if params.slice(*release_params).values.include?('immediate') # rubocop:disable Performance/InefficientHashSearch
+                                nil # Do not attempt to deserialize date if release is immediate
+                              else
+                                deserialize(params, name)
+                              end
     end
 
     params.merge(date_attributes)
@@ -20,5 +24,12 @@ class EmbargoDateParamsFilter
     month = params.delete("#{date_attribute}(2i)").to_i
     day = params.delete("#{date_attribute}(3i)").to_i
     Date.new(year, month, day) if Date.valid_date?(year, month, day)
+  end
+
+  private
+
+  # Work and Collection models use differently named release params
+  def release_params
+    %w[release release_option]
   end
 end

--- a/sorbet/rails-rbi/mailers/collections_mailer.rbi
+++ b/sorbet/rails-rbi/mailers/collections_mailer.rbi
@@ -3,6 +3,9 @@
 # Please rerun bundle exec rake rails_rbi:mailers to regenerate.
 class CollectionsMailer
   sig { returns(ActionMailer::MessageDelivery) }
+  def self.collection_activity; end
+
+  sig { returns(ActionMailer::MessageDelivery) }
   def self.deposit_access_removed_email; end
 
   sig { returns(ActionMailer::MessageDelivery) }

--- a/spec/components/works/dates_component_spec.rb
+++ b/spec/components/works/dates_component_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Works::DatesComponent do
   let(:work_form) { WorkForm.new(work) }
   let(:rendered) { render_inline(described_class.new(form: form, min_year: 1000, max_year: 2020)) }
 
+  before do
+    work_form.prepopulate!
+  end
+
   it 'renders the component' do
     expect(rendered.to_html).to include('Enter dates related to your deposit')
   end
@@ -20,6 +24,9 @@ RSpec.describe Works::DatesComponent do
       expect(rendered.css('#work_published_year').first['value']).to eq '2020'
       expect(rendered.css('#work_published_month option[@selected="selected"]').first['value']).to eq '2'
       expect(rendered.css('#work_published_day option[@selected="selected"]').first['value']).to eq '14'
+
+      expect(rendered.css('#created_type_range[@checked]')).to be_present
+      expect(rendered.css('#created_type_single[@checked]')).not_to be_present
 
       expect(rendered.css('#work_created_range_start_year').first['value']).to eq '2020'
       expect(rendered.css('#work_created_range_start_month option[@selected="selected"]').first['value']).to eq '3'
@@ -35,6 +42,9 @@ RSpec.describe Works::DatesComponent do
     let(:work) { build(:work, :with_creation_date) }
 
     it 'renders the component' do
+      expect(rendered.css('#created_type_single[@checked]')).to be_present
+      expect(rendered.css('#created_type_range[@checked]')).not_to be_present
+
       expect(rendered.css('#work_created_year').first['value']).to eq '2020'
       expect(rendered.css('#work_created_month option[@selected="selected"]').first['value']).to eq '3'
       expect(rendered.css('#work_created_day option[@selected="selected"]').first['value']).to eq '8'

--- a/spec/components/works/embargo_component_spec.rb
+++ b/spec/components/works/embargo_component_spec.rb
@@ -9,14 +9,28 @@ RSpec.describe Works::EmbargoComponent do
   let(:work_form) { WorkForm.new(work) }
   let(:rendered) { render_inline(described_class.new(form: form)) }
 
+  before do
+    work_form.prepopulate!
+  end
+
   it 'renders the component' do
     expect(rendered.to_html)
       .to include('Manage release of this deposit for discovery and download after publication')
   end
 
+  it 'checks the immediate release radio button' do
+    expect(rendered.css('#release_immediate[@checked]')).to be_present
+    expect(rendered.css('#release_embargo[@checked]')).not_to be_present
+  end
+
   context 'when the embargo date is set' do
     let(:embargo_date) { work.embargo_date }
     let(:work) { build(:work, :embargoed) }
+
+    it 'checks the embargo release radio button' do
+      expect(rendered.css('#release_embargo[@checked]')).to be_present
+      expect(rendered.css('#release_immediate[@checked]')).not_to be_present
+    end
 
     it 'renders the year' do
       expect(rendered.css('#work_embargo_year option[@selected]').first['value'])

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -17,11 +17,12 @@ FactoryBot.define do
     state { 'first_draft' }
     collection
 
-    factory :valid_deposited_work do
-      deposited
-      with_keywords
-      with_contributors
-      with_attached_file
+    factory :valid_work do
+      with_required_associations
+
+      factory :valid_deposited_work do
+        deposited
+      end
     end
   end
 
@@ -31,6 +32,12 @@ FactoryBot.define do
 
   trait :embargoed do
     embargo_date { 30.months.from_now }
+  end
+
+  trait :with_required_associations do
+    with_keywords
+    with_contributors
+    with_attached_file
   end
 
   trait :with_creation_date_range do

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -56,30 +56,32 @@ RSpec.describe WorkForm do
   describe 'contributors validation' do
     let(:contributor_error) { { contributors: ['Please add at least one contributor.'] } }
 
+    before do
+      form.validate(contributors: contributors)
+    end
+
     context 'with no contributors' do
+      let(:contributors) { [] }
+
       it 'does not validate' do
-        expect(form).not_to be_valid
         expect(form.errors.messages).to include(contributor_error)
       end
     end
 
     context 'with contributors' do
-      let(:work) { build(:valid_work) }
+      let(:contributors) do
+        [
+          { '_destroy' => 'false', 'first_name' => 'Naomi',
+            'last_name' => 'Dushay', 'full_name' => 'Stanford', 'role_term' => 'person|Author' },
+          { '_destroy' => 'false', 'first_name' => 'Naomi',
+            'last_name' => 'Dushay', 'full_name' => 'The Leland Stanford Junior University',
+            'role_term' => 'organization|Host institution' }
+        ]
+      end
 
-      it 'validates' do
-        expect(form).to be_valid
+      it 'validates with contributors in place' do
         expect(form.errors.messages).not_to include(contributor_error)
       end
-    end
-  end
-
-  describe 'embargo date validation' do
-    let(:embargo_error) { { 'embargo-date' => ['Must provide all parts'] } }
-    let(:work) { build(:valid_work, :embargoed) }
-
-    it 'validates' do
-      expect(form).to be_valid
-      expect(form.errors.messages).not_to include(embargo_error)
     end
   end
 
@@ -112,28 +114,6 @@ RSpec.describe WorkForm do
     it 'validates' do
       form.validate(license: License.license_list.first)
       expect(form.errors.messages).not_to include({ license: ['is not included in the list'] })
-    end
-  end
-
-  describe 'created_type prepopulation' do
-    before do
-      form.prepopulate!
-    end
-
-    context 'when created_edtf is a single date' do
-      let(:work) { build(:valid_work, :with_creation_date) }
-
-      it 'is set to "single"' do
-        expect(form.created_type).to eq('single')
-      end
-    end
-
-    context 'when created_edtf is a range' do
-      let(:work) { build(:valid_work, :with_creation_date_range) }
-
-      it 'is set to "range"' do
-        expect(form.created_type).to eq('range')
-      end
     end
   end
 

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -115,6 +115,28 @@ RSpec.describe WorkForm do
     end
   end
 
+  describe 'created_type prepopulation' do
+    before do
+      form.prepopulate!
+    end
+
+    context 'when created_edtf is a single date' do
+      let(:work) { build(:valid_work, :with_creation_date) }
+
+      it 'is set to "single"' do
+        expect(form.created_type).to eq('single')
+      end
+    end
+
+    context 'when created_edtf is a range' do
+      let(:work) { build(:valid_work, :with_creation_date_range) }
+
+      it 'is set to "range"' do
+        expect(form.created_type).to eq('range')
+      end
+    end
+  end
+
   describe 'type and subtype validation' do
     it 'does not validate with an invalid work type' do
       form.validate(work_type: 'a pile of something')

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -64,13 +64,22 @@ RSpec.describe WorkForm do
     end
 
     context 'with contributors' do
-      let(:embargo) { { embargo_date: Date.new } }
-      let(:work) { build(:work, :with_contributors, :with_attached_file, :with_keywords, embargo) }
+      let(:work) { build(:valid_work) }
 
       it 'validates' do
         expect(form).to be_valid
         expect(form.errors.messages).not_to include(contributor_error)
       end
+    end
+  end
+
+  describe 'embargo date validation' do
+    let(:embargo_error) { { 'embargo-date' => ['Must provide all parts'] } }
+    let(:work) { build(:valid_work, :embargoed) }
+
+    it 'validates' do
+      expect(form).to be_valid
+      expect(form.errors.messages).not_to include(embargo_error)
     end
   end
 

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -347,7 +347,8 @@ RSpec.describe 'Create a new work' do
             contact_email: '',
             abstract: '',
             license: License.license_list.first,
-            work_type: 'text'
+            work_type: 'text',
+            release: 'immediate'
           }
         end
 
@@ -382,6 +383,7 @@ RSpec.describe 'Create a new work' do
             abstract: '',
             license: License.license_list.first,
             work_type: 'text',
+            release: 'immediate',
             citation: 'manual one',
             citation_auto: 'Zappa, F. (2020). Test publication yy/mm date in past. ' \
               'Stanford Digital Repository. Available at :link:',


### PR DESCRIPTION
Fixes #771

## Why was this change made?

To fix a bug in deployed environments that could change values previously set by the user.

Also includes:
* Disentangle embargo and contributor validation in work form test 
  * And add a new factory for valid works for more descriptive factory names in specs

## How was this change tested?

CI and in the browser locally and in QA

## Which documentation and/or configurations were updated?

None

