### PR TITLE
Ignore spring when it is not installed

### DIFF
--- a/bin/spring
+++ b/bin/spring
@@ -1,10 +1,13 @@
 #!/usr/bin/env ruby
 if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
-  # Load Spring without loading other gems in the Gemfile, for speed.
   require "bundler"
+
+  # Load Spring without loading other gems in the Gemfile, for speed.
   Bundler.locked_gems.specs.find { |spec| spec.name == "spring" }&.tap do |spring|
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
     gem "spring", spring.version
     require "spring/binstub"
+  rescue Gem::LoadError
+  # Ignore when Spring is not installed.
   end
 end


### PR DESCRIPTION


## Why was this change made?
i.e. in production.

This allows us to do `bin/rails c -e p` on the servers again

See: https://github.com/rails/rails/pull/40913


## How was this change tested?



## Which documentation and/or configurations were updated?



