### PR TITLE
Align the breadcrumbs with the SUL icon

### DIFF
--- a/app/components/breadcrumb_nav_component.html.erb
+++ b/app/components/breadcrumb_nav_component.html.erb
@@ -1,15 +1,17 @@
-<nav id="breadcrumbs" aria-label="breadcrumb" class="bg-light">
-  <ol class="breadcrumb">
-    <% breadcrumbs.each do |breadcrumb| %>
-      <li class="breadcrumb-item">
-        <% if breadcrumb[:link].blank? %>
-          <span class="breadcrumb-link"><%= breadcrumb[:title] %></span>
-        <% else %>
-          <%= link_to breadcrumb[:title].presence || 'No title',
-                      breadcrumb[:link], class: 'breadcrumb-link',
-                      data: (breadcrumb[:confirm] ? { confirm: 'Are you sure you want to leave this page? Your changes will not be saved.' } : nil) %>
-        <% end %>
-      </li>
-    <% end %>
-  </ol>
+<nav class="bg-light">
+  <div id="breadcrumbs" aria-label="breadcrumb" class="container-xxl">
+    <ol class="breadcrumb">
+      <% breadcrumbs.each do |breadcrumb| %>
+        <li class="breadcrumb-item">
+          <% if breadcrumb[:link].blank? %>
+            <span class="breadcrumb-link"><%= breadcrumb[:title] %></span>
+          <% else %>
+            <%= link_to breadcrumb[:title].presence || 'No title',
+                        breadcrumb[:link], class: 'breadcrumb-link',
+                        data: (breadcrumb[:confirm] ? { confirm: 'Are you sure you want to leave this page? Your changes will not be saved.' } : nil) %>
+          <% end %>
+        </li>
+      <% end %>
+    </ol>
+  </div>
 </nav>


### PR DESCRIPTION


## Why was this change made?



## How was this change tested?

Before:
<img width="967" alt="Screen Shot 2021-01-26 at 9 04 04 AM" src="https://user-images.githubusercontent.com/92044/105862515-76b19180-5fb5-11eb-980d-075adf58b239.png">

After:
<img width="1007" alt="Screen Shot 2021-01-26 at 9 02 15 AM" src="https://user-images.githubusercontent.com/92044/105862426-5f72a400-5fb5-11eb-8c23-d6930d0f80c6.png">

## Which documentation and/or configurations were updated?



