### PR TITLE
Move validations to the WorkForm

### DIFF
--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -30,8 +30,6 @@ class DraftWorkForm < Reform::Form
   end)
   property :embargo_date, embargo_date: true
 
-  validates :created_edtf, created_in_past: true
-  validates :published_edtf, created_in_past: true
   validates :embargo_date, embargo_date: true,
                            if: proc { |form| form.model.collection.user_can_set_availability? }
   validates_with EmbargoDateParts,

--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -15,4 +15,6 @@ class WorkForm < DraftWorkForm
   validates :subtype, work_subtype: true
   validates :work_type, presence: true, work_type: true
   validates :contributors, length: { minimum: 1, message: 'Please add at least one contributor.' }
+  validates :created_edtf, created_in_past: true
+  validates :published_edtf, created_in_past: true
 end


### PR DESCRIPTION


## Why was this change made?

Because we only require these validations when the user is trying to deposit.  Ref #932

## How was this change tested?



## Which documentation and/or configurations were updated?



