### PR TITLE
adjust work sub-types

### DIFF
--- a/app/models/work_type.rb
+++ b/app/models/work_type.rb
@@ -9,36 +9,20 @@ class WorkType
 
   DATA_TYPES = [
     '3D model',
-    'Audio',
     'Database',
-    'GIS',
+    'Geospatial data',
     'Image',
-    'Questionnaire',
-    'Remote sensing imagery',
-    'Software/code',
-    'Statistical model',
     'Tabular data',
     'Text corpus',
-    'Text documentation',
-    'Video'
+    'Documentation'
   ].freeze
 
   VIDEO_TYPES = [
-    'Animation',
-    'Broadcast',
     'Conference session',
-    'Course/instruction',
     'Documentary',
-    'Ethnography',
     'Event',
-    'Experimental',
-    'Field recordings',
-    'Narrative film',
     'Oral history',
-    'Performance',
-    'Presentation',
-    'Unedited footage',
-    'Video art'
+    'Performance'
   ].freeze
 
   MIXED_TYPES = [
@@ -51,44 +35,20 @@ class WorkType
   ].freeze
 
   SOUND_TYPES = [
-    'Course/instruction',
-    'Documentary',
-    'Dramatic performance',
-    'Ethnography',
-    'Field recordings',
     'Interview',
-    'MIDI',
-    'Musical notation',
-    'Musical performance',
     'Oral history',
-    'Other spoken word',
     'Podcast',
-    'Poetry reading',
-    'Speech',
-    'Story',
-    'Transcript',
-    'Unedited recording'
+    'Speech'
   ].freeze
 
   TEXT_TYPES = [
     'Article',
-    'Book',
-    'Book chapter',
-    'Correspondence',
-    'Essay',
     'Government document',
-    'Journal/periodical',
-    'Manuscript',
-    'Poster',
-    'Presentation slides',
+    'Policy brief',
+    'Preprint',
     'Report',
-    'Speech',
-    'Syllabus',
-    'Teaching materials',
     'Technical report',
     'Thesis',
-    'Transcription',
-    'White paper',
     'Working paper'
   ].freeze
 

--- a/config/mappings/types_to_genres.yml
+++ b/config/mappings/types_to_genres.yml
@@ -125,7 +125,7 @@ Data:
       uri: http://id.loc.gov/authorities/genreForms/gf2014026081
       source:
         code: lcgft
-  GIS:
+  Geospatial Data:
     - type: genre
       value: dataset
     - type: genre

--- a/spec/components/works/description_component_spec.rb
+++ b/spec/components/works/description_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Works::DescriptionComponent do
   end
 
   it 'has a checkbox with a label' do
-    expect(rendered.css('#work_subtype_journalperiodical')).to be_present
-    expect(rendered.css("label[for='work_subtype_journalperiodical']")).to be_present
+    expect(rendered.css('#work_subtype_article')).to be_present
+    expect(rendered.css("label[for='work_subtype_article']")).to be_present
   end
 end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
       "Test title #{n}"
     end
     work_type { 'text' }
-    subtype { ['Article', 'Presentation slides'] } # Subtype values intentionally include an item with whitespace
+    subtype { ['Article', 'Government document'] } # Subtype values intentionally include an item with whitespace
     contact_email { 'io@io.io' }
     abstract { 'test abstract' }
     citation { 'test citation' }

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
         expect(page).to have_css('input#subtype_other')
         find('label', text: 'Sound').click
 
-        check 'Course/instruction'
-        check 'Poetry reading'
+        check 'Interview'
+        check 'Podcast'
 
         click_button 'Continue'
 
@@ -89,7 +89,7 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
         select 'Everyone', from: 'Who can access?'
 
         fill_in 'Abstract', with: 'User provided abstract'
-        check 'Musical notation'
+        check 'Oral history'
 
         check 'I agree to the SDR Terms of Deposit'
 
@@ -123,7 +123,7 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
         expect(page).to have_link(Collection.last.name)
         expect(page).to have_content(user.email)
         expect(page).to have_content('sound')
