### PR TITLE
allow types with no subtypes to be mapped

### DIFF
--- a/config/mappings/types_to_genres.yml
+++ b/config/mappings/types_to_genres.yml
@@ -1,478 +1,509 @@
 Text:
-  Article:
-    - type: genre
-      value: articles
-      uri: http://vocab.getty.edu/aat/300048715
-      source:
-        code: aat
-  Book:
-    - type: genre
-      value: books
-      uri: http://vocab.getty.edu/aat/300028051
-      source:
-        code: aat
-  Book chapter:
-    - type: genre
-      value: Book chapters
-  Correspondence:
-    - type: genre
-      value: correspondence
-      uri: http://vocab.getty.edu/aat/300026877
-      source:
-        code: aat
-  Essay:
-    - type: genre
-      value: Essays
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
-      source:
-        code: lcgft
-  Government document:
-    - type: genre
-      value: government records
-      uri: http://vocab.getty.edu/aat/300027777
-      source:
-        code: aat
-  Journal/periodical:
-    - type: genre
-      value: Periodicals
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
-  Manuscript:
-    - type: genre
-      value: manuscripts (documents)
-      uri: http://vocab.getty.edu/aat/300028569
-      source:
-        code: aat
-  Poster:
-    - type: genre
-      value: Posters
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
-      source:
-        code: lcgft
-  Presentation slides:
-    - type: genre
-      value: Presentation slides
-  Report:
-    - type: genre
-      value: reports
-      uri: http://vocab.getty.edu/aat/300027267
-      source:
-        code: aat
-  Speech:
-    - type: genre
-      value: Speeches
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
-      source:
-        code: lcgft
-  Syllabus:
-    - type: genre
-      value: Outlines and syllabi
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
-      source:
-        code: lcgft
-  Teaching materials:
-    - type: genre
-      value: Instructional and educational works
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-      source:
-        code: lcgft
-  Technical report:
-    - type: genre
-      value: Technical reports
-      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
-      source:
-        code: lcgft
-  Thesis:
-    - type: genre
-      value: Academic theses
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
-      source:
-        code: lcgft
-  Transcription:
-    - type: genre
-      value: transcripts
-      uri: http://vocab.getty.edu/aat/300027388
-      source:
-        code: aat
-  White paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-  Working paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
+  subtypes:
+    Article:
+      - type: genre
+        value: articles
+        uri: http://vocab.getty.edu/aat/300048715
+        source:
+          code: aat
+    Book:
+      - type: genre
+        value: books
+        uri: http://vocab.getty.edu/aat/300028051
+        source:
+          code: aat
+    Book chapter:
+      - type: genre
+        value: Book chapters
+    Correspondence:
+      - type: genre
+        value: correspondence
+        uri: http://vocab.getty.edu/aat/300026877
+        source:
+          code: aat
+    Essay:
+      - type: genre
+        value: Essays
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+        source:
+          code: lcgft
+    Government document:
+      - type: genre
+        value: government records
+        uri: http://vocab.getty.edu/aat/300027777
+        source:
+          code: aat
+    Journal/periodical:
+      - type: genre
+        value: Periodicals
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+    Manuscript:
+      - type: genre
+        value: manuscripts (documents)
+        uri: http://vocab.getty.edu/aat/300028569
+        source:
+          code: aat
+    Poster:
+      - type: genre
+        value: Posters
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+        source:
+          code: lcgft
+    Presentation slides:
+      - type: genre
+        value: Presentation slides
+    Report:
+      - type: genre
+        value: reports
+        uri: http://vocab.getty.edu/aat/300027267
+        source:
+          code: aat
+    Speech:
+      - type: genre
+        value: Speeches
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+        source:
+          code: lcgft
+    Syllabus:
+      - type: genre
+        value: Outlines and syllabi
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+        source:
+          code: lcgft
+    Teaching materials:
+      - type: genre
+        value: Instructional and educational works
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+        source:
+          code: lcgft
+    Technical report:
+      - type: genre
+        value: Technical reports
+        uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+        source:
+          code: lcgft
+    Thesis:
+      - type: genre
+        value: Academic theses
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+        source:
+          code: lcgft
+    Transcription:
+      - type: genre
+        value: transcripts
+        uri: http://vocab.getty.edu/aat/300027388
+        source:
+          code: aat
+    White paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+    Working paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
 Data:
