### PR TITLE
Fix work type modal and collection form styles

### DIFF
--- a/app/components/collections/edit_license_component.html.erb
+++ b/app/components/collections/edit_license_component.html.erb
@@ -11,9 +11,7 @@
     <fieldset class="license-option">
       <div class="form-check" data-complex-radio-target="selection">
         <%= form.radio_button :license_option, 'required', class: "form-check-input", data: { action: 'complex-radio#disableUnselectedInputs' } %>
-        <%= form.label :license_option_required, class: "form-check-label" do %>
-          Require license for all deposits
-        <% end %>
+        <%= form.label :license_option_required, 'Require license for all deposits', class: "form-check-label" %>
         <%= form.label :required_license, class: 'form-check-label visually-hidden' %>
         <%= form.select :required_license, grouped_options_for_select(License.grouped_options, required_license, prompt: 'Select...'),
                         {}, class: "form-select" %>
@@ -24,9 +22,7 @@
 
       <div class="form-check license-option" data-complex-radio-target="selection">
         <%= form.radio_button :license_option, 'depositor-selects', class: "form-check-input", data: { action: 'complex-radio#disableUnselectedInputs' } %>
-        <%= form.label 'license_option_depositor-selects', class: "form-check-label" do %>
-          Depositor selects license
-        <% end %>
+        <%= form.label 'license_option_depositor-selects', 'Depositor selects license', class: "form-check-label" %>
         <%= form.label :default_license, class: 'form-check-label visually-hidden' %>
         <%= form.select :default_license, grouped_options_for_select(License.grouped_options, default_license, prompt: 'Select default license...'),
                         {}, class: "form-select default_license" %>

--- a/app/components/works/work_type_modal_component.html.erb
+++ b/app/components/works/work_type_modal_component.html.erb
@@ -14,7 +14,7 @@
   <form method="get" action="/collections/1/work/new" data-work-type-target="form">
     <div class="row">
       <% types.each do |type| %>
-        <div class="col-md-3" style="height: 4rem">
+        <div class="col-md-3 mb-5" style="height: 4rem">
           <%= render CheckboxButtonComponent.new(name: 'work_type', value: type.id, data: { action: "work-type#change" }) do %>
             <span class="fas fa-2x fa-<%= type.icon %>"></span> <div class="work-type-button-text"><%= type.label %></div>
           <% end %>

--- a/app/javascript/stylesheets/bootstrapVariables.scss
+++ b/app/javascript/stylesheets/bootstrapVariables.scss
@@ -16,6 +16,3 @@ $table-group-separator-color: $silver-sand;
 
 // Breadcrumbs
 $breadcrumb-divider: quote(">");
-
-// Checkboxes + Radio buttons
-$form-check-margin-bottom: 1.25rem;

--- a/app/javascript/stylesheets/collectionEditor.scss
+++ b/app/javascript/stylesheets/collectionEditor.scss
@@ -4,6 +4,8 @@
   .release-option, .license-option {
     .form-check {
       @include embargo;
+
+      margin-bottom: 1.25rem;
     }
 
     .form-check-input {

--- a/app/javascript/stylesheets/embargo.scss
+++ b/app/javascript/stylesheets/embargo.scss
@@ -1,6 +1,6 @@
 @mixin embargo {
   display: flex;
-  
+
   * {
     margin-right: .3rem;
   }


### PR DESCRIPTION
Fixes #940 

## Why was this change made?

To fix style-related bugs.

### Collection form

#### Before

![collection_form_before](https://user-images.githubusercontent.com/131982/106060408-e2c0f200-60a8-11eb-90b2-335425cea193.png)

#### After

![collection_form_after](https://user-images.githubusercontent.com/131982/106060426-e8b6d300-60a8-11eb-88ff-879b221ce3d2.png)

### Work type modal

#### Before

![work_type_modal_before](https://user-images.githubusercontent.com/131982/106060459-f66c5880-60a8-11eb-9e73-10ffe51d2d47.png)

#### After

![work_type_modal_after](https://user-images.githubusercontent.com/131982/106060479-fc623980-60a8-11eb-9b9a-bb8c4f5d6408.png)

## How was this change tested?

CI and local browser. See screenshots above.

## Which documentation and/or configurations were updated?

None

