### PR TITLE
Update label for organizational name

### DIFF
--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -26,7 +26,7 @@
     <div class="invalid-feedback">You must provide a last name</div>
   </div>
   <div class="col-md-8" data-contributors-target="organizationName">
-    <%= form.label :full_name, 'Name', class: 'form-label' %>
+    <%= form.label :full_name, 'Organization Name', class: 'form-label' %>
     <%= form.text_field :full_name, html_options('organizationNameInput', 'contributorOrg') %>
     <div class="invalid-feedback">You must provide a name</div>
   </div>


### PR DESCRIPTION
## Why was this change made?

Fixes #573



## How was this change tested?

<img width="1176" alt="Screen Shot 2021-02-01 at 10 57 58 PM" src="https://user-images.githubusercontent.com/92044/106554473-1359bf00-64e1-11eb-8f38-211d028e73f9.png">

## Which documentation and/or configurations were updated?



