### PR TITLE
Disable child select elements of unselected radio buttons in collection form

### DIFF
--- a/app/components/collections/form_component.html.erb
+++ b/app/components/collections/form_component.html.erb
@@ -48,17 +48,17 @@
   <section id="release_details">
     <header>Manage release of deposits for discovery and download</header>
 
-    <fieldset class="mb-5 release-option">
+    <fieldset class="mb-5 release-option" data-controller="complex-radio">
       <legend class="h5">When will files on deposits to this collection be downloadable?</legend>
-      <div class="form-check">
-        <%= form.radio_button :release_option, 'immediate', class: "form-check-input" %>
+      <div class="form-check" data-complex-radio-target="selection">
+        <%= form.radio_button :release_option, 'immediate', class: "form-check-input", data: { action: 'complex-radio#disableUnselectedInputs' } %>
         <%= form.label 'release_option_immediate', class: "form-check-label" do %>
           Immediately
         <% end %>
       </div>
 
-      <div class="form-check">
-        <%= form.radio_button :release_option, 'delay', class: "form-check-input" %>
+      <div class="form-check" data-complex-radio-target="selection">
+        <%= form.radio_button :release_option, 'delay', class: "form-check-input", data: { action: 'complex-radio#disableUnselectedInputs' } %>
         <%= form.label 'release_option_delay', class: "form-check-label" do %>
           Delay release until
         <% end %>
@@ -78,8 +78,8 @@
         </div>
       </div>
 
-      <div class="form-check">
-        <%= form.radio_button :release_option, 'depositor-selects', class: "form-check-input" %>
+      <div class="form-check" data-complex-radio-target="selection">
+        <%= form.radio_button :release_option, 'depositor-selects', class: "form-check-input", data: { action: 'complex-radio#disableUnselectedInputs' } %>
         <%= form.label 'release_option_depositor-selects', class: "form-check-label" do %>
           Depositor selects a date
         <% end %>

--- a/app/components/collections/workflow_review_component.rb
+++ b/app/components/collections/workflow_review_component.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 module Collections

--- a/app/javascript/controllers/complex_radio_controller.js
+++ b/app/javascript/controllers/complex_radio_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = ["selection"]
+
+  connect() {
+    this.disableUnselectedInputs();
+  }
+
+  disableUnselectedInputs(_event) {
+    this.selectionTargets.forEach((target) => {
+      const checked = target.querySelector("input[type='radio']").checked
+      // If radio is checked, enable its child select elements; if unchecked, disable.
+      target.querySelectorAll('select').forEach((element) => element.disabled = !checked)
+    })
+  }
+}

--- a/spec/features/single_radio_selection_spec.rb
+++ b/spec/features/single_radio_selection_spec.rb
@@ -1,0 +1,56 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Selecting a radio button causes other radio button inputs to be disabled', js: true do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user, groups: ['dlss:hydrus-app-administrators']
+  end
+
+  context 'with collection form' do
+    let(:collection) { create(:collection, managers: [user], release_option: 'depositor-selects') }
+
+    before { visit edit_collection_path(collection) }
+
+    it 'shows only one release option as checked and disables child select elements of other options' do
+      expect(find('#collection_release_option_immediate')).not_to be_checked
+      expect(find('#collection_release_option_delay')).not_to be_checked
+      expect(find('#collection_release_option_depositor-selects')).to be_checked
+
+      expect(find('#collection_release_duration')).not_to be_disabled
+
+      expect(find('#collection_release_date_year')).to be_disabled
+      expect(find('#collection_release_date_month')).to be_disabled
+      expect(find('#collection_release_date_day')).to be_disabled
+
+      # Disable "depositor-selects" select when "delay" selected
+      choose('Delay release until')
+
+      expect(find('#collection_release_option_immediate')).not_to be_checked
+      expect(find('#collection_release_option_delay')).to be_checked
+      expect(find('#collection_release_option_depositor-selects')).not_to be_checked
+
+      expect(find('#collection_release_duration')).to be_disabled
+
+      expect(find('#collection_release_date_year')).not_to be_disabled
+      expect(find('#collection_release_date_month')).not_to be_disabled
+      expect(find('#collection_release_date_day')).not_to be_disabled
+
+      # Disable "depositor-selects" and "delay" selects when "immediately" selected
+      choose('Immediately')
+
+      expect(find('#collection_release_option_immediate')).to be_checked
+      expect(find('#collection_release_option_delay')).not_to be_checked
+      expect(find('#collection_release_option_depositor-selects')).not_to be_checked
+
+      expect(find('#collection_release_duration')).to be_disabled
+
+      expect(find('#collection_release_date_year')).to be_disabled
+      expect(find('#collection_release_date_month')).to be_disabled
+      expect(find('#collection_release_date_day')).to be_disabled
+    end
+  end
+end


### PR DESCRIPTION
Fixes #796

## Why was this change made?

This PR introduces a new Stimulus controller that can make sure only the currently selected radio button has any child select elements enabled. This is only being used in the collection edit form for release/embargo options, currently, but the approach can be extended to other radio buttons in forms within the application. Since the work is primarily done on the client side, a feature spec is used for testing the change in behavior.

### Animated

![Peek 2021-01-25 10-11](https://user-images.githubusercontent.com/131982/105751665-32fa5180-5efb-11eb-885a-21f42cc0d8ef.gif)


## How was this change tested?

CI and in local browser

## Which documentation and/or configurations were updated?

None

