### PR TITLE
client side-validation of publication dates

### DIFF
--- a/app/components/works/publication_date_component.html.erb
+++ b/app/components/works/publication_date_component.html.erb
@@ -2,7 +2,7 @@
   <div class="col-sm-2 h6">
     Publication date
   </div>
-  <div class="col-sm-10">
+  <div data-controller="date-validation" class="col-sm-10">
     <div class="year">
       <label for="work_published_year" class="visually-hidden">Publication year</label>
       <%= year_field %>

--- a/app/components/works/publication_date_component.rb
+++ b/app/components/works/publication_date_component.rb
@@ -28,7 +28,8 @@ module Works
       number_field_tag 'work[published(1i)]', published_year,
                        data: {
                          auto_citation_target: 'year',
-                         action: 'change->auto-citation#updateDisplay'
+                         date_validation_target: 'year',
+                         action: 'change->auto-citation#updateDisplay date-validation#change'
                        },
                        id: 'work_published_year',
                        class: 'form-control',
@@ -41,7 +42,8 @@ module Works
                    { prefix: 'work', field_name: 'published(2i)', prompt: 'month' },
                    data: {
                      auto_citation_target: 'month',
-                     action: 'change->auto-citation#updateDisplay'
+                     date_validation_target: 'month',
+                     action: 'change->auto-citation#updateDisplay date-validation#change'
                    },
                    id: 'work_published_month',
                    class: 'form-control'
@@ -52,7 +54,8 @@ module Works
                  { prefix: 'work', field_name: 'published(3i)', prompt: 'day' },
                  data: {
                    auto_citation_target: 'day',
-                   action: 'change->auto-citation#updateDisplay'
+                   date_validation_target: 'day',
+                   action: 'change->auto-citation#updateDisplay date-validation#change'
                  },
                  id: 'work_published_day',
                  class: 'form-control'


### PR DESCRIPTION
as with creation dates, ensure that the user can't enter incomplete dates (e.g. month with no year)

## Why was this change made?

fixes #872

## How was this change tested?

I tested on my local instance, and an incomplete publication date both flagged an error and prevented form submission.

When I tried to submit, there was no explanation of the error at the top of the page, but the box that needed a year was highlighted with an explanation as to what needed correcting (this seems to be the same as the behavior of the creation date field).  Happy to revisit that in this PR or a follow on if that's desired.

I also didn't add a feature test, as I was cribbing from #758, which also declined to add a test.  But similarly, happy to work on testing these validations if we'd prefer to give that another shot.

<img width="635" alt="Screen Shot 2021-01-26 at 1 35 26 PM" src="https://user-images.githubusercontent.com/7741604/105910710-2e5a9980-5fde-11eb-83bc-af8234f06b62.png">


## Which documentation and/or configurations were updated?

n/a