### PR TITLE
truncate long titles in breadcrumbs

### DIFF
--- a/app/components/breadcrumb_nav_component.html.erb
+++ b/app/components/breadcrumb_nav_component.html.erb
@@ -1,14 +1,17 @@
 <nav class="breadcrumbs">
   <nav id="breadcrumbs" aria-label="breadcrumb" class="container-xxl">
     <ol class="breadcrumb">
-      <% breadcrumbs.each do |breadcrumb| %>
+      <% breadcrumbs.each do |breadcrumb|
+        full_title = breadcrumb[:title].presence || 'No title'
+        truncated_title = truncate(full_title, length: 150, separator: ' ')
+        %>
         <li class="breadcrumb-item">
           <% if breadcrumb[:link].blank? %>
-            <span class="breadcrumb-link"><%= breadcrumb[:title] %></span>
+            <span title="<%=full_title%>" class="breadcrumb-link"><%= truncated_title %></span>
           <% else %>
-            <%= link_to breadcrumb[:title].presence || 'No title',
-                        breadcrumb[:link], class: 'breadcrumb-link',
-                        data: (breadcrumb[:confirm] ? { confirm: 'Are you sure you want to leave this page? Your changes will not be saved.' } : nil) %>
+            <%= link_to truncated_title,
+                          breadcrumb[:link], class: 'breadcrumb-link', title: full_title,
+                          data: (breadcrumb[:confirm] ? { confirm: 'Are you sure you want to leave this page? Your changes will not be saved.' } : nil) %>
           <% end %>
         </li>
       <% end %>

--- a/app/components/breadcrumb_nav_component.html.erb
+++ b/app/components/breadcrumb_nav_component.html.erb
@@ -1,16 +1,13 @@
 <nav class="breadcrumbs">
   <nav id="breadcrumbs" aria-label="breadcrumb" class="container-xxl">
     <ol class="breadcrumb">
-      <% breadcrumbs.each do |breadcrumb|
-        full_title = breadcrumb[:title].presence || 'No title'
-        truncated_title = truncate(full_title, length: 150, separator: ' ')
-        %>
+      <% breadcrumbs.each do |breadcrumb| %>
         <li class="breadcrumb-item">
           <% if breadcrumb[:link].blank? %>
-            <span title="<%=full_title%>" class="breadcrumb-link"><%= truncated_title %></span>
+            <span title="<%=full_title(breadcrumb[:title])%>" class="breadcrumb-link"><%= truncated_title(breadcrumb[:title]) %></span>
           <% else %>
-            <%= link_to truncated_title,
-                          breadcrumb[:link], class: 'breadcrumb-link', title: full_title,
+            <%= link_to truncated_title(breadcrumb[:title]),
+                          breadcrumb[:link], class: 'breadcrumb-link', title: full_title(breadcrumb[:title]),
                           data: (breadcrumb[:confirm] ? { confirm: 'Are you sure you want to leave this page? Your changes will not be saved.' } : nil) %>
           <% end %>
         </li>

--- a/app/components/breadcrumb_nav_component.rb
+++ b/app/components/breadcrumb_nav_component.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: false
 # frozen_string_literal: true
 
 # Displays the top bread crumb navigation
@@ -6,6 +6,16 @@ class BreadcrumbNavComponent < ApplicationComponent
   def initialize(breadcrumbs: [], show_dashboard: true, confirm_dashboard: false)
     @breadcrumbs = breadcrumbs
     @breadcrumbs.unshift({ title: 'Dashboard', link: '/dashboard', confirm: confirm_dashboard }) if show_dashboard
+  end
+
+  sig { params(breadcrumb: T.nilable(String)).returns(T.nilable(String)) }
+  def full_title(breadcrumb)
+    breadcrumb.presence || 'No title'
+  end
+
+  sig { params(breadcrumb: T.nilable(String)).returns(T.nilable(String)) }
+  def truncated_title(breadcrumb)
+    truncate(full_title(breadcrumb), length: 150, separator: ' ')
   end
 
   attr_accessor :breadcrumbs

--- a/app/components/dashboard/in_progress_row_component.html.erb
+++ b/app/components/dashboard/in_progress_row_component.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-4">
-    <%= collection_name %> &gt; <%= edit_work_link %>
+    <span title="<%=collection_name%>"><%= truncate(collection_name, length: 100, separator: ' ') %></span> &gt; <%= edit_work_link %>
   </div>
   <div class="col-5">
     <%= render Dashboard::DepositProgressComponent.new(work: work) %>

--- a/app/components/dashboard/in_progress_row_component.html.erb
+++ b/app/components/dashboard/in_progress_row_component.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-4">
-    <span title="<%=collection_name%>"><%= truncate(collection_name, length: 100, separator: ' ') %></span> &gt; <%= edit_work_link %>
+    <span title="<%=collection_name%>"><%=truncated_collection_name%></span> &gt; <%= edit_work_link %>
   </div>
   <div class="col-5">
     <%= render Dashboard::DepositProgressComponent.new(work: work) %>

--- a/app/components/dashboard/in_progress_row_component.rb
+++ b/app/components/dashboard/in_progress_row_component.rb
@@ -16,6 +16,10 @@ module Dashboard
       Dashboard::CollectionHeaderComponent.new(collection: work.collection).name
     end
 
+    def truncated_collection_name
+      truncate(collection_name, length: 100, separator: ' ')
+    end
+
     def edit_work_link
       title = Works::DetailComponent.new(work: work).title
       link_to truncate(title, length: 100, separator: ' '), edit_work_path(work), title: title

--- a/app/components/dashboard/in_progress_row_component.rb
+++ b/app/components/dashboard/in_progress_row_component.rb
@@ -17,7 +17,8 @@ module Dashboard
     end
 
     def edit_work_link
-      link_to Works::DetailComponent.new(work: work).title, edit_work_path(work)
+      title = Works::DetailComponent.new(work: work).title
+      link_to truncate(title, length: 100, separator: ' '), edit_work_path(work), title: title
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #953 - truncate collection and work title lengths in breadcrumb navigation and in-progress section of dashboard

## How was this change tested?

Unit test and localhost browser


## Which documentation and/or configurations were updated?



