### PR TITLE
Only allow access selection if collection is depositor-selects

### DIFF
--- a/app/components/works/embargo_component.rb
+++ b/app/components/works/embargo_component.rb
@@ -30,5 +30,9 @@ module Works
     def access_from_collection
       'TBD' # TODO: by https://github.com/sul-dlss/happy-heron/pull/884
     end
+
+    def default_access
+      Collection.find(reform.collection_id).access
+    end
   end
 end

--- a/app/components/works/embargo_component.rb
+++ b/app/components/works/embargo_component.rb
@@ -18,7 +18,9 @@ module Works
 
     # The access level is specified by the collection
     def user_can_set_access?
-      true # TODO: by https://github.com/sul-dlss/happy-heron/pull/884
+      return true if access_from_collection == 'depositor-selects'
+
+      false
     end
 
     def availability_from_collection
@@ -28,17 +30,7 @@ module Works
     end
 
     def access_from_collection
-      'TBD' # TODO: by https://github.com/sul-dlss/happy-heron/pull/884
-    end
-
-    def collection_access_restriction
-      reform.model.collection.access
-    end
-
-    def depositor_selects_access?
-      return true if collection_access_restriction == 'depositor-selects'
-
-      false
+      collection.access
     end
   end
 end

--- a/app/components/works/embargo_component.rb
+++ b/app/components/works/embargo_component.rb
@@ -31,10 +31,14 @@ module Works
       'TBD' # TODO: by https://github.com/sul-dlss/happy-heron/pull/884
     end
 
-    def default_access
-      return unless reform.collection_id
+    def collection_access_restriction
+      reform.model.collection.access
+    end
 
-      Collection.find_by(id: reform.collection_id)&.access
+    def depositor_selects_access?
+      return true if collection_access_restriction == 'depositor-selects'
+
+      false
     end
   end
 end

--- a/app/components/works/embargo_component.rb
+++ b/app/components/works/embargo_component.rb
@@ -32,7 +32,9 @@ module Works
     end
 
     def default_access
-      Collection.find(reform.collection_id).access
+      return unless reform.collection_id
+
+      Collection.find_by(id: reform.collection_id)&.access
     end
   end
 end

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -39,6 +39,7 @@ class DraftWorkForm < Reform::Form
     # Choose between using the user provided citation and the auto-generated citation
     params['citation'] = params.delete('citation_auto') if params['default_citation'] == 'true'
     deserialize_embargo(params)
+    access_from_collection(params)
     super(params)
   end
 
@@ -58,6 +59,12 @@ class DraftWorkForm < Reform::Form
     end
   end
   # rubocop:enable Metrics/AbcSize
+
+  def access_from_collection(params)
+    return if model.collection.access == 'depositor-selects'
+
+    params['access'] = model.collection.access
+  end
 
   collection :contributors,
              populator: ContributorPopulator.new(:contributors, Contributor),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,3 @@ en:
     last_modified: Modified
     number_of_files: Files
     persistent_link: Persistent link
-  access:
-    stanford: Stanford Community
-    world: Everyone

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,3 +35,6 @@ en:
     last_modified: Modified
     number_of_files: Files
     persistent_link: Persistent link
+  access:
+    stanford: Stanford Community
+    world: Everyone

--- a/spec/components/works/access_component_spec.rb
+++ b/spec/components/works/access_component_spec.rb
@@ -20,11 +20,8 @@ RSpec.describe Works::AccessComponent, type: :component do
   end
 
   context 'when collection access is depositor selects' do
-    let(:work) { build(:work) }
-
-    before do
-      work.collection.access = 'depositor-selects'
-    end
+    let(:work) { build(:work, collection: collection) }
+    let(:collection) { build(:collection, :depositor_selects_access, release_option: 'immediate') }
 
     it 'renders the access selector' do
       expect(rendered.css('#access')).to be_present

--- a/spec/components/works/access_component_spec.rb
+++ b/spec/components/works/access_component_spec.rb
@@ -4,13 +4,30 @@
 require 'rails_helper'
 
 RSpec.describe Works::AccessComponent, type: :component do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
+  let(:work) { build(:work, collection: collection) }
+  let(:collection) { build(:collection, release_option: 'immediate') }
+  let(:work_form) { WorkForm.new(work) }
+  let(:rendered) { render_inline(described_class.new(form: form)) }
 
-  # it "renders something useful" do
-  #   expect(
-  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
-  #   ).to include(
-  #     "Hello, components!"
-  #   )
-  # end
+  before do
+    work_form.prepopulate!
+  end
+
+  it 'renders the component' do
+    expect(rendered.to_html)
+      .to include('Select which audience you would like to have access to download')
+  end
+
+  context 'when collection access is depositor selects' do
+    let(:work) { build(:work) }
+
+    before do
+      work.collection.access = 'depositor-selects'
+    end
+
+    it 'renders the access selector' do
+      expect(rendered.css('#access')).to be_present
+    end
+  end
 end