-  3D model:
-    - type: genre
-      value: Three dimensional scan
-  Audio:
-    - type: genre
-      value: dataset
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Database:
-    - type: genre
-      value: dataset
-    - type: genre
-      value: Databases
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
-      source:
-        code: lcgft
-  GIS:
-    - type: genre
-      value: dataset
-    - type: genre
-      value: Geographic information systems
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
-      source:
-        code: lcgft
-  Image:
-    - type: genre
-      value: dataset
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Questionnaire:
-    - type: genre
-      value: dataset
-    - type: genre
-      value: Questionnaires
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
-      source:
-        code: lcgft
-  Remote sensing imagery:
-    - type: genre
-      value: dataset
-    - type: genre
-      value: Remote-sensing images
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
-      source:
-        code: lcgft
-  Software/code:
-    - type: genre
-      value: dataset
-    - type: genre
-      value: software
-      uri: http://vocab.getty.edu/aat/300028566
-      source:
-        code: aat
-  Statistical model:
-    - type: genre
-      value: dataset
-    - type: genre
-      value: mathematical models
-      uri: http://vocab.getty.edu/aat/300065075
-      source:
-        code: aat
-  Tabular data:
-    - type: genre
-      value: dataset
-    - type: genre
-      value: Tables (Data)
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
-      source:
-        code: lcgft
-  Text corpus:
-    - type: genre
-      value: dataset
-    - type: genre
-      value: Text corpora
-      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
-      source:
-        code: lcgft
-  Text documentation:
-    - type: genre
-      value: dataset
-    - type: genre
-      value: Data dictionaries
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026080
-      source:
-        code: lcgft
-  Video:
-    - type: genre
-      value: dataset
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-Software or Code:
-  Code:
-    - type: genre
-      value: programs (computer)
-      uri: http://vocab.getty.edu/aat/300312188
-      source:
-        code: aat
-  Documentation:
-    - type: genre
-      value: technical manuals
-      uri: http://vocab.getty.edu/aat/300026413
-      source:
-        code: aat
-  Game:
-    - type: genre
-      value: video games
-      uri: http://vocab.getty.edu/aat/300256888
-      source:
-        code: aat
-Image:
-  CAD:
-    - type: genre
-      value: computer-aided designs (visual works)
-      uri: http://vocab.getty.edu/aat/300418056
-      source:
-        code: aat
-  Map:
-    - type: genre
-      value: Maps
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
-      source:
-        code: lcgft
-  Photograph:
-    - type: genre
-      value: Photographs
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
-      source:
-        code: lcgft
-  Poster:
-    - type: genre
-      value: Posters
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
-      source:
-        code: lcgft
-  Presentation slides:
-    - type: genre
-      value: Presentation slides
-Sound:
-  Course/instruction:
-    - type: genre
-      value: Instructional and educational works
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-      source:
-        code: lcgft
-  Documentary:
-    - type: genre
-      value: documentaries (documents)
-      uri: http://vocab.getty.edu/aat/300249172
-      source:
-        code: aat
-  Dramatic performance:
-    - type: genre
-      value: Drama
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
-      source:
-        code: lcgft
-  Ethnography:
-    - type: genre
-      value: Ethnographies
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
-      source:
-        code: lcgft
-  Field recordings:
-    - type: genre
-      value: Field recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
-      source:
-        code: lcgft
-  Interview:
-    - type: genre
-      value: Interviews
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
-      source:
-        code: lcgft
-  MIDI:
-    - type: genre
-      value: MIDI (information technology)
-      uri: http://vocab.getty.edu/aat/300266746
-      source:
-        code: aat
-  Musical notation:
-    - type: genre
-      value: Notated music
-      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
-      source:
-        code: lcgft
-  Musical performance:
-    - type: genre
-      value: musical performances
-      uri: http://vocab.getty.edu/aat/300262956
-      source:
-        code: aat
-  Oral history:
-    - type: genre
-      value: Oral histories
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
-      source:
-        code: lcgft
-  Other spoken word:
-    - type: genre
-      value: Spoken word
-  Podcast:
-    - type: genre
-      value: Podcasts
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
-      source:
-        code: lcgft
-  Poetry reading:
-    - type: genre
-      value: Poetry
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
-      source:
-        code: lcgft
-  Speech:
-    - type: genre
-      value: Speeches
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
-      source:
-        code: lcgft
-  Story:
-    - type: genre
-      value: Fiction
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
-      source:
-        code: lcgft
-  Transcript:
-    - type: genre
-      value: transcripts
-      uri: http://vocab.getty.edu/aat/300027388
-      source:
-        code: aat
-  Unedited recording:
-    - type: genre
-      value: Unedited sound recordings
-Video:
-  Animation:
-    - type: genre
-      value: animations (visual works)
-      uri: http://vocab.getty.edu/aat/300411663
-      source:
-        code: aat
-  Broadcast:
-    - type: genre
-      value: Television programs
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026673
-      source:
-        code: lcgft
-  Conference session:
-    - type: genre
-      value: Conference sessions
-  Course/instruction:
-    - type: genre
-      value: Instructional and educational works
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-      source:
-        code: lcgft
-  Documentary:
-    - type: genre
-      value: Documentary films
-      uri: http://id.loc.gov/authorities/genreForms/gf201102620
-      source:
-        code: lcgft
-  Ethnography:
-    - type: genre
-      value: Ethnographic films
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026232
-      source:
-        code: lcgft
-  Event:
-    - type: genre
-      value: events (activities)
-      uri: http://vocab.getty.edu/aat/300069084
-      source:
-        code: aat
-  Experimental:
-    - type: genre
-      value: Experimental films
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026235
-      source:
-        code: lcgft
-  Field recordings:
-    - type: genre
-      value: Field recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
-      source:
-        code: lcgft
-  Narrative film:
-    - type: genre
-      value: Fiction films
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
-      source:
-        code: lcgft
-  Oral history:
-    - type: genre
-      value: Oral histories
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
-      source:
-        code: lcgft
-  Performance:
-    - type: genre
-      value: Filmed performances
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026276
-      source:
-        code: lcgft
-  Presentation:
-    - type: genre
-      value: presentations (communicative events)
-      uri: http://vocab.getty.edu/aat/300258677
-      source:
-        code: aat
-  Unedited footage:
-    - type: genre
-      value: Unedited footage
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026712
-      source:
-        code: lcgft
-  Video art:
-    - type: genre
-      value: Video art
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
-      source:
-        code: lcgft
-Mixed Materials:
-  Data:
-    - type: genre
-      value: dataset
+  type:
     - type: genre
       value: Data sets
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026119
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
       source:
         code: lcgft
