### PR TITLE
Require the email to be entered before the title is marked as complete

### DIFF
--- a/app/components/dashboard/deposit_progress_component.rb
+++ b/app/components/dashboard/deposit_progress_component.rb
@@ -19,7 +19,7 @@ module Dashboard
 
     sig { returns(T::Boolean) }
     def has_title?
-      work.title.present?
+      work.title.present? && work.contact_email.present?
     end
 
     sig { returns(T::Boolean) }

--- a/spec/components/dashboard/deposit_progress_component_spec.rb
+++ b/spec/components/dashboard/deposit_progress_component_spec.rb
@@ -8,6 +8,14 @@ RSpec.describe Dashboard::DepositProgressComponent, type: :component do
   let(:work) { build_stubbed(:work, collection: build(:collection, id: 7)) }
   let(:rendered) { render_inline(component) }
 
+  context 'when work is new' do
+    let(:work) { Work.new }
+
+    it 'only license and release are marked as active' do
+      expect(rendered.css('li.active').size).to eq 2
+    end
+  end
+
   context 'when work has a title' do
     let(:work) { build_stubbed(:work) }
 


### PR DESCRIPTION
## Why was this change made?

Fixes #957

## How was this change tested?



## Which documentation and/or configurations were updated?



