### PR TITLE
Fix the rack configuration for Rails 6.1

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -5,4 +5,5 @@
 
 require_relative 'config/environment'
 
+run Rails.application
 Rails.application.load_server


### PR DESCRIPTION
## Why was this change made?
Without this change the server won't start and will give the error:
```
/Users/jcoyne85/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:233:in `to_app': missing run or map statement (RuntimeError)
```


## How was this change tested?



## Which documentation and/or configurations were updated?