-  Image:
+  subtypes:
+    3D model:
+      - type: genre
+        value: Three dimensional scan
+    Audio:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Database:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: Databases
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+        source:
+          code: lcgft
+    GIS:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: Geographic information systems
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+        source:
+          code: lcgft
+    Image:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Questionnaire:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: Questionnaires
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+        source:
+          code: lcgft
+    Remote sensing imagery:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: Remote-sensing images
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+        source:
+          code: lcgft
+    Software/code:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: software
+        uri: http://vocab.getty.edu/aat/300028566
+        source:
+          code: aat
+    Statistical model:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: mathematical models
+        uri: http://vocab.getty.edu/aat/300065075
+        source:
+          code: aat
+    Tabular data:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: Tables (Data)
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+        source:
+          code: lcgft
+    Text corpus:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: Text corpora
+        uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+        source:
+          code: lcgft
+    Text documentation:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: Data dictionaries
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026080
+        source:
+          code: lcgft
+    Video:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+Software or Code:
+  subtypes:
+    Code:
+      - type: genre
+        value: programs (computer)
+        uri: http://vocab.getty.edu/aat/300312188
+        source:
+          code: aat
+    Documentation:
+      - type: genre
+        value: technical manuals
+        uri: http://vocab.getty.edu/aat/300026413
+        source:
+          code: aat
+    Game:
+      - type: genre
+        value: video games
+        uri: http://vocab.getty.edu/aat/300256888
+        source:
+          code: aat
+Image:
+  type:
     - type: genre
       value: Pictures
       uri: http://id.loc.gov/authorities/genreForms/gf2017027251
       source:
         code: lcgft
-  Software/Code:
-    - type: genre
-      value: software
-      uri: http://vocab.getty.edu/aat/300028566
-      source:
-        code: aat
-  Sound:
+  subtypes:
+    CAD:
+      - type: genre
+        value: computer-aided designs (visual works)
+        uri: http://vocab.getty.edu/aat/300418056
+        source:
+          code: aat
+    Map:
+      - type: genre
+        value: Maps
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+        source:
+          code: lcgft
+    Photograph:
+      - type: genre
+        value: Photographs
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+        source:
+          code: lcgft
+    Poster:
+      - type: genre
+        value: Posters
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+        source:
+          code: lcgft
+    Presentation slides:
+      - type: genre
+        value: Presentation slides
+Sound:
+  type:
     - type: genre
       value: Sound recordings
       uri: http://id.loc.gov/authorities/genreForms/gf2011026594
       source:
         code: lcgft
