### PR TITLE
make collection form consistent with other attribute retrieval

### DIFF
--- a/app/components/collections/form_component.html.erb
+++ b/app/components/collections/form_component.html.erb
@@ -77,7 +77,7 @@
           between date of deposit and
         <% end %>
         <%= form.select :release_duration,
-          options_for_select(DraftCollectionForm::EMBARGO_RELEASE_DURATION_OPTIONS, selected: release_duration),
+          options_for_select(embargo_release_duration_options, selected: release_duration),
                               {},
                               class: 'form-select release-duration' %>
       </div>

--- a/app/components/collections/form_component.html.erb
+++ b/app/components/collections/form_component.html.erb
@@ -77,7 +77,7 @@
           between date of deposit and
         <% end %>
         <%= form.select :release_duration,
-          options_for_select(DraftCollectionForm::EMBARGO_RELEASE_DURATION_OPTIONS, selected: collection_form.release_duration),
+          options_for_select(DraftCollectionForm::EMBARGO_RELEASE_DURATION_OPTIONS, selected: release_duration),
                               {},
                               class: 'form-select release-duration' %>
       </div>

--- a/app/components/collections/form_component.rb
+++ b/app/components/collections/form_component.rb
@@ -15,6 +15,10 @@ module Collections
       release_date&.year || Time.zone.today.year
     end
 
+    def release_duration
+      collection_form.release_duration
+    end
+
     def release_date_month
       release_date&.month
     end

--- a/app/components/collections/form_component.rb
+++ b/app/components/collections/form_component.rb
@@ -6,17 +6,19 @@ module Collections
   class FormComponent < ApplicationComponent
     attr_reader :collection_form
 
+    delegate :release_duration, to: :collection_form
+
     sig { params(collection_form: DraftCollectionForm).void }
     def initialize(collection_form:)
       @collection_form = collection_form
     end
 
-    def release_date_year
-      release_date&.year || Time.zone.today.year
+    def embargo_release_duration_options
+      DraftCollectionForm::EMBARGO_RELEASE_DURATION_OPTIONS
     end
 
-    def release_duration
-      collection_form.release_duration
+    def release_date_year
+      release_date&.year || Time.zone.today.year
     end
 
     def release_date_month
@@ -29,15 +31,10 @@ module Collections
 
     sig { returns(T.nilable(Date)) }
     def release_date
-      case reform.release_date
+      case collection_form.release_date
       when Date
-        T.cast(reform.release_date, Date)
+        T.cast(collection_form.release_date, Date)
       end
-    end
-
-    sig { returns(DraftCollectionForm) }
-    def reform
-      collection_form
     end
   end
 end

--- a/sorbet/rails-rbi/mailers/collections_mailer.rbi
+++ b/sorbet/rails-rbi/mailers/collections_mailer.rbi
@@ -12,5 +12,11 @@ class CollectionsMailer
   def self.invitation_to_deposit_email; end
 
   sig { returns(ActionMailer::MessageDelivery) }
+  def self.manage_access_removed_email; end
+
+  sig { returns(ActionMailer::MessageDelivery) }
+  def self.participants_changed_email; end
+
+  sig { returns(ActionMailer::MessageDelivery) }
   def self.review_access_granted_email; end
 end

--- a/sorbet/rails-rbi/mailers/works_mailer.rbi
+++ b/sorbet/rails-rbi/mailers/works_mailer.rbi
@@ -15,6 +15,9 @@ class WorksMailer
   def self.new_version_deposited_email; end
 
   sig { returns(ActionMailer::MessageDelivery) }
+  def self.new_version_reminder_email; end
+
+  sig { returns(ActionMailer::MessageDelivery) }
   def self.reject_email; end
 
   sig { returns(ActionMailer::MessageDelivery) }


### PR DESCRIPTION
## Why was this change made?

Make the collection form params consistent and get rid of reform indirection


## How was this change tested?

Unit tests


## Which documentation and/or configurations were updated?