--- a/spec/components/works/embargo_component_spec.rb
+++ b/spec/components/works/embargo_component_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Works::EmbargoComponent do
 
   before do
     work_form.prepopulate!
+    collection.access = 'depositor-selects'
   end
 
   it 'renders the component' do
@@ -40,26 +41,6 @@ RSpec.describe Works::EmbargoComponent do
 
     it 'renders the component' do
       expect(rendered.to_html).to include 'starting on September 07, 2030.'
-    end
-  end
-
-  context 'when collection access is depositor selects' do
-    let(:work) { build(:work) }
-
-    it 'renders the access selector' do
-      expect(rendered.css('#access')).to be_present
-    end
-  end
-
-  context 'when collection access is set to world' do
-    let(:work) { build(:work) }
-
-    before do
-      work.collection.access = 'world'
-    end
-
-    it 'does not render the access selector' do
-      expect(rendered.css('#access')).not_to be_present
     end
   end
 end

--- a/spec/components/works/embargo_component_spec.rb
+++ b/spec/components/works/embargo_component_spec.rb
@@ -6,14 +6,13 @@ require 'rails_helper'
 RSpec.describe Works::EmbargoComponent do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
   let(:work) { build(:work, collection: collection) }
-  let(:collection) { build(:collection, release_option: 'immediate') }
+  let(:collection) { build(:collection, :depositor_selects_access, release_option: 'immediate') }
 
   let(:work_form) { WorkForm.new(work) }
   let(:rendered) { render_inline(described_class.new(form: form)) }
 
   before do
     work_form.prepopulate!
-    collection.access = 'depositor-selects'
   end
 
   it 'renders the component' do

--- a/spec/components/works/embargo_component_spec.rb
+++ b/spec/components/works/embargo_component_spec.rb
@@ -42,4 +42,24 @@ RSpec.describe Works::EmbargoComponent do
       expect(rendered.to_html).to include 'starting on September 07, 2030.'
     end
   end
+
+  context 'when collection access is depositor selects' do
+    let(:work) { build(:work) }
+
+    it 'renders the access selector' do
+      expect(rendered.css('#access')).to be_present
+    end
+  end
+
+  context 'when collection access is set to world' do
+    let(:work) { build(:work) }
+
+    before do
+      work.collection.access = 'world'
+    end
+
+    it 'does not render the access selector' do
+      expect(rendered.css('#access')).not_to be_present
+    end
+  end
 end

--- a/spec/components/works/form_component_spec.rb
+++ b/spec/components/works/form_component_spec.rb
@@ -6,13 +6,12 @@ require 'rails_helper'
 RSpec.describe Works::FormComponent do
   let(:component) { described_class.new(work_form: work_form) }
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
-  let(:work) { build_stubbed(:work, collection: build(:collection, id: 7)) }
+  let(:work) { build_stubbed(:work, collection: build(:collection, :depositor_selects_access, id: 7)) }
   let(:work_form) { WorkForm.new(work) }
   let(:rendered) { render_inline(component) }
 
   before do
     allow(controller).to receive(:allowed_to?).and_return(true)
-    work.collection.access = 'depositor-selects'
   end
 
   it 'renders the component' do

--- a/spec/components/works/form_component_spec.rb
+++ b/spec/components/works/form_component_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Works::FormComponent do
 
   before do
     allow(controller).to receive(:allowed_to?).and_return(true)
+    work.collection.access = 'depositor-selects'
   end
 
   it 'renders the component' do

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     contact_email { 'email@example.com' }
     release_option { 'immediate' }
     release_date { '2020-10-09' }
-    access { 'MyString' }
+    access { 'world' }
     required_license { 'CC0-1.0' }
     default_license { nil }
     email_when_participants_changed { false }
@@ -63,5 +63,9 @@ FactoryBot.define do
 
   trait :email_when_participants_changed do
     email_when_participants_changed { true }
+  end
+
+  trait :depositor_selects_access do
+    access { 'depositor-selects' }
   end
 end

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 
 RSpec.describe 'Create a new work in a deposited collection', js: true do
   let(:user) { create(:user) }
-  let!(:collection) { create(:collection, :deposited, depositors: [user]) }
+  let!(:collection) { create(:collection, :deposited, :depositor_selects_access, depositors: [user]) }
 
   before do
     sign_in user, groups: ['dlss:hydrus-app-collection-creators']

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -128,6 +128,7 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
         expect(page).to have_content('2020-03-06/2020-10-30')
         expect(page).to have_content 'User provided abstract'
         expect(page).to have_content 'Citation from user input'
