### PR TITLE
Avoid the deprecated errors API

### DIFF
--- a/app/views/collections/errors.json.jbuilder
+++ b/app/views/collections/errors.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-@form.errors.each do |key, value|
+@form.errors.each do |error|
   # Transform the property name in the model to the value used by the javascript:
-  json.set! key == :reviewer_sunets ? 'reviewerSunets' : key, [value]
+  json.set! error.attribute == :reviewer_sunets ? 'reviewerSunets' : error.attribute, [error.message]
 end

--- a/app/views/works/errors.json.jbuilder
+++ b/app/views/works/errors.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-@form.errors.each do |key, value|
+@form.errors.each do |error|
   # Transform the property name in the model to the value used by the javascript:
-  json.set! normalize_key(key), [value]
+  json.set! normalize_key(error.attribute), [error.message]
 end


### PR DESCRIPTION


## Why was this change made?

Rails 6.1 has a new errors API

## How was this change tested?



## Which documentation and/or configurations were updated?



