### PR TITLE
Render datatables on collection works page

### DIFF
--- a/app/components/collections/works_component.html.erb
+++ b/app/components/collections/works_component.html.erb
@@ -1,4 +1,4 @@
-<table class="table">
+<table class="table" data-controller="datatables">
   <thead class="table-light">
     <tr>
       <th width="18%"><%= I18n.t 'collection.deposits' %></th>
@@ -16,12 +16,3 @@
     <%= render Collections::WorkRowComponent.with_collection(works) %>
   </tbody>
 </table>
-
-<script src="https://cdn.jsdelivr.net/npm/simple-datatables@2.1.13"></script>
-<script>
-  new simpleDatatables.DataTable("table", {
-    columns: [
-        { select: 4, sort: "desc" },  // Sort the fifth column in ascending order
-        { select: [1, 5, 6, 7, 8], sortable: false } // Disable unsortable columns
-    ]});
-</script>

--- a/app/components/dashboard/in_progress_component.html.erb
+++ b/app/components/dashboard/in_progress_component.html.erb
@@ -1,4 +1,4 @@
-<section class="mb-5">
+<section class="mb-5" id="deposits-in-progress">
   <header>Deposits in progress</header>
   <% in_progress.each do |work| %>
     <div>

--- a/app/javascript/controllers/datatables_controller.js
+++ b/app/javascript/controllers/datatables_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "stimulus"
+import { DataTable } from "simple-datatables"
+
+export default class extends Controller {
+  connect() {
+    new DataTable("table", {
+      columns: [
+        { select: 4, sort: "desc" },  // Sort the fifth column in ascending order
+        { select: [1, 5, 6, 7, 8], sortable: false } // Disable unsortable columns
+      ]})
+  }
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -13,8 +13,9 @@ import '@hotwired/turbo'
 window.bootstrap = require("bootstrap") // Required for contact_us_controller
 require.context('../images', true)
 import 'stylesheets/main'
-import '@fortawesome/fontawesome-free/css/all.css';
-import '@fortawesome/fontawesome-free/js/all.js';
+import '@fortawesome/fontawesome-free/css/all.css'
+import '@fortawesome/fontawesome-free/js/all.js'
+import 'simple-datatables'
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@rails/webpacker": "5.2.1",
     "bootstrap": "5.0.0-beta1",
     "dropzone": "^5.7.2",
+    "simple-datatables": "^3.0.0",
     "stimulus": "2.0.0"
   },
   "version": "0.1.0",

--- a/spec/features/edit_draft_work_spec.rb
+++ b/spec/features/edit_draft_work_spec.rb
@@ -4,18 +4,24 @@
 require 'rails_helper'
 
 RSpec.describe 'Edit a draft work', js: true do
-  let(:work) { create(:work, :with_keywords, :with_attached_file, work_type: 'other', subtype: ['Graphic novel']) }
-  let(:user) { work.depositor }
+  let(:depositor) { create(:user) }
+  let!(:work) do
+    create(:work, :with_keywords, :with_attached_file,
+           work_type: 'other', subtype: ['Graphic novel'], depositor: depositor)
+  end
 
   before do
-    sign_in user
+    work.collection.depositors = [depositor]
+    sign_in depositor
   end
 
   context 'when successful deposit' do
     it 'deposits and renders work show page' do
       visit dashboard_path
 
-      click_link work.title
+      within('#deposits-in-progress') do
+        click_link work.title
+      end
 
       expect(page).to have_content work.title
 
@@ -44,7 +50,9 @@ RSpec.describe 'Edit a draft work', js: true do
     it 'shows a confirmation if you cancel the deposit and goes back if confirmed' do
       visit dashboard_path
 
-      click_link work.title
+      within('#deposits-in-progress') do
+        click_link work.title
+      end
 
       accept_confirm do
         click_link 'Cancel'
@@ -56,7 +64,9 @@ RSpec.describe 'Edit a draft work', js: true do
     it 'shows a confirmation if you cancel the deposit and stays on the page if not confirmed' do
       visit dashboard_path
 
-      click_link work.title
+      within('#deposits-in-progress') do
+        click_link work.title
+      end
 
       dismiss_confirm do
         click_link 'Cancel'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2433,6 +2433,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+dayjs@^1.10.3:
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.4.tgz#8e544a9b8683f61783f570980a8a80eaf54ab1e2"
+  integrity sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -6561,6 +6566,13 @@ signal-exit@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+
+simple-datatables@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/simple-datatables/-/simple-datatables-3.0.0.tgz#f3901c6dc4527ab1025664ca87708981ecb19cb0"
+  integrity sha512-HG71ndHHQ2yl/JzaoDaW+Xl1WPIa5pZyhmOvz/JKvC+t+4aGxCCaPd/54PtOJb5ie876N+0b2bqQFEoQNDlhCg==
+  dependencies:
+    dayjs "^1.10.3"
 
 simple-swizzle@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
## Why was this change made?

This commit uses Stimulus to setup the simple-datatables library, making sure the DataTable class is imported when needed. Without this change, the data table only renders after reloading the page because of turbo(links).

## How was this change tested?

CI + local browser + QA

## Which documentation and/or configurations were updated?

None

