### PR TITLE
Add ruby to PLATFORMS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -498,6 +498,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  ruby
   x86_64-darwin-18
   x86_64-darwin-19
   x86_64-linux


### PR DESCRIPTION
## Why was this change made?

Without including `ruby` in the `PLATFORMS` section of the Gemfile.lock, everytime I run `bin/rails server` bundler apparently automatically adds it. Causing issues switching branching without committing this change or ditching it.

Happy to discuss at standup and close if there is a better approach to addressing this.

## How was this change tested?



## Which documentation and/or configurations were updated?



