### PR TITLE
update embargo release options and reduce duplication

### DIFF
--- a/app/components/collections/form_component.html.erb
+++ b/app/components/collections/form_component.html.erb
@@ -77,12 +77,7 @@
           between date of deposit and
         <% end %>
         <%= form.select :release_duration,
-          options_for_select([['1 month from date of deposit', '1 month'],
-                              ['3 months from date of deposit', '3 month'],
-                              ['6 months from date of deposit', '6 month'],
-                              ['1 year from date of deposit', '1 year'],
-                              ['2 years from date of deposit', '2 years'],
-                              ['3 years from date of deposit', '3 years']]),
+          options_for_select(collection_form.class::EMBARGO_RELEASE_DURATION_OPTIONS),
                               {},
                               class: 'form-select release-duration' %>
       </div>

--- a/app/forms/draft_collection_form.rb
+++ b/app/forms/draft_collection_form.rb
@@ -6,6 +6,11 @@ class DraftCollectionForm < Reform::Form
   extend T::Sig
   feature EmbargoDate
 
+  EMBARGO_RELEASE_DURATION_OPTIONS = [['6 months from date of deposit', '6 month'],
+                                      ['1 year from date of deposit', '1 year'],
+                                      ['2 years from date of deposit', '2 years'],
+                                      ['3 years from date of deposit', '3 years']].freeze
+
   property :name
   property :description
   property :contact_email
@@ -39,9 +44,7 @@ class DraftCollectionForm < Reform::Form
   validate :reviewable_form
   validates :release_date, embargo_date: true
   validates :release_option, presence: true, inclusion: { in: %w[immediate delay depositor-selects] }
-  validates :release_duration, inclusion: {
-    in: ['1 month', '2 months', '6 months', '1 year', '2 years', '3 years']
-  }, allow_blank: true
+  validates :release_duration, inclusion: { in: EMBARGO_RELEASE_DURATION_OPTIONS.map(&:last) }, allow_blank: true
 
   def sync(*)
     update_depositors

--- a/sorbet/rails-rbi/mailers/collections_mailer.rbi
+++ b/sorbet/rails-rbi/mailers/collections_mailer.rbi
@@ -3,6 +3,9 @@
 # Please rerun bundle exec rake rails_rbi:mailers to regenerate.
 class CollectionsMailer
   sig { returns(ActionMailer::MessageDelivery) }
+  def self.collection_activity; end
+
+  sig { returns(ActionMailer::MessageDelivery) }
   def self.deposit_access_removed_email; end
 
   sig { returns(ActionMailer::MessageDelivery) }

--- a/spec/requests/create_collection_spec.rb
+++ b/spec/requests/create_collection_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'Create a collection' do
             'release_date(1i)' => '2020',
             'release_date(2i)' => '7',
             'release_date(3i)' => '14',
-            'release_duration' => '1 month',
+            'release_duration' => '1 year',
             related_links_attributes: related_links
           }
         end


### PR DESCRIPTION
## Why was this change made?

Fix #818 - adjust the embargo release date options in the collection form to match the spec.  Also, I refactored the code to move the options to a single location (used in both the form and the validation of the values).

## How was this change tested?

Unit tests and localhost browser

## Which documentation and/or configurations were updated?

None