-  Text:
-    - type: genre
-      value: texts (documents)
-      uri: http://vocab.getty.edu/aat/300263751
-      source:
-        code: aat
-  Video:
+  subtypes:
+    Course/instruction:
+      - type: genre
+        value: Instructional and educational works
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+        source:
+          code: lcgft
+    Documentary:
+      - type: genre
+        value: documentaries (documents)
+        uri: http://vocab.getty.edu/aat/300249172
+        source:
+          code: aat
+    Dramatic performance:
+      - type: genre
+        value: Drama
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+        source:
+          code: lcgft
+    Ethnography:
+      - type: genre
+        value: Ethnographies
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+        source:
+          code: lcgft
+    Field recordings:
+      - type: genre
+        value: Field recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+        source:
+          code: lcgft
+    Interview:
+      - type: genre
+        value: Interviews
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+        source:
+          code: lcgft
+    MIDI:
+      - type: genre
+        value: MIDI (information technology)
+        uri: http://vocab.getty.edu/aat/300266746
+        source:
+          code: aat
+    Musical notation:
+      - type: genre
+        value: Notated music
+        uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+        source:
+          code: lcgft
+    Musical performance:
+      - type: genre
+        value: musical performances
+        uri: http://vocab.getty.edu/aat/300262956
+        source:
+          code: aat
+    Oral history:
+      - type: genre
+        value: Oral histories
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+        source:
+          code: lcgft
+    Other spoken word:
+      - type: genre
+        value: Spoken word
+    Podcast:
+      - type: genre
+        value: Podcasts
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+        source:
+          code: lcgft
+    Poetry reading:
+      - type: genre
+        value: Poetry
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+        source:
+          code: lcgft
+    Speech:
+      - type: genre
+        value: Speeches
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+        source:
+          code: lcgft
+    Story:
+      - type: genre
+        value: Fiction
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+        source:
+          code: lcgft
+    Transcript:
+      - type: genre
+        value: transcripts
+        uri: http://vocab.getty.edu/aat/300027388
+        source:
+          code: aat
+    Unedited recording:
+      - type: genre
+        value: Unedited sound recordings
+Video:
+  type:
     - type: genre
       value: moving images
       uri: http://vocab.getty.edu/aat/300263857
       source:
         code: aat
+  subtypes:
+    Animation:
+      - type: genre
+        value: animations (visual works)
+        uri: http://vocab.getty.edu/aat/300411663
+        source:
+          code: aat
+    Broadcast:
+      - type: genre
+        value: Television programs
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026673
+        source:
+          code: lcgft
+    Conference session:
+      - type: genre
+        value: Conference sessions
+    Course/instruction:
+      - type: genre
+        value: Instructional and educational works
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+        source:
+          code: lcgft
+    Documentary:
+      - type: genre
+        value: Documentary films
+        uri: http://id.loc.gov/authorities/genreForms/gf201102620
+        source:
+          code: lcgft
+    Ethnography:
+      - type: genre
+        value: Ethnographic films
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026232
+        source:
+          code: lcgft
+    Event:
+      - type: genre
+        value: events (activities)
+        uri: http://vocab.getty.edu/aat/300069084
+        source:
+          code: aat
+    Experimental:
+      - type: genre
+        value: Experimental films
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026235
+        source:
+          code: lcgft
+    Field recordings:
+      - type: genre
+        value: Field recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+        source:
+          code: lcgft
+    Narrative film:
+      - type: genre
+        value: Fiction films
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+        source:
+          code: lcgft
+    Oral history:
+      - type: genre
+        value: Oral histories
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+        source:
+          code: lcgft
+    Performance:
+      - type: genre
+        value: Filmed performances
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026276
+        source:
+          code: lcgft
+    Presentation:
+      - type: genre
+        value: presentations (communicative events)
+        uri: http://vocab.getty.edu/aat/300258677
+        source:
+          code: aat
+    Unedited footage:
+      - type: genre
+        value: Unedited footage
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026712
+        source:
+          code: lcgft
+    Video art:
+      - type: genre
+        value: Video art
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+        source:
+          code: lcgft
+Mixed Materials:
+  subtypes:
+    Data:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: Data sets
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+    Image:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Software/Code:
+      - type: genre
+        value: software
+        uri: http://vocab.getty.edu/aat/300028566
+        source:
+          code: aat
+    Sound:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Text:
+      - type: genre
+        value: texts (documents)
+        uri: http://vocab.getty.edu/aat/300263751
+        source:
+          code: aat
+    Video:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat

