### PR TITLE
Add pencil icons that are edit links to the items in progress

### DIFF
--- a/app/components/dashboard/in_progress_row_component.html.erb
+++ b/app/components/dashboard/in_progress_row_component.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-4">
-    <%= show_collection_link %> &gt; <%= edit_work_link %>
+    <%= show_collection_link %> &gt; <%= work_link %> <%= edit_work_link %>
   </div>
   <div class="col-5">
     <%= render Dashboard::DepositProgressComponent.new(work: work) %>

--- a/app/components/dashboard/in_progress_row_component.rb
+++ b/app/components/dashboard/in_progress_row_component.rb
@@ -17,7 +17,16 @@ module Dashboard
     end
 
     def edit_work_link
-      title = Works::DetailComponent.new(work: work).title
+      link_to edit_work_path(work), aria: { label: "Edit #{title}" } do
+        tag.span class: 'fas fa-pencil-alt'
+      end
+    end
+
+    def title
+      @title ||= Works::DetailComponent.new(work: work).title
+    end
+
+    def work_link
       link_to truncate(title, length: 100, separator: ' '), edit_work_path(work), title: title
     end
 

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -156,7 +156,6 @@ RSpec.describe 'Dashboard requests' do
       get '/dashboard'
       expect(response).to have_http_status(:ok)
       expect(response.body).to include 'Deposit to this collection'
-      expect(response.body).not_to include 'Edit'
     end
   end
 


### PR DESCRIPTION


## Why was this change made?


Fixes #944

## How was this change tested?

<img width="919" alt="Screen Shot 2021-02-01 at 8 28 41 PM" src="https://user-images.githubusercontent.com/92044/106543864-2c0baa00-64cc-11eb-8910-0a21d9452769.png">




## Which documentation and/or configurations were updated?



