### PR TITLE
Display collection license validation inline in the form

### DIFF
--- a/app/components/collections/edit_license_component.html.erb
+++ b/app/components/collections/edit_license_component.html.erb
@@ -9,28 +9,30 @@
     </p>
 
     <fieldset class="license-option">
-      <div class="form-check" data-complex-radio-target="selection">
+      <div class="form-check<%= ' is-invalid' if error? %>" data-complex-radio-target="selection">
         <%= form.radio_button :license_option, 'required', class: "form-check-input", data: { action: 'complex-radio#disableUnselectedInputs' } %>
         <%= form.label :license_option_required, class: "form-check-label" do %>
           Require license for all deposits
         <% end %>
         <%= form.label :required_license, class: 'form-check-label visually-hidden' %>
         <%= form.select :required_license, grouped_options_for_select(License.grouped_options, required_license, prompt: 'Select...'),
-                        {}, class: "form-select" %>
+                        {}, class: "form-select#{' is-invalid' if error?}" %>
         <a href="https://library.stanford.edu/research/stanford-digital-repository/faqs/sdr-license-options" target="_blank">
           Get help selecting a license
         </a>
       </div>
 
-      <div class="form-check license-option" data-complex-radio-target="selection">
+      <div class="form-check<%= ' is-invalid' if error? %>" data-complex-radio-target="selection">
         <%= form.radio_button :license_option, 'depositor-selects', class: "form-check-input", data: { action: 'complex-radio#disableUnselectedInputs' } %>
         <%= form.label 'license_option_depositor-selects', class: "form-check-label" do %>
           Depositor selects license
         <% end %>
         <%= form.label :default_license, class: 'form-check-label visually-hidden' %>
         <%= form.select :default_license, grouped_options_for_select(License.grouped_options, default_license, prompt: 'Select default license...'),
-                        {}, class: "form-select default_license" %>
+                        {}, class: "form-select default_license#{ ' is-invalid' if error? }" %>
       </div>
+
+      <div class="invalid-feedback"><%= error_message %></div>
     </fieldset>
 
     <hr>

--- a/app/components/collections/edit_license_component.rb
+++ b/app/components/collections/edit_license_component.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: false
 # frozen_string_literal: true
 
 module Collections
@@ -17,6 +17,20 @@ module Collections
     sig { returns(DraftCollectionForm) }
     def collection_form
       form.object
+    end
+
+    sig { returns(T::Boolean) }
+    def error?
+      errors.present?
+    end
+
+    def errors
+      collection_form.errors.where(:license)
+    end
+
+    sig { returns(String) }
+    def error_message
+      safe_join(errors.map(&:message), tag.br)
     end
   end
 end

--- a/app/validators/collection_license_validator.rb
+++ b/app/validators/collection_license_validator.rb
@@ -8,6 +8,6 @@ class CollectionLicenseValidator < ActiveModel::Validator
     return if record.required_license.in?(License.license_list) ||
               record.default_license.in?(License.license_list)
 
-    record.errors.add('license', 'Either required license or default license must be present')
+    record.errors.add(:license, 'Either a required license or a default license must be present')
   end
 end

--- a/spec/components/collections/edit_license_component_spec.rb
+++ b/spec/components/collections/edit_license_component_spec.rb
@@ -31,4 +31,20 @@ RSpec.describe Collections::EditLicenseComponent, type: :component do
       expect(rendered.to_html).to include('<option selected value="CC0-1.0">CC0-1.0</option>')
     end
   end
+
+  context 'with errors' do
+    let(:collection) { build(:collection, required_license: nil) }
+
+    before do
+      collection_form.errors.add(:license, 'Either a required license or a default license must be present')
+    end
+
+    it 'renders the message and adds invalid styles' do
+      expect(rendered.css('.is-invalid ~ .invalid-feedback').text).to eq(
+        'Either a required license or a default license must be present'
+      )
+      expect(rendered.css('#required_license.is-invalid')).to be_present
+      expect(rendered.css('#default_license.is-invalid')).to be_present
+    end
+  end
 end

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
         click_button 'Deposit'
 
         expect(page).to have_content 'Keller, M. (2020, February). My Title. ' \
-          'Stanford Digital Repository. Available at :link:'
+          "Stanford Digital Repository. Available at #{Work::LINK_TEXT}"
       end
     end
   end

--- a/spec/validators/collection_license_validator_spec.rb
+++ b/spec/validators/collection_license_validator_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CollectionLicenseValidator do
 
     it 'is invalid' do
       expect(record.errors.where(:license).first.message).to eq(
-        'Either required license or default license must be present'
+        'Either a required license or a default license must be present'
       )
     end
   end
@@ -50,7 +50,7 @@ RSpec.describe CollectionLicenseValidator do
 
     it 'is invalid' do
       expect(record.errors.where(:license).first.message).to eq(
-        'Either required license or default license must be present'
+        'Either a required license or a default license must be present'
       )
     end
   end
@@ -62,7 +62,7 @@ RSpec.describe CollectionLicenseValidator do
 
     it 'is invalid' do
       expect(record.errors.where(:license).first.message).to eq(
-        'Either required license or default license must be present'
+        'Either a required license or a default license must be present'
       )
     end
   end


### PR DESCRIPTION
Follows the approach used in https://github.com/sul-dlss/happy-heron/pull/928 and https://github.com/sul-dlss/happy-heron/pull/919

Also, fixes the build.

## Why was this change made?

Consistency and kinder UX. Note that the UI looks messed up in the screen shot due to #929 not having been merged yet.

![license_validation](https://user-images.githubusercontent.com/131982/106067431-80b9ba00-60b3-11eb-828e-2ccba9325a8c.png)

## How was this change tested?

CI, local browser

## Which documentation and/or configurations were updated?

None

