### PR TITLE
Improve work type modal style and refactor in advance of modal changes

### DIFF
--- a/app/components/works/work_type_modal_component.html.erb
+++ b/app/components/works/work_type_modal_component.html.erb
@@ -31,10 +31,18 @@
       </div>
     </template>
 
+    <template data-work-type-target="templateHeader">
+      <h5>Which of the following terms further describe your deposit?</h5>
+    </template>
+
     <template data-work-type-target="otherTemplate">
       <div class="col-md-4">
         <input type="text" name="subtype[]" class="form-control" id="subtype_other">
       </div>
+    </template>
+
+    <template data-work-type-target="otherTemplateHeader">
+      <h5>Specify "Other" type</h5>
     </template>
 
     <div class="row" data-work-type-target="area" hidden></div>

--- a/app/components/works/work_type_modal_component.html.erb
+++ b/app/components/works/work_type_modal_component.html.erb
@@ -14,7 +14,7 @@
   <form method="get" action="/collections/1/work/new" data-work-type-target="form">
     <div class="row">
       <% types.each do |type| %>
-        <div class="col-md-3 mb-5" style="height: 4rem">
+        <div class="work-type-box">
           <%= render CheckboxButtonComponent.new(name: 'work_type', value: type.id, data: { action: "work-type#change" }) do %>
             <span class="fas fa-2x fa-<%= type.icon %>"></span> <div class="work-type-button-text"><%= type.label %></div>
           <% end %>

--- a/app/components/works/work_type_modal_component.html.erb
+++ b/app/components/works/work_type_modal_component.html.erb
@@ -1,9 +1,5 @@
 <script>
-  document.subtypes = {
-    <% WorkType.all.each do |type| %>
-      "<%= type.id %>": <%= type.subtypes.to_json.html_safe %>,
-    <% end %>
-  }
+  document.subtypes = <%= WorkType.to_json.html_safe %>
 </script>
 
 <div class="modal-header">

--- a/app/javascript/controllers/work_type_controller.js
+++ b/app/javascript/controllers/work_type_controller.js
@@ -1,7 +1,9 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  static targets = ["form", "template", "otherTemplate", "subtype", "area"]
+  static targets = [
+    "form", "template", "otherTemplate", "subtype", "area", "templateHeader", "otherTemplateHeader"
+  ]
 
   // Sets the form in the popup to use the action in the data-destination attribute
   set_collection(event) {
@@ -27,11 +29,11 @@ export default class extends Controller {
       return this.templateTarget.innerHTML.replace(/SUBTYPE_LABEL/g, subtype).replace(/SUBTYPE_ID/g, id)
     })
     this.subtypeTarget.innerHTML = subtypes.join('')
-    this.areaTarget.innerHTML = '<h5>Which of the following terms further describe your deposit?</h5>'
+    this.areaTarget.innerHTML = this.templateHeaderTarget.innerHTML
   }
 
   displayOtherSubtypeOptions() {
     this.subtypeTarget.innerHTML = this.otherTemplateTarget.innerHTML
-    this.areaTarget.innerHTML = '<h5>Specify "Other" type</h5>'
+    this.areaTarget.innerHTML = this.otherTemplateHeaderTarget.innerHTML
   }
 }

--- a/app/javascript/stylesheets/dashboard.scss
+++ b/app/javascript/stylesheets/dashboard.scss
@@ -28,9 +28,17 @@
     padding: 0.375rem 0.375rem;
   }
 
+  .work-type-box {
+    @extend .col-md-3;
+    @extend .mb-5;
+
+    height: 2rem;
+  }
+
   .work-type-button-text {
     display: inline-block;
     max-width: 60%;
+    padding-left: 1rem;
     vertical-align: middle;
   }
 