-        expect(page).to have_content('Course/instruction, Musical notation, Poetry reading')
+        expect(page).to have_content('Interview, Oral history, Podcast')
         expect(page).to have_content('Best Publisher')
         expect(page).to have_content('2020-03-06/2020-10-30')
         expect(page).to have_content 'User provided abstract'

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe WorkForm do
     end
 
     it 'validates with a valid subtype/work_type combo' do
-      form.validate(work_type: 'data', subtype: ['Software/code'])
+      form.validate(work_type: 'data', subtype: ['Database'])
       expect(messages).to be_empty
     end
   end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe Work do
     end
 
     context 'with a valid subtype/work_type combo ' do
-      let(:work) { build(:work, work_type: 'data', subtype: ['Software/code']) }
+      let(:work) { build(:work, work_type: 'data', subtype: ['Database']) }
 
       it 'validates' do
         expect(work).to be_valid

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'Create a new work' do
 
       context 'with a valid subtype/work_type combo' do
         it 'renders the form' do
-          get "/collections/#{collection.id}/works/new?work_type=text&subtype%5B%5D=Essay"
+          get "/collections/#{collection.id}/works/new?work_type=text&subtype%5B%5D=Thesis"
           expect(response).to have_http_status(:ok)
           expect(response.body).to include 'text'
         end
@@ -278,7 +278,7 @@ RSpec.describe 'Create a new work' do
           expect(work.published_edtf.to_edtf).to eq '2020-02-14'
           expect(work.created_edtf.to_s).to eq '2020-03-04/2020-10-31'
           expect(work.embargo_date).to eq Date.parse("#{embargo_year}-04-04")
-          expect(work.subtype).to eq ['Article', 'Presentation slides']
+          expect(work.subtype).to eq ['Article', 'Government document']
           expect(DepositJob).to have_received(:perform_later).with(work)
           expect(work.state).to eq 'depositing'
           expect(work.access).to eq 'world' # shows that `stanford` was overwritten

--- a/spec/services/description_generator_spec.rb
+++ b/spec/services/description_generator_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe DescriptionGenerator do
           },
           {
             type: 'subtype',
-            value: 'Presentation slides'
+            value: 'Government document'
           }
         ],
         type: 'resource type'
@@ -49,8 +49,12 @@ RSpec.describe DescriptionGenerator do
         value: 'articles'
       },
       {
+        source: {
+          code: 'aat'
+        },
         type: 'genre',
-        value: 'Presentation slides'
+        value: 'government records',
+        uri: 'http://vocab.getty.edu/aat/300027777'
       },
       {
         source: {

--- a/spec/services/request_generator_spec.rb
+++ b/spec/services/request_generator_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RequestGenerator do
           },
           {
             type: 'subtype',
-            value: 'Presentation slides'
+            value: 'Government document'
           }
         ],
         type: 'resource type'
@@ -38,8 +38,12 @@ RSpec.describe RequestGenerator do
         value: 'articles'
       },
       {
+        source: {
+          code: 'aat'
+        },
         type: 'genre',
-        value: 'Presentation slides'
+        value: 'government records',
+        uri: 'http://vocab.getty.edu/aat/300027777'
       },
       {
         source: {

--- a/spec/services/types_generator_spec.rb
+++ b/spec/services/types_generator_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe TypesGenerator do
               ),
               Cocina::Models::DescriptiveValue.new(
                 type: 'subtype',
-                value: 'Presentation slides'
+                value: 'Government document'
               )
             ]
           )
@@ -56,7 +56,9 @@ RSpec.describe TypesGenerator do
           ),
           Cocina::Models::DescriptiveValue.new(
             type: 'genre',
-            value: 'Presentation slides'
+            value: 'government records',
+            uri: 'http://vocab.getty.edu/aat/300027777',
+            source: { code: 'aat' }
           )
         )
       end


### PR DESCRIPTION
**NOTE**: This will be subsumed by #1019 

## Why was this change made?

Fixes #755 

- adjust work sub-types in config used in modal for new deposits
- adjust tests/factory so that (now invalid) removed sub-types are replaced with current valid subtypes

To do: 

- [ ] add new genre and resource type mappings https://github.com/sul-dlss/happy-heron/pull/905#issuecomment-767859534


## How was this change tested?

Localhost browser and existing unit tests

## Which documentation and/or configurations were updated?

The design doc was updated