--- a/config/mappings/types_to_resource_types.yml
+++ b/config/mappings/types_to_resource_types.yml
@@ -1,401 +1,443 @@
 Text:
-  Article:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Book:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Book chapter:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Correspondence:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Essay:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Government document:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Journal/periodical:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Manuscript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Poster:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Presentation slides:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Speech:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Syllabus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Teaching materials:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Technical report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Thesis:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Transcription:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  White paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Working paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
+  type:
+    type: resource type
+    value: text
+    source:
+      value: MODS resource types
+  subtypes:
+    Article:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Book:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Book chapter:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Correspondence:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Essay:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Government document:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Journal/periodical:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Manuscript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Poster:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Presentation slides:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Speech:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Syllabus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Teaching materials:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Technical report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Thesis:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Transcription:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    White paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Working paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
 Data:
-  3D model:
-    - type: resource type
-      value: three dimensional object
-      source:
-        value: MODS resource types
-  Audio:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Database:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  GIS:
-    - type: resource type
-      value: cartographic
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Image:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Questionnaire:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Remote sensing imagery:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Software/code:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Statistical model:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Tabular data:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Text corpus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Text documentation:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Video:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
+  type:
+    type: resource type
+    value: software, multimedia
+    source:
+      value: MODS resource types
+  subtypes:
+    3D model:
+      - type: resource type
+        value: three dimensional object
+        source:
+          value: MODS resource types
+    Audio:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Database:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    GIS:
+      - type: resource type
+        value: cartographic
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Image:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Questionnaire:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Remote sensing imagery:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Software/code:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Statistical model:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Tabular data:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Text corpus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Text documentation:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Video:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
 Software or Code:
-  Code:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Documentation:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Game:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
+  type:
+    type: resource type
+    value: software, multimedia
+    source:
+      value: MODS resource types
+  subtypes:
+    Code:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Documentation:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Game:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
 Image:
-  CAD:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Map:
-    - type: resource type
-      value: cartographic
-      source:
-        value: MODS resource types
-  Photograph:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Poster:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Presentation slides:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
+  type:
+    type: resource type
+    value: still image
+    source:
+      value: MODS resource types
+  subtypes:
+    CAD:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Map:
+      - type: resource type
+        value: cartographic
+        source:
+          value: MODS resource types
+    Photograph:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Poster:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Presentation slides:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
 Sound:
-  Course/instruction:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Documentary:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Dramatic performance:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Ethnography:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Field recordings:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Interview:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  MIDI:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Musical notation:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-  Musical performance:
-    - type: resource type
-      value: sound recording-musical
-      source:
-        value: MODS resource types
-  Oral history:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Other spoken word:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Podcast:
-    - type: resource type
-      value: Podcasts
-      source:
-        value: MODS resource types
-  Poetry reading:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Speech:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Story:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Transcript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Unedited recording:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
+  type:
+    type: resource type
+    value: sound recording
+    source:
+      value: MODS resource types
+  subtypes:
+    Course/instruction:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Documentary:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Dramatic performance:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Ethnography:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Field recordings:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Interview:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    MIDI:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Musical notation:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+    Musical performance:
+      - type: resource type
+        value: sound recording-musical
+        source:
+          value: MODS resource types
+    Oral history:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Other spoken word:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Podcast:
+      - type: resource type
+        value: Podcasts
+        source:
+          value: MODS resource types
+    Poetry reading:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Speech:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Story:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Transcript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Unedited recording:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
 Video:
-  Animation:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Broadcast:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Conference session:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Course/instruction:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Documentary:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Ethnography:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Event:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Experimental:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Field recordings:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Narrative film:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Oral history:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Performance:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Presentation:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Unedited footage:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Video art:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
+  type:
+    type: resource type
+    value: moving image
+    source:
+      value: MODS resource types
+  subtypes:
+    Animation:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Broadcast:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Conference session:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Course/instruction:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Documentary:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Ethnography:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Event:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Experimental:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Field recordings:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Narrative film:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Oral history:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Performance:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Presentation:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Unedited footage:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Video art:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
 Mixed materials:
