### PR TITLE
Display validations when the embargo date is invalid

### DIFF
--- a/app/components/works/available_date_component.html.erb
+++ b/app/components/works/available_date_component.html.erb
@@ -5,8 +5,8 @@
   </div>
 </div>
 
-<div class="embargo-date" data-edit-deposit-target="embargo-dateField">
-  <div class="mb-5 row">
+<div class="embargo-date mb-5" data-edit-deposit-target="embargo-dateField">
+  <div class="row<%= ' is-invalid' if error? %>">
     <div class="col-sm-10 release-option">
       <%= form.radio_button :release, 'embargo', class: 'form-check-input' %>
       <%= form.label :release_embargo, 'On this date' %>
@@ -27,5 +27,5 @@
       </div>
     </div>
   </div>
-  <div data-embargo-date-target="error" class="invalid-feedback"></div>
+  <div class="invalid-feedback"><%= error_message %></div>
 </div>

--- a/app/components/works/available_date_component.rb
+++ b/app/components/works/available_date_component.rb
@@ -16,6 +16,18 @@ module Works
       form.object
     end
 
+    def error?
+      errors.present?
+    end
+
+    def error_message
+      safe_join(errors.map(&:message), tag.br)
+    end
+
+    def errors
+      form.object.errors.where(:embargo_date)
+    end
+
     def year_field
       select_year embargo_year,
                   {
@@ -25,21 +37,21 @@ module Works
                     end_year: 3.years.from_now.year
                   },
                   id: 'work_embargo_year',
-                  class: 'form-control'
+                  class: "form-control#{' is-invalid' if error?}"
     end
 
     def month_field
       select_month embargo_month,
                    { prefix: 'work', field_name: 'embargo_date(2i)', prompt: 'month' },
                    id: 'work_embargo_month',
-                   class: 'form-control'
+                   class: "form-control#{' is-invalid' if error?}"
     end
 
     def day_field
       select_day embargo_day,
                  { prefix: 'work', field_name: 'embargo_date(3i)', prompt: 'day' },
                  id: 'work_embargo_day',
-                 class: 'form-control'
+                 class: "form-control#{' is-invalid' if error?}"
     end
 
     def embargo_year

--- a/app/components/works/form_component.html.erb
+++ b/app/components/works/form_component.html.erb
@@ -4,7 +4,7 @@
       controller: 'edit-deposit auto-citation',
       auto_citation_purl: purl
     },
-    html: { class: "needs-validation work-editor #{'was-validated' if work_form.errors.present?}", novalidate: true, multipart: true } do |f| %>
+    html: { class: "needs-validation work-editor", novalidate: true, multipart: true } do |f| %>
   <% if work_form.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(work_form.errors.count, "error") %> prohibited this item from being saved:</h2>

--- a/spec/components/works/available_date_component_spec.rb
+++ b/spec/components/works/available_date_component_spec.rb
@@ -42,4 +42,20 @@ RSpec.describe Works::AvailableDateComponent, type: :component do
         .to eq embargo_date.day.to_s
     end
   end
+
+  context 'when there is an error' do
+    let(:embargo_date) { work.embargo_date }
+    let(:work) { build(:work, :embargoed) }
+
+    before do
+      work_form.errors.add(:embargo_date, 'Must be less than 3 years in the future')
+    end
+
+    it 'renders the message and adds invalid styles' do
+      expect(rendered.css('.is-invalid ~ .invalid-feedback').text).to eq 'Must be less than 3 years in the future'
+      expect(rendered.css('#work_embargo_year.is-invalid')).to be_present
+      expect(rendered.css('#work_embargo_month.is-invalid')).to be_present
+      expect(rendered.css('#work_embargo_day.is-invalid')).to be_present
+    end
+  end
 end

--- a/spec/components/works/form_component_spec.rb
+++ b/spec/components/works/form_component_spec.rb
@@ -23,16 +23,5 @@ RSpec.describe Works::FormComponent do
                   'Describe your deposit',
                   'Manage release of this deposit',
                   'Select a license')
-    expect(rendered.css('.was-validated')).not_to be_present
-  end
-
-  context 'when there are errors' do
-    before do
-      work_form.validate({})
-    end
-
-    it 'renders the component errors' do
-      expect(rendered.css('form.was-validated')).to be_present
-    end
   end
 end


### PR DESCRIPTION


## Why was this change made?

Fixes #664 

## How was this change tested?

<img width="1223" alt="Screen Shot 2021-01-27 at 12 51 17 PM" src="https://user-images.githubusercontent.com/92044/106042879-40ead680-60a3-11eb-9a20-1b9506f1d06a.png">

## Which documentation and/or configurations were updated?



