### PR TITLE
Loosen type declarations for Works::FormComponent

### DIFF
--- a/app/components/works/form_component.rb
+++ b/app/components/works/form_component.rb
@@ -4,15 +4,15 @@
 module Works
   # The component that renders the form for editing or creating a work.
   class FormComponent < ApplicationComponent
-    sig { returns(WorkForm) }
+    sig { returns(DraftWorkForm) }
     attr_reader :work_form
 
-    sig { params(work_form: WorkForm).void }
+    sig { params(work_form: DraftWorkForm).void }
     def initialize(work_form:)
       @work_form = work_form
     end
 
-    sig { returns(T.any(WorkForm, T::Array[T.any(Collection, WorkForm)])) }
+    sig { returns(T.any(DraftWorkForm, T::Array[T.any(Collection, DraftWorkForm)])) }
     def url
       persisted? ? work_form : [model.collection, work_form]
     end


### PR DESCRIPTION


## Why was this change made?

I believe this may have started when we switched back to local form.
Fixes #915

## How was this change tested?



## Which documentation and/or configurations were updated?



