### PR TITLE
Tag works and collections with H2 project tag

### DIFF
--- a/app/services/collection_generator.rb
+++ b/app/services/collection_generator.rb
@@ -33,7 +33,8 @@ class CollectionGenerator
     {
       access: access,
       administrative: {
-        hasAdminPolicy: Settings.h2.hydrus_apo
+        hasAdminPolicy: Settings.h2.hydrus_apo,
+        partOfProject: Settings.h2.project_tag
       },
       identification: {},
       label: collection.name,

--- a/app/services/request_generator.rb
+++ b/app/services/request_generator.rb
@@ -33,7 +33,8 @@ class RequestGenerator
     {
       access: AccessGenerator.generate(work: work),
       administrative: {
-        hasAdminPolicy: Settings.h2.hydrus_apo
+        hasAdminPolicy: Settings.h2.hydrus_apo,
+        partOfProject: Settings.h2.project_tag
       },
       identification: {
         sourceId: "hydrus:#{work.id}" # TODO: what should this be?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,6 +16,7 @@ remote_user_headers:
 
 h2:
   hydrus_apo: 'druid:zx485kb6348'
+  project_tag: 'H2'
 
 earliest_year: 1000
 

--- a/spec/services/collection_generator_spec.rb
+++ b/spec/services/collection_generator_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 
 RSpec.describe CollectionGenerator do
   let(:model) { described_class.generate_model(collection: collection) }
+  let(:project_tag) { Settings.h2.project_tag }
 
   context 'without a druid' do
     let(:collection) { build(:collection, name: 'Test title', id: 7) }
@@ -15,7 +16,8 @@ RSpec.describe CollectionGenerator do
         version: 0,
         access: { access: 'stanford' },
         administrative: {
-          hasAdminPolicy: 'druid:zx485kb6348'
+          hasAdminPolicy: 'druid:zx485kb6348',
+          partOfProject: project_tag
         },
         description: {
           title: [
@@ -43,7 +45,8 @@ RSpec.describe CollectionGenerator do
         version: 0,
         access: { access: 'stanford' },
         administrative: {
-          hasAdminPolicy: 'druid:zx485kb6348'
+          hasAdminPolicy: 'druid:zx485kb6348',
+          partOfProject: project_tag
         },
         description: {
           title: [

--- a/spec/services/request_generator_spec.rb
+++ b/spec/services/request_generator_spec.rb
@@ -4,9 +4,9 @@
 require 'rails_helper'
 
 RSpec.describe RequestGenerator do
-  let(:model) { described_class.generate_model(work: work) }
   let(:collection) { build(:collection, druid: 'druid:bc123df4567') }
-
+  let(:model) { described_class.generate_model(work: work) }
+  let(:project_tag) { Settings.h2.project_tag }
   let(:types_form) do
     [
       {
@@ -63,7 +63,8 @@ RSpec.describe RequestGenerator do
           version: 0,
           access: { access: 'world', download: 'world' },
           administrative: {
-            hasAdminPolicy: 'druid:zx485kb6348'
+            hasAdminPolicy: 'druid:zx485kb6348',
+            partOfProject: project_tag
           },
           description: {
             title: [
@@ -120,7 +121,8 @@ RSpec.describe RequestGenerator do
           version: 0,
           access: { access: 'world', download: 'world' },
           administrative: {
-            hasAdminPolicy: 'druid:zx485kb6348'
+            hasAdminPolicy: 'druid:zx485kb6348',
+            partOfProject: project_tag
           },
           description: {
             title: [
@@ -196,7 +198,8 @@ RSpec.describe RequestGenerator do
           version: 1,
           access: { access: 'world', download: 'world' },
           administrative: {
-            hasAdminPolicy: 'druid:zx485kb6348'
+            hasAdminPolicy: 'druid:zx485kb6348',
+            partOfProject: project_tag
           },
           description: {
             title: [
@@ -277,7 +280,8 @@ RSpec.describe RequestGenerator do
           externalIdentifier: 'druid:bk123gh4567',
           access: { access: 'world', download: 'world' },
           administrative: {
-            hasAdminPolicy: 'druid:zx485kb6348'
+            hasAdminPolicy: 'druid:zx485kb6348',
+            partOfProject: project_tag
           },
           description: {
             title: [


### PR DESCRIPTION
Fixes #838

## Why was this change made?


This commit attaches an attribute to the Cocina registration parameters that allows SDR to associate H2 works and collections with the "Project : H2" project tag, as requested by the P.O.

## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None

