### PR TITLE
only show edit icons when user is allowed to edit works or collections

### DIFF
--- a/app/components/collections/edit_link_component.rb
+++ b/app/components/collections/edit_link_component.rb
@@ -11,6 +11,11 @@ module Collections
       @label = label
     end
 
+    sig { returns(T::Boolean) }
+    def render?
+      collection.can_update_metadata?
+    end
+
     attr_reader :collection, :anchor, :label
   end
 end

--- a/app/components/dashboard/in_progress_row_component.html.erb
+++ b/app/components/dashboard/in_progress_row_component.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-4">
-    <%= show_collection_link %> &gt; <%= work_link %> <%= edit_work_link %>
+    <%= show_collection_link %> &gt; <%= work_link %> <%= render Works::EditLinkComponent.new(work: work, anchor: '', label: "Edit #{title}") %>
   </div>
   <div class="col-5">
     <%= render Dashboard::DepositProgressComponent.new(work: work) %>

--- a/app/components/dashboard/in_progress_row_component.html.erb
+++ b/app/components/dashboard/in_progress_row_component.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-4">
-    <%= show_collection_link %> &gt; <%= work_link %> <%= render Works::EditLinkComponent.new(work: work, anchor: '', label: "Edit #{title}") %>
+    <%= show_collection_link %> &gt; <%= work_link %> <%= helpers.turbo_frame_tag dom_id(work, :edit), src: edit_button_work_path(work), target: '_top' %>
   </div>
   <div class="col-5">
     <%= render Dashboard::DepositProgressComponent.new(work: work) %>

--- a/app/components/dashboard/in_progress_row_component.rb
+++ b/app/components/dashboard/in_progress_row_component.rb
@@ -16,18 +16,12 @@ module Dashboard
       Dashboard::CollectionHeaderComponent.new(collection: work.collection).name
     end
 
-    def edit_work_link
-      link_to edit_work_path(work), aria: { label: "Edit #{title}" } do
-        tag.span class: 'fas fa-pencil-alt'
-      end
-    end
-
     def title
       @title ||= Works::DetailComponent.new(work: work).title
     end
 
     def work_link
-      link_to truncate(title, length: 100, separator: ' '), edit_work_path(work), title: title
+      link_to truncate(title, length: 100, separator: ' '), work_path(work), title: title
     end
 
     def show_collection_link

--- a/app/components/works/edit_link_component.rb
+++ b/app/components/works/edit_link_component.rb
@@ -11,6 +11,11 @@ module Works
       @label = label
     end
 
+    sig { returns(T::Boolean) }
+    def render?
+      work.can_update_metadata? && !work.pending_approval?
+    end
+
     attr_reader :work, :anchor, :label
   end
 end

--- a/app/components/works/edit_link_component.rb
+++ b/app/components/works/edit_link_component.rb
@@ -13,7 +13,7 @@ module Works
 
     sig { returns(T::Boolean) }
     def render?
-      work.can_update_metadata? && !work.pending_approval?
+      work.can_update_metadata?
     end
 
     attr_reader :work, :anchor, :label

--- a/spec/features/edit_draft_work_spec.rb
+++ b/spec/features/edit_draft_work_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Edit a draft work', js: true do
       visit dashboard_path
 
       within('#deposits-in-progress') do
-        click_link work.title
+        click_link "Edit #{work.title}"
       end
 
       expect(page).to have_content work.title
@@ -63,7 +63,7 @@ RSpec.describe 'Edit a draft work', js: true do
     visit dashboard_path
 
     within('#deposits-in-progress') do
-      click_link work.title
+      click_link "Edit #{work.title}"
     end
 
     accept_confirm do
@@ -77,7 +77,7 @@ RSpec.describe 'Edit a draft work', js: true do
     visit dashboard_path
 
     within('#deposits-in-progress') do
-      click_link work.title
+      click_link "Edit #{work.title}"
     end
 
     dismiss_confirm do
@@ -99,7 +99,7 @@ RSpec.describe 'Edit a draft work', js: true do
       visit dashboard_path
 
       within('#deposits-in-progress') do
-        click_link work.title
+        click_link "Edit #{work.title}"
       end
 
       expect(page).to have_content work.title


### PR DESCRIPTION
## Why was this change made?

- Users should only see edit icons/links if they are allowed to edit a collection or work.
- Refactor one spot where we create a edit work link to use the component instead
- Update specs
- Also fixes #943 (sorry @jcoyne didn't see you had this in progress), work text in progress bar should link to work show page, not work edit page

## How was this change tested?

Unit tests and localhost browser

## Which documentation and/or configurations were updated?