-  Data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Image:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Software/Code:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Sound:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Text:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Video:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
+  type:
+    type: resource type
+    value: mixed material
+    source:
+      value: MODS resource types
+  subtypes:
+    Data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Image:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Software/Code:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Sound:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Text:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Video:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types

--- a/sorbet/rails-rbi/models/collection.rbi
+++ b/sorbet/rails-rbi/models/collection.rbi
@@ -17,15 +17,6 @@ module Collection::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def access?; end
 
-  sig { returns(T.nilable(String)) }
-  def contact_email; end
-
-  sig { params(value: T.nilable(T.any(String, Symbol))).void }
-  def contact_email=(value); end
-
-  sig { returns(T::Boolean) }
-  def contact_email?; end
-
   sig { returns(ActiveSupport::TimeWithZone) }
   def created_at; end
 
@@ -181,6 +172,15 @@ module Collection::GeneratedAttributeMethods
 end
 
 module Collection::GeneratedAssociationMethods
+  sig { returns(::ContactEmail::ActiveRecord_Associations_CollectionProxy) }
+  def contact_emails; end
+
+  sig { returns(T::Array[Integer]) }
+  def contact_email_ids; end
+
+  sig { params(value: T::Enumerable[::ContactEmail]).void }
+  def contact_emails=(value); end
+
   sig { returns(::User) }
   def creator; end
 

--- a/spec/services/types_generator_spec.rb
+++ b/spec/services/types_generator_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe TypesGenerator do
     context 'with a work of type Text lacking subtypes' do
       let(:work) { build(:work, work_type: 'text', subtype: []) }
 
-      it 'generates a single structured value' do
+      it 'generates a single structured value, a single resource type and no genre' do
         expect(generated).to eq(
           [
             Cocina::Models::DescriptiveValue.new(
@@ -96,6 +96,38 @@ RSpec.describe TypesGenerator do
             Cocina::Models::DescriptiveValue.new(
               type: 'resource type',
               value: 'text',
+              source: { value: 'MODS resource types' }
+            )
+          ]
+        )
+      end
+    end
+
+    context 'with a work of type Sound lacking subtypes' do
+      let(:work) { build(:work, work_type: 'sound', subtype: []) }
+
+      it 'generates a single structured value, a single resource type, and a single genre' do
+        expect(generated).to eq(
+          [
+            Cocina::Models::DescriptiveValue.new(
+              source: { value: 'Stanford self-deposit resource types' },
+              type: 'resource type',
+              structuredValue: [
+                Cocina::Models::DescriptiveValue.new(
+                  type: 'type',
+                  value: 'Sound'
+                )
+              ]
+            ),
+            Cocina::Models::DescriptiveValue.new(
+              type: 'genre',
+              value: 'Sound recordings',
+              uri: 'http://id.loc.gov/authorities/genreForms/gf2011026594',
+              source: { code: 'lcgft' }
+            ),
+            Cocina::Models::DescriptiveValue.new(
+              type: 'resource type',
+              value: 'sound recording',
               source: { value: 'MODS resource types' }
             )
           ]

--- a/spec/services/types_generator_spec.rb
+++ b/spec/services/types_generator_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe TypesGenerator do
       end
     end
 
-    context 'with a work lacking subtypes' do
+    context 'with a work of type Text lacking subtypes' do
       let(:work) { build(:work, work_type: 'text', subtype: []) }
 
       it 'generates a single structured value' do
@@ -92,6 +92,11 @@ RSpec.describe TypesGenerator do
                   value: 'Text'
                 )
               ]
+            ),
+            Cocina::Models::DescriptiveValue.new(
+              type: 'resource type',
+              value: 'text',
+              source: { value: 'MODS resource types' }
             )
           ]
         )


### PR DESCRIPTION
## Why was this change made?

Fixes #939 - allow resource type and genre mappings of top level work types (without subtype selected) 

Note, it looks like all of the mappings changed in the .yml, but they did not.  Instead, all of the subtype mappings became nested in a new `subtypes` header, allowing a `type` header for mapping a work type without subtypes.

## How was this change tested?

New and existing unit tests

## Which documentation and/or configurations were updated?

Mapping spreadsheet: https://docs.google.com/spreadsheets/d/1EiGgVqtb6PUJE2cI_jhqnAoiQkiwZtar4tF7NHwSMz8/edit#gid=387882643
