### PR TITLE
add confirmation to cancel buttons on edit pages

### DIFF
--- a/app/components/collections/cancel_component.html.erb
+++ b/app/components/collections/cancel_component.html.erb
@@ -1,1 +1,2 @@
-<%= link_to 'Cancel', dashboard_path %>
+<%= link_to 'Cancel', dashboard_path,
+  data: { confirm: 'Are you sure you want to leave this page? Your changes will not be saved.' } %>

--- a/app/components/works/cancel_component.html.erb
+++ b/app/components/works/cancel_component.html.erb
@@ -1,1 +1,2 @@
-<%= link_to 'Cancel', collection_works_path(work.collection) %>
+<%= link_to 'Cancel', collection_works_path(work.collection),
+    data: { confirm: 'Are you sure you want to leave this page? Your changes will not be saved.' } %>

--- a/spec/features/create_new_collection_spec.rb
+++ b/spec/features/create_new_collection_spec.rb
@@ -34,5 +34,29 @@ RSpec.describe 'Create a new collection', js: true do
       # We should not see the delete button for this collection since it is not a draft
       expect(page).not_to have_selector("[aria-label='Delete #{Collection.last.name}']")
     end
+
+    it 'shows a confirmation if you cancel the collection deposit and goes back if confirmed' do
+      visit dashboard_path
+
+      click_link '+ Create a new collection'
+
+      accept_confirm do
+        click_link 'Cancel'
+      end
+
+      expect(page).to have_current_path(dashboard_path)
+    end
+
+    it 'shows a confirmation if you cancel the collection deposit and stays on the page if not confirmed' do
+      visit dashboard_path
+
+      click_link '+ Create a new collection'
+
+      dismiss_confirm do
+        click_link 'Cancel'
+      end
+
+      expect(page).to have_current_path(new_collection_path)
+    end
   end
 end

--- a/spec/features/edit_draft_work_spec.rb
+++ b/spec/features/edit_draft_work_spec.rb
@@ -40,5 +40,29 @@ RSpec.describe 'Edit a draft work', js: true do
       # Attached file should now be gone
       expect(page).not_to have_content(work.attached_files.first.filename.to_s)
     end
+
+    it 'shows a confirmation if you cancel the deposit and goes back if confirmed' do
+      visit dashboard_path
+
+      click_link work.title
+
+      accept_confirm do
+        click_link 'Cancel'
+      end
+
+      expect(page).to have_current_path(collection_works_path(work.collection))
+    end
+
+    it 'shows a confirmation if you cancel the deposit and stays on the page if not confirmed' do
+      visit dashboard_path
+
+      click_link work.title
+
+      dismiss_confirm do
+        click_link 'Cancel'
+      end
+
+      expect(page).to have_current_path(edit_work_path(work))
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #892 - add a confirmation to the cancel button shown on edit pages to verify user will lose changes if clicked.  Already discussed with Astrid and Amy.

## How was this change tested?

Localhost browser

## Which documentation and/or configurations were updated?

None