+        expect(page).to have_content 'Everyone'
         expect(page).to have_content('CC-PDDC Public Domain Dedication and Certification')
 
         visit dashboard_path

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -257,8 +257,7 @@ RSpec.describe 'Create a new work' do
                    'created_range(1i)' => '2020', 'created_range(2i)' => '3', 'created_range(3i)' => '4',
                    'created_range(4i)' => '2020', 'created_range(5i)' => '10', 'created_range(6i)' => '31',
                    'release' => 'embargo',
-                   'embargo_date(1i)' => embargo_year, 'embargo_date(2i)' => '4', 'embargo_date(3i)' => '4',
-                   access: collection.access)
+                   'embargo_date(1i)' => embargo_year, 'embargo_date(2i)' => '4', 'embargo_date(3i)' => '4')
         end
 
         it 'displays the work' do

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -278,11 +278,12 @@ RSpec.describe 'Create a new work' do
           expect(work.subtype).to eq ['Article', 'Presentation slides']
           expect(DepositJob).to have_received(:perform_later).with(work)
           expect(work.state).to eq 'depositing'
+          expect(work.access).to eq 'world'
         end
       end
 
       context 'with a minimal set' do
-        let(:collection) { create(:collection, :deposited, depositors: [user]) }
+        let(:collection) { create(:collection, :deposited, :depositor_selects_access, depositors: [user]) }
         let(:work_params) do
           {
             title: 'Test title',
@@ -295,7 +296,8 @@ RSpec.describe 'Create a new work' do
               '0' => { '_destroy' => 'false', 'label' => 'Feminism', 'uri' => 'http://id.worldcat.org/fast/922671' }
             },
             license: 'CC0-1.0',
-            release: 'immediate'
+            release: 'immediate',
+            access: 'stanford'
           }
         end
 

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe 'Create a new work' do
         allow(DepositJob).to receive(:perform_later)
       end
 
-      context 'when a collection allows embargo but sets access and with everything' do
+      context 'when a collection allows embargo but restricts access and with everything' do
         let(:collection) do
           create(:collection, :deposited, depositors: [user], release_option: 'depositor-selects')
         end

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe 'Create a new work' do
         allow(DepositJob).to receive(:perform_later)
       end
 
-      context 'when a collection allows embargo and with everything' do
+      context 'when a collection allows embargo but sets access and with everything' do
         let(:collection) do
           create(:collection, :deposited, depositors: [user], release_option: 'depositor-selects')
         end
@@ -257,7 +257,8 @@ RSpec.describe 'Create a new work' do
                    'created_range(1i)' => '2020', 'created_range(2i)' => '3', 'created_range(3i)' => '4',
                    'created_range(4i)' => '2020', 'created_range(5i)' => '10', 'created_range(6i)' => '31',
                    'release' => 'embargo',
-                   'embargo_date(1i)' => embargo_year, 'embargo_date(2i)' => '4', 'embargo_date(3i)' => '4')
+                   'embargo_date(1i)' => embargo_year, 'embargo_date(2i)' => '4', 'embargo_date(3i)' => '4',
+                   'access' => 'stanford') # an access selection that will be overwritten
         end
 
         it 'displays the work' do
@@ -278,7 +279,7 @@ RSpec.describe 'Create a new work' do
           expect(work.subtype).to eq ['Article', 'Presentation slides']
           expect(DepositJob).to have_received(:perform_later).with(work)
           expect(work.state).to eq 'depositing'
-          expect(work.access).to eq 'world'
+          expect(work.access).to eq 'world' # shows that `stanford` was overwritten
         end
       end
 

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -257,7 +257,8 @@ RSpec.describe 'Create a new work' do
                    'created_range(1i)' => '2020', 'created_range(2i)' => '3', 'created_range(3i)' => '4',
                    'created_range(4i)' => '2020', 'created_range(5i)' => '10', 'created_range(6i)' => '31',
                    'release' => 'embargo',
-                   'embargo_date(1i)' => embargo_year, 'embargo_date(2i)' => '4', 'embargo_date(3i)' => '4')
+                   'embargo_date(1i)' => embargo_year, 'embargo_date(2i)' => '4', 'embargo_date(3i)' => '4',
+                   access: collection.access)
         end
 
         it 'displays the work' do


### PR DESCRIPTION
## Why was this change made?

Fixes #697 by removing the selection list if the collection has an access right set other than `depositor-selects`.

When stanford:

<img width="831" alt="Screen Shot 2021-01-21 at 3 35 35 PM" src="https://user-images.githubusercontent.com/2294288/105425614-908e5580-5bfe-11eb-9c6c-dbe5493b3b0f.png">


## How was this change tested?

TBD

## Which documentation and/or configurations were updated?

N/A