--- a/app/javascript/stylesheets/toggle.scss
+++ b/app/javascript/stylesheets/toggle.scss
@@ -4,14 +4,17 @@ input[type="radio"].toggle {
 
 input[type="radio"].toggle:checked + label {
   border: 3px solid $primary;
-  background-color: rgba($primary, 0.3);
+  background-color: rgba($primary, 0.1);
   left: -1.5px;
   position: relative;
   top: -1.5px; /* keeps the button from moving when the border grows */
 
   .check {
+    color: $primary;
     display: inline-block;
+    font-size: 1.5rem;
   }
+
   .uncheck {
     display: none;
   }
@@ -19,9 +22,9 @@ input[type="radio"].toggle:checked + label {
 
 input[type="radio"].toggle:focus + label {
   border: 3px solid $primary;
-  background-color: rgba($primary, 0.3);
+  background-color: rgba($primary, 0.1);
   left: -1.5px;
-  position: relative;  
+  position: relative;
   top: -1.5px;
 }
 

--- a/app/models/work_type.rb
+++ b/app/models/work_type.rb
@@ -8,102 +8,40 @@ class WorkType
   class InvalidType < StandardError; end
 
   DATA_TYPES = [
-    '3D model',
-    'Audio',
-    'Database',
-    'GIS',
-    'Image',
-    'Questionnaire',
-    'Remote sensing imagery',
-    'Software/code',
-    'Statistical model',
-    'Tabular data',
-    'Text corpus',
-    'Text documentation',
-    'Video'
+    '3D model', 'Audio', 'Database', 'GIS', 'Image', 'Questionnaire',
+    'Remote sensing imagery', 'Software/code', 'Statistical model',
+    'Tabular data', 'Text corpus', 'Text documentation', 'Video'
   ].freeze
 
   VIDEO_TYPES = [
-    'Animation',
-    'Broadcast',
-    'Conference session',
-    'Course/instruction',
-    'Documentary',
-    'Ethnography',
-    'Event',
-    'Experimental',
-    'Field recordings',
-    'Narrative film',
-    'Oral history',
-    'Performance',
-    'Presentation',
-    'Unedited footage',
-    'Video art'
+    'Animation', 'Broadcast', 'Conference session', 'Course/instruction',
+    'Documentary', 'Ethnography', 'Event', 'Experimental', 'Field recordings',
+    'Narrative film', 'Oral history', 'Performance', 'Presentation',
+    'Unedited footage', 'Video art'
   ].freeze
 
   MIXED_TYPES = [
-    'Data',
-    'Image',
-    'Software/Code',
-    'Sound',
-    'Text',
-    'Video'
+    'Data', 'Image', 'Software/Code', 'Sound', 'Text', 'Video'
   ].freeze
 
   SOUND_TYPES = [
-    'Course/instruction',
-    'Documentary',
-    'Dramatic performance',
-    'Ethnography',
-    'Field recordings',
-    'Interview',
-    'MIDI',
-    'Musical notation',
-    'Musical performance',
-    'Oral history',
-    'Other spoken word',
-    'Podcast',
-    'Poetry reading',
-    'Speech',
-    'Story',
-    'Transcript',
-    'Unedited recording'
+    'Course/instruction', 'Documentary', 'Dramatic performance', 'Ethnography',
+    'Field recordings', 'Interview', 'MIDI', 'Musical notation',
+    'Musical performance', 'Oral history', 'Other spoken word', 'Podcast',
+    'Poetry reading', 'Speech', 'Story', 'Transcript', 'Unedited recording'
   ].freeze
 
   TEXT_TYPES = [
-    'Article',
-    'Book',
-    'Book chapter',
-    'Correspondence',
-    'Essay',
-    'Government document',
-    'Journal/periodical',
-    'Manuscript',
-    'Poster',
-    'Presentation slides',
-    'Report',
-    'Speech',
-    'Syllabus',
-    'Teaching materials',
-    'Technical report',
-    'Thesis',
-    'Transcription',
-    'White paper',
-    'Working paper'
+    'Article', 'Book', 'Book chapter', 'Correspondence', 'Essay',
+    'Government document', 'Journal/periodical', 'Manuscript', 'Poster',
+    'Presentation slides', 'Report', 'Speech', 'Syllabus', 'Teaching materials',
+    'Technical report', 'Thesis', 'Transcription', 'White paper', 'Working paper'
   ].freeze
 
-  SOFTWARE_TYPES = %w[
-    Code
-    Documentation
-    Game
-  ].freeze
+  SOFTWARE_TYPES = %w[Code Documentation Game].freeze
 
   IMAGE_TYPES = [
-    'CAD',
-    'Map',
-    'Photograph',
-    'Poster',
-    'Presentation slides'
+    'CAD', 'Map', 'Photograph', 'Poster', 'Presentation slides'
   ].freeze
 
   sig { returns(String) }
@@ -168,5 +106,15 @@ class WorkType
   sig { params(id: T.nilable(String)).returns(T::Array[String]) }
   def self.subtypes_for(id)
     find(id).subtypes
+  end
+
+  sig { returns(T::Hash[String, T::Array[String]]) }
+  def self.to_h
+    all.map { |type| [type.id, type.subtypes] }.to_h
+  end
+
+  sig { returns(String) }
+  def self.to_json
+    to_h.to_json
   end
 end

--- a/spec/models/work_type_spec.rb
+++ b/spec/models/work_type_spec.rb
@@ -1,0 +1,26 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WorkType do
+  describe '.to_h' do
+    let(:work_types_hash) { described_class.to_h }
+
+    it 'uses work types as hash keys' do
+      expect(work_types_hash.keys).to match_array(described_class.type_list)
+    end
+
+    it 'contains all subtypes as values' do
+      expect(work_types_hash.values).to match_array(described_class.all.map(&:subtypes))
+    end
+  end
+
+  describe '.to_json' do
+    let(:work_types_json) { described_class.to_json }
+
+    it 'generates valid JSON' do
+      expect { JSON.parse(work_types_json) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Connects to #716

## Why was this change made?

In order to:

1. Bring the work type modal styles more in line with the mock-ups and the desired look & feel; and
2. Refactor work type modal-related code to make it easier/clearer to do the work in #716 

Includes:

* Make work type modal appearance more closely resemble mock-ups (see mock-up below!)
  * Increase padding between work type icon and work type text
  * Shrink space between work type boxes
  * Lighten background shade of selected work type box to increase contrast
  * Increase size of selected work type check box
  * Shade selected check box red (instead of black)
* Keep HTML for work type modal header in partial (instead of in JavaScript)
* Move JSON conversion into WorkType class

### BEFORE

![before](https://user-images.githubusercontent.com/131982/107062492-35c43480-678e-11eb-92ed-39a113d04ea2.png)

### AFTER

![after](https://user-images.githubusercontent.com/131982/107062516-3bba1580-678e-11eb-9841-ae8f569f961b.png)

### MOCK-UP

![mockup](https://user-images.githubusercontent.com/131982/107063302-0f52c900-678f-11eb-8980-c76064b11a2f.png)

## How was this change tested?

CI, local browser

## Which documentation and/or configurations were updated?

None

