### PR TITLE
allow saving of works that are in the pending_approval states by collection managers

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -57,6 +57,7 @@ class Work < ApplicationRecord
 
     event :submit_for_review do
       transition %i[first_draft version_draft rejected] => :pending_approval
+      transition pending_approval: same
     end
 
     event :reject do
@@ -67,7 +68,7 @@ class Work < ApplicationRecord
       transition deposited: :version_draft
       transition new: :first_draft
 
-      transition %i[first_draft version_draft rejected] => same
+      transition %i[first_draft version_draft pending_approval rejected] => same
     end
   end
 

--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -32,17 +32,19 @@ class WorkPolicy < ApplicationPolicy
   #   The work is in a state where it can be updated (e.g. not depositing)
   #   AND if any one of the following is true:
   #     1. The user is an administrator
-  #     2. The user is the depositor of the work
+  #     2. The user is the depositor of the work and it is not currently pending approval (review workflow)
   #     3. The user is a manager of the collection the work is in
   #     4. The user is a reviewer of the collection the work is in
+  # rubocop:disable Metrics/AbcSize
   sig { returns(T::Boolean) }
   def update?
     return true if administrator? ||
                    record.collection.managers.include?(user) ||
                    record.collection.reviewed_by.include?(user)
 
-    record.depositor == user && record.can_update_metadata?
+    record.depositor == user && record.can_update_metadata? && !record.pending_approval?
   end
+  # rubocop:enable Metrics/AbcSize
 
   # Can show a work iff any one of the following is true:
   #   1. The user is an administrator

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -289,6 +289,15 @@ RSpec.describe Work do
             .with(work, state: 'Draft - Not deposited')
         end
       end
+
+      context 'when the state is pending_approval' do
+        let(:work) { create(:work, :pending_approval) }
+
+        it 'does not transition the state' do
+          work.update_metadata!
+          expect(work.state).to eq 'pending_approval'
+        end
+      end
     end
 
     describe 'a deposit_complete event' do


### PR DESCRIPTION
## Why was this change made?

Fixes #996 - if an item has been submitted for approval, it is still possible for certain people (like a collection manager) to edit it ... this allows it to be saved correctly by keeping the state the same

## How was this change tested?

Localhost browser and new unit test


## Which documentation and/or configurations were updated?



