### PR TITLE
add terms to progress bars

### DIFF
--- a/app/components/dashboard/deposit_progress_component.html.erb
+++ b/app/components/dashboard/deposit_progress_component.html.erb
@@ -5,4 +5,5 @@
   <li class="<%= 'active' if has_description? %>">Description</li>
   <li class="<%= 'active' if has_release? %>">Release</li>
   <li class="<%= 'active' if has_license? %>">License</li>
+  <li class="<%= 'active' if has_terms? %>">Terms</li>
 </ul>

--- a/app/components/dashboard/deposit_progress_component.rb
+++ b/app/components/dashboard/deposit_progress_component.rb
@@ -41,5 +41,10 @@ module Dashboard
     def has_license?
       true # The license section is always done as it defaults to a valid choice.
     end
+
+    sig { returns(T.nilable(T::Boolean)) }
+    def has_terms?
+      work.agree_to_terms
+    end
   end
 end

--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -7,7 +7,7 @@
                         data: { dropzone_target: 'input',
                                 edit_deposit_target: 'fileField',
                                 'progress-step': 'file',
-                                action: "change->progress#check" } %>
+                                action: "change->edit-deposit#check" } %>
     <div class="dz-message needsclick text-secondary">
       <p>Drop files here</p>
     </div>

--- a/app/components/works/agreement_component.html.erb
+++ b/app/components/works/agreement_component.html.erb
@@ -1,6 +1,9 @@
 <div class="row justify-content-end agreement">
   <div class="form-check col-auto">
-    <%= form.check_box :agree_to_terms, required: true, class: 'form-check-input' %>
+    <%= form.check_box :agree_to_terms, required: true, class: 'form-check-input',
+        data: { action: "change->edit-deposit#check",
+                        'progress-step': 'terms', edit_deposit_target: 'termsField' }
+     %>
     <%= form.label :agree_to_terms,
      "I agree to the #{link_to 'SDR Terms of Deposit', '#termsOfDepositModal', data: { bs_toggle: 'modal', bs_target: '#termsOfDepositModal'}}".html_safe,
      class: 'form-check-label' %>

--- a/app/components/works/deposit_progress_component.html.erb
+++ b/app/components/works/deposit_progress_component.html.erb
@@ -7,6 +7,7 @@
       <li data-edit-deposit-target="description">Description</li>
       <li data-edit-deposit-target="release">Release</li>
       <li data-edit-deposit-target="license">License</li>
+      <li data-edit-deposit-target="terms">Terms</li>
     </ul>
   </div>
 

--- a/app/components/works/title_component.html.erb
+++ b/app/components/works/title_component.html.erb
@@ -4,7 +4,7 @@
      <%= form.label :title, 'Title of deposit', class: 'col-sm-2 col-form-label' %>
      <div class="col-sm-10">
        <%= form.text_field :title, class: "form-control", required: true,
-                           data: { action: "change->auto-citation#updateDisplay change->progress#check",
+                           data: { action: "change->auto-citation#updateDisplay change->edit-deposit#check",
                                    'progress-step': 'title',
                                    auto_citation_target: 'titleField',
                                    edit_deposit_target: 'titleField' } %>

--- a/app/javascript/controllers/edit_deposit_controller.js
+++ b/app/javascript/controllers/edit_deposit_controller.js
@@ -4,12 +4,13 @@ export default class extends Controller {
   static targets = ["title", "titleField",
                     "file", "fileField",
                     "keywordsField", "contributorsField",
-                    "embargo-dateField"];
+                    "embargo-dateField", "terms", "termsField"];
 
   connect() {
     // TODO see what of the things are already valid
     this.checkField(this.fileFieldTarget)
     this.checkField(this.titleFieldTarget)
+    this.checkField(this.termsFieldTarget)
   }
 
   check(e) {
@@ -20,9 +21,11 @@ export default class extends Controller {
     const stepName = field.getAttribute("data-progress-step")
     const step = this.targets.find(stepName)
     let isComplete = field.value !== ''
-    // For files look for hidden inputs
     if (stepName === 'file') {
-      isComplete = document.querySelectorAll('[type=hidden][name="work[files][]"]').length > 0
+      isComplete = document.querySelectorAll('.dz-preview').length > 0
+    }
+    if (stepName === 'terms') {
+      isComplete = document.querySelector('#work_agree_to_terms').checked
     }
     step.classList.toggle('active', isComplete)
   }

--- a/sorbet/rails-rbi/models/abstract_contributor.rbi
+++ b/sorbet/rails-rbi/models/abstract_contributor.rbi
@@ -71,15 +71,6 @@ module AbstractContributor::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def role?; end
 
-  sig { returns(T.nilable(String)) }
-  def type; end
-
-  sig { params(value: T.nilable(T.any(String, Symbol))).void }
-  def type=(value); end
-
-  sig { returns(T::Boolean) }
-  def type?; end
-
   sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 

--- a/sorbet/rails-rbi/models/author.rbi
+++ b/sorbet/rails-rbi/models/author.rbi
@@ -71,15 +71,6 @@ module Author::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def role?; end
 
-  sig { returns(T.nilable(String)) }
-  def type; end
-
-  sig { params(value: T.nilable(T.any(String, Symbol))).void }
-  def type=(value); end
-
-  sig { returns(T::Boolean) }
-  def type?; end
-
   sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 

--- a/sorbet/rails-rbi/models/contributor.rbi
+++ b/sorbet/rails-rbi/models/contributor.rbi
@@ -71,15 +71,6 @@ module Contributor::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def role?; end
 
-  sig { returns(T.nilable(String)) }
-  def type; end
-
-  sig { params(value: T.nilable(T.any(String, Symbol))).void }
-  def type=(value); end
-
-  sig { returns(T::Boolean) }
-  def type?; end
-
   sig { returns(ActiveSupport::TimeWithZone) }
   def updated_at; end
 


### PR DESCRIPTION
## Why was this change made?

Fixes #969 : 
- add "terms" to progress bar on both dashboard and edit work page.
- ensure terms progress field is updated dynamically when you check/uncheck on edit work page
- fix misnamed JS controller reference in other terms on edit work page
- use a different selector for the files that accurately reflects when files exist (previous selector always return length == 0, so that it never looked like files had been uploaded)

NOTE: when working on this, it appears multiple other fields in the terms progress bar on the edit work page are not being updated right now:
- author, description, release, license

## How was this change tested?

Unit tests


## Which documentation and/or configurations were updated?



