### PR TITLE
Show returned and version draft works as in progress in dashboard

### DIFF
--- a/app/components/dashboard/in_progress_component.html.erb
+++ b/app/components/dashboard/in_progress_component.html.erb
@@ -1,0 +1,9 @@
+<section class="mb-5">
+  <header>Deposits in progress</header>
+  <% in_progress.each do |work| %>
+    <div>
+      <%= Dashboard::CollectionHeaderComponent.new(collection: work.collection).name %> &gt; <%= link_to Works::DetailComponent.new(work: work).title, edit_work_path(work) %>
+      <%= render Works::DeleteComponent.new(work: work) %>
+    </div>
+  <% end %>
+</section>

--- a/app/components/dashboard/in_progress_component.rb
+++ b/app/components/dashboard/in_progress_component.rb
@@ -1,0 +1,16 @@
+# typed: true
+# frozen_string_literal: true
+
+module Dashboard
+  # Renders a list of works in progress
+  class InProgressComponent < ApplicationComponent
+    sig { params(presenter: DashboardPresenter).void }
+    def initialize(presenter:)
+      @presenter = presenter
+    end
+
+    attr_reader :presenter
+
+    delegate :in_progress, to: :presenter
+  end
+end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,7 +1,7 @@
 # typed: false
 # frozen_string_literal: true
 
-# Displays the list of collections to the user
+# Displays the list of collections and works to the user
 class DashboardsController < ApplicationController
   before_action :authenticate_user!
   verify_authorized
@@ -11,9 +11,10 @@ class DashboardsController < ApplicationController
     @presenter = DashboardPresenter.new(
       collections: authorized_scope(Collection.all, as: :deposit),
       approvals: Work.with_state(:pending_approval)
-                      .joins(collection: :reviewers)
-                      .where('reviewers.user_id' => current_user),
-      drafts: Work.with_state(:first_draft).where(depositor: current_user)
+                     .joins(collection: :reviewers)
+                     .where('reviewers.user_id' => current_user),
+      in_progress: Work.with_state(:first_draft, :version_draft, :rejected)
+                       .where(depositor: current_user)
     )
 
     @presenter.work_stats = StatBuilder.build_stats if user_with_groups.administrator?

--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -6,18 +6,18 @@ class DashboardPresenter
   extend T::Sig
 
   sig do
-    params(drafts: ActiveRecord::Relation,
+    params(in_progress: ActiveRecord::Relation,
            approvals: ActiveRecord::Relation,
            collections: ActiveRecord::Relation).void
   end
-  def initialize(drafts:, approvals:, collections:)
-    @drafts = drafts
+  def initialize(in_progress:, approvals:, collections:)
+    @in_progress = in_progress
     @approvals = approvals
     @collections = collections
   end
 
   sig { returns(ActiveRecord::Relation) }
-  attr_reader :drafts
+  attr_reader :in_progress
 
   sig { returns(ActiveRecord::Relation) }
   attr_reader :approvals

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -1,15 +1,6 @@
 <main class="mb-3 mb-md-5" id="content">
   <div class="container px-4 px-md-3" id="dashboard">
-    <section class="mb-5">
-      <header>Deposits in progress</header>
-      <% @presenter.drafts.each do |draft| %>
-        <div>
-          <%= Dashboard::CollectionHeaderComponent.new(collection: draft.collection).name %> &gt; <%= link_to Works::DetailComponent.new(work: draft).title, edit_work_path(draft) %>
-          <%= render Works::DeleteComponent.new(work: draft) %>
-        </div>
-      <% end %>
-    </section>
-
+    <%= render Dashboard::InProgressComponent.new(presenter: @presenter) %>
     <%= render Dashboard::ApprovalsComponent.new(presenter: @presenter) %>
 
     <section data-controller="work-type">

--- a/spec/components/dashboard/in_progress_component_spec.rb
+++ b/spec/components/dashboard/in_progress_component_spec.rb
@@ -1,0 +1,42 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Dashboard::InProgressComponent, type: :component do
+  let(:presenter) do
+    DashboardPresenter.new(
+      in_progress: works,
+      approvals: Work.none,
+      collections: Collection.none
+    )
+  end
+  let(:rendered) { render_inline(described_class.new(presenter: presenter)) }
+
+  before do
+    allow(controller).to receive(:allowed_to?).and_return(true)
+    create(:work)
+    create(:work)
+    create(:work)
+  end
+
+  context 'when presenter has zero in progress works' do
+    let(:works) { Work.none }
+
+    it 'renders the component with a header alone' do
+      expect(rendered.to_html).to include('Deposits in progress')
+      expect(rendered.to_html).not_to include('Test title')
+    end
+  end
+
+  context 'when presenter has one or more in progress works' do
+    let(:works) { Work.all }
+
+    it 'renders the component with works' do
+      expect(rendered.to_html).to include('Deposits in progress')
+      works.pluck(:title).each do |title|
+        expect(rendered.to_html).to include(title)
+      end
+    end
+  end
+end

--- a/spec/features/mediated_deposit_versioning_spec.rb
+++ b/spec/features/mediated_deposit_versioning_spec.rb
@@ -38,7 +38,9 @@ RSpec.describe 'Edit a new version of a work in a collection using mediated depo
       click_button('Submit')
 
       visit dashboard_path
-      click_link new_work_title
+      within('.collections') do
+        click_link new_work_title
+      end
       expect(page).to have_content(rejection_reason)
 
       find("a[aria-label='Edit #{new_work_title}']").click

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -48,6 +48,29 @@ RSpec.describe 'Dashboard requests' do
     end
   end
 
+  context 'when user has in progress deposits in different states' do
+    before do
+      sign_in user
+      create(:work, depositor: user, state: 'first_draft', title: 'I am a first draft')
+      create(:work, depositor: user, state: 'version_draft', title: 'I am a version draft')
+      create(:work, depositor: user, state: 'rejected', title: 'I am rejected')
+      create(:work, depositor: user, state: 'deposited', title: 'I am deposited')
+      create(:work, depositor: user, state: 'depositing', title: 'I am depositing')
+      create(:work, depositor: user, state: 'pending_approval', title: 'I am pending approval')
+    end
+
+    it 'shows draft and rejected deposits as being in progress' do
+      get '/dashboard'
+      expect(response).to be_successful
+      expect(response.body).to include('I am a first draft')
+      expect(response.body).to include('I am a version draft')
+      expect(response.body).to include('I am rejected')
+      expect(response.body).not_to include('I am deposited')
+      expect(response.body).not_to include('I am depositing')
+      expect(response.body).not_to include('I am pending approval')
+    end
+  end
+
   context 'when user has the collection creator LDAP role' do
     before { sign_in user, groups: ['dlss:hydrus-app-collection-creators'] }
 


### PR DESCRIPTION
Fixes #847

## Why was this change made?

This PR adds to the "in progress" section of the dashboard, which previously displayed only works in the first draft state, by also displaying works in the version draft and rejected states. As part of this work, rename the `drafts` attr of the DashboardPresenter to be more accurate, and extract a view component for this section of the dashboard.

## How was this change tested?

CI, and tested by @amyehodge in QA

## Which documentation and/or configurations were updated?

None

