### PR TITLE
Add collapsible "see more/fewer options" link to work type modal

### DIFF
--- a/app/components/collections/header_component.html.erb
+++ b/app/components/collections/header_component.html.erb
@@ -17,13 +17,7 @@
             },
             class: "btn btn-primary" %>
 
-      <div class="modal fade" id="workTypeModal" tabindex="-1" aria-labelledby="content-type-prompt" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered modal-lg">
-          <div class="modal-content">
-            <%= render Works::WorkTypeModalComponent.new %>
-          </div>
-        </div>
-      </div>
+      <%= render Works::WorkTypeModalComponent.new %>
     </span>
   <% end %>
 </header>

--- a/app/components/works/work_type_modal_component.html.erb
+++ b/app/components/works/work_type_modal_component.html.erb
@@ -1,50 +1,64 @@
 <script>
-  document.subtypes = <%= WorkType.to_json.html_safe %>
+  document.subtypes = <%= WorkType.to_json.html_safe %>;
+  document.moreTypes = <%= WorkType::MORE_TYPES.to_json.html_safe %>
 </script>
 
-<div class="modal-header">
-  <h5 class="modal-title" id="content-type-prompt">What type of content will you deposit?</h5>
-  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-</div>
-<div class="modal-body">
-  <form method="get" action="/collections/1/work/new" data-work-type-target="form">
-    <div class="row">
-      <% types.each do |type| %>
-        <div class="work-type-box">
-          <%= render CheckboxButtonComponent.new(name: 'work_type', value: type.id, data: { action: "work-type#change" }) do %>
-            <span class="fas fa-2x fa-<%= type.icon %>"></span> <div class="work-type-button-text"><%= type.label %></div>
-          <% end %>
-        </div>
-      <% end %>
+<div class="modal fade" id="workTypeModal" tabindex="-1" aria-labelledby="content-type-prompt" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="content-type-prompt">What type of content will you deposit?</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+
+      <div class="modal-body">
+        <form method="get" action="/collections/1/work/new" data-work-type-target="form">
+          <div class="row">
+            <% types.each do |type| %>
+              <div class="work-type-box">
+                <%= render CheckboxButtonComponent.new(name: 'work_type', value: type.id, data: { action: "work-type#change" }) do %>
+                  <span class="fas fa-2x fa-<%= type.icon %>"></span> <div class="work-type-button-text"><%= type.label %></div>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+
+          <template data-work-type-target="templateHeader">
+            <h5>Which of the following terms further describe your deposit?</h5>
+          </template>
+
+          <template data-work-type-target="template">
+            <div class="col-md-4">
+              <div class="form-check">
+                <input type="checkbox" name="subtype[]" value="SUBTYPE_LABEL" id="subtype_SUBTYPE_ID" class="form-check-input">
+                <label for="subtype_SUBTYPE_ID" class="form-check-label">SUBTYPE_LABEL</label>
+              </div>
+            </div>
+          </template>
+
+          <template data-work-type-target="otherTemplateHeader">
+            <h5>Specify "Other" type</h5>
+          </template>
+
+          <template data-work-type-target="otherTemplate">
+            <div class="col-md-4">
+              <input type="text" name="subtype[]" class="form-control" id="subtype_other">
+            </div>
+          </template>
+
+          <div class="row" data-work-type-target="area" hidden></div>
+
+          <div class="row mb-4" data-work-type-target="subtype"></div>
+
+          <a href="#" class="more-options collapsed" data-action="work-type#toggleMoreTypes" data-work-type-target="moreTypesLink" hidden>
+            See more options
+          </a>
+
+          <div class="row mb-4" data-work-type-target="moreTypes" hidden></div>
+
+          <button type="submit" class="btn btn-primary mx-auto d-block" data-work-type-target="continueButton">Continue</button>
+        </form>
+      </div>
     </div>
-
-    <template data-work-type-target="template">
-      <div class="col-md-4">
-        <div class="form-check">
-          <input type="checkbox" name="subtype[]" value="SUBTYPE_LABEL" id="subtype_SUBTYPE_ID" class="form-check-input">
-          <label for="subtype_SUBTYPE_ID" class="form-check-label">SUBTYPE_LABEL</label>
-        </div>
-      </div>
-    </template>
-
-    <template data-work-type-target="templateHeader">
-      <h5>Which of the following terms further describe your deposit?</h5>
-    </template>
-
-    <template data-work-type-target="otherTemplate">
-      <div class="col-md-4">
-        <input type="text" name="subtype[]" class="form-control" id="subtype_other">
-      </div>
-    </template>
-
-    <template data-work-type-target="otherTemplateHeader">
-      <h5>Specify "Other" type</h5>
-    </template>
-
-    <div class="row" data-work-type-target="area" hidden></div>
-
-    <div class="row mb-4" data-work-type-target="subtype"></div>
-
-    <button type="submit" class="btn btn-primary mx-auto d-block">Continue</button>
-  </form>
+  </div>
 </div>

--- a/app/components/works/work_type_modal_component.html.erb
+++ b/app/components/works/work_type_modal_component.html.erb
@@ -1,6 +1,6 @@
 <script>
   document.subtypes = <%= WorkType.to_json.html_safe %>;
-  document.moreTypes = <%= WorkType::MORE_TYPES.to_json.html_safe %>
+  document.moreTypes = <%= WorkType.more_types.to_json.html_safe %>
 </script>
 
 <div class="modal fade" id="workTypeModal" tabindex="-1" aria-labelledby="content-type-prompt" aria-hidden="true">

--- a/app/javascript/controllers/work_type_controller.js
+++ b/app/javascript/controllers/work_type_controller.js
@@ -71,6 +71,13 @@ export default class extends Controller {
   }
 
   moreTypesFor(type) {
+    // Work types have a small number of primary subtypes and they share a large
+    // number of general subtypes, which we refer to as "more types." Some work types
+    // have primary subtypes that also appear in the list of "more types" and we
+    // don't want users to be able to see and select multiple types of the same value,
+    // so we only return the "more types" for a given type that do not match any of
+    // the type's primary subtypes, hence the filtering in this function.
+
     return document
       .moreTypes
       .filter(moreType => !document.subtypes[type].includes(moreType))

--- a/app/javascript/controllers/work_type_controller.js
+++ b/app/javascript/controllers/work_type_controller.js
@@ -2,7 +2,8 @@ import { Controller } from "stimulus"
 
 export default class extends Controller {
   static targets = [
-    "form", "template", "otherTemplate", "subtype", "area", "templateHeader", "otherTemplateHeader"
+    "form", "template", "otherTemplate", "subtype", "area", "templateHeader",
+    "otherTemplateHeader", "moreTypesLink", "moreTypes", "continueButton"
   ]
 
   // Sets the form in the popup to use the action in the data-destination attribute
@@ -23,17 +24,59 @@ export default class extends Controller {
     this.areaTarget.hidden = false
   }
 
+  toggleMoreTypes(event) {
+    event.preventDefault()
+
+    this.moreTypesTarget.hidden ?
+      this.showMoreTypes() :
+      this.hideMoreTypes()
+  }
+
+  showMoreTypes() {
+    this.moreTypesTarget.hidden = false
+    this.moreTypesLinkTarget.innerHTML = 'See fewer options'
+    this.moreTypesLinkTarget.classList.toggle('collapsed', false)
+    this.continueButtonTarget.focus()
+  }
+
+  hideMoreTypes() {
+    this.moreTypesTarget.hidden = true
+    this.moreTypesLinkTarget.innerHTML = 'See more options'
+    this.moreTypesLinkTarget.classList.toggle('collapsed', true)
+  }
+
   displaySubtypeOptions(type) {
-    const subtypes = document.subtypes[type].map((subtype)=> {
-      const id = subtype.replace(/\s/g, '_')
-      return this.templateTarget.innerHTML.replace(/SUBTYPE_LABEL/g, subtype).replace(/SUBTYPE_ID/g, id)
-    })
-    this.subtypeTarget.innerHTML = subtypes.join('')
+    // Show the more options link
+    this.moreTypesLinkTarget.hidden = false
+    this.subtypeTarget.innerHTML = this.subtypesFor(type).join('')
+    this.moreTypesTarget.innerHTML = this.moreTypesFor(type).join('')
     this.areaTarget.innerHTML = this.templateHeaderTarget.innerHTML
   }
 
   displayOtherSubtypeOptions() {
+    // Hide the more options link
+    this.moreTypesLinkTarget.hidden = true
+    this.hideMoreTypes()
     this.subtypeTarget.innerHTML = this.otherTemplateTarget.innerHTML
     this.areaTarget.innerHTML = this.otherTemplateHeaderTarget.innerHTML
+  }
+
+  subtypesFor(type) {
+    return document
+      .subtypes[type]
+      .map((subtype)=> {
+        const id = subtype.replace(/\s/g, '_')
+        return this.templateTarget.innerHTML.replace(/SUBTYPE_LABEL/g, subtype).replace(/SUBTYPE_ID/g, id)
+      })
+  }
+
+  moreTypesFor(type) {
+    return document
+      .moreTypes
+      .filter(moreType => !document.subtypes[type].includes(moreType))
+      .map((moreType) => {
+        const id = moreType.replace(/\s/g, '_')
+        return this.templateTarget.innerHTML.replace(/SUBTYPE_LABEL/g, moreType).replace(/SUBTYPE_ID/g, id)
+      })
   }
 }

--- a/app/javascript/stylesheets/dashboard.scss
+++ b/app/javascript/stylesheets/dashboard.scss
@@ -54,3 +54,19 @@
 ul.collections {
   list-style-type: none;
 }
+
+#workTypeModal {
+  a {
+    text-decoration: none;
+
+    &:after {
+      content: '\f078';
+      font-family: Fontawesome;
+      padding-left: 0.5rem;
+    }
+
+    &.collapsed:after {
+      content: '\f054';
+    }
+  }
+}

--- a/app/models/work_type.rb
+++ b/app/models/work_type.rb
@@ -21,8 +21,8 @@ class WorkType
   SOUND_TYPES = ['Interview', 'Oral history', 'Podcast', 'Speech'].freeze
 
   TEXT_TYPES = [
-    'Article', 'Government document', 'Preprint', 'Report', 'Technical report',
-    'Thesis', 'Working paper'
+    'Article', 'Government document', 'Policy brief', 'Preprint', 'Report',
+    'Technical report', 'Thesis', 'Working paper'
   ].freeze
 
   SOFTWARE_TYPES = %w[Code Documentation Game].freeze
@@ -85,7 +85,7 @@ class WorkType
           cocina_type: Cocina::Models::Vocab.object),
       new(id: 'data', label: 'Data', icon: 'chart-bar', subtypes: DATA_TYPES,
           cocina_type: Cocina::Models::Vocab.object),
-      new(id: 'software, multimedia', label: 'Software or Code', icon: 'mouse', subtypes: SOFTWARE_TYPES,
+      new(id: 'software, multimedia', label: 'Software/Code', icon: 'mouse', subtypes: SOFTWARE_TYPES,
           cocina_type: Cocina::Models::Vocab.object),
       new(id: 'image', label: 'Image', icon: 'images', subtypes: IMAGE_TYPES,
           cocina_type: Cocina::Models::Vocab.image),

--- a/app/models/work_type.rb
+++ b/app/models/work_type.rb
@@ -106,9 +106,17 @@ class WorkType
     all.map(&:id).sort
   end
 
-  sig { params(id: T.nilable(String)).returns(T::Array[String]) }
-  def self.subtypes_for(id)
-    find(id).subtypes
+  sig { returns(T::Array[String]) }
+  def self.more_types
+    MORE_TYPES
+  end
+
+  sig { params(id: T.nilable(String), include_more_types: T::Boolean).returns(T::Array[String]) }
+  def self.subtypes_for(id, include_more_types: false)
+    subtypes = find(id).subtypes
+    return subtypes unless include_more_types
+
+    subtypes + more_types
   end
 
   sig { returns(T::Hash[String, T::Array[String]]) }

--- a/app/models/work_type.rb
+++ b/app/models/work_type.rb
@@ -8,40 +8,43 @@ class WorkType
   class InvalidType < StandardError; end
 
   DATA_TYPES = [
-    '3D model', 'Audio', 'Database', 'GIS', 'Image', 'Questionnaire',
-    'Remote sensing imagery', 'Software/code', 'Statistical model',
-    'Tabular data', 'Text corpus', 'Text documentation', 'Video'
+    '3D model', 'Database', 'Documentation', 'Geospatial data', 'Image',
+    'Tabular data', 'Text corpus'
   ].freeze
 
   VIDEO_TYPES = [
-    'Animation', 'Broadcast', 'Conference session', 'Course/instruction',
-    'Documentary', 'Ethnography', 'Event', 'Experimental', 'Field recordings',
-    'Narrative film', 'Oral history', 'Performance', 'Presentation',
-    'Unedited footage', 'Video art'
+    'Conference session', 'Documentary', 'Event', 'Oral history', 'Performance'
   ].freeze
 
-  MIXED_TYPES = [
-    'Data', 'Image', 'Software/Code', 'Sound', 'Text', 'Video'
-  ].freeze
+  MIXED_TYPES = %w[Data Image Software/Code Sound Text Video].freeze
 
-  SOUND_TYPES = [
-    'Course/instruction', 'Documentary', 'Dramatic performance', 'Ethnography',
-    'Field recordings', 'Interview', 'MIDI', 'Musical notation',
-    'Musical performance', 'Oral history', 'Other spoken word', 'Podcast',
-    'Poetry reading', 'Speech', 'Story', 'Transcript', 'Unedited recording'
-  ].freeze
+  SOUND_TYPES = ['Interview', 'Oral history', 'Podcast', 'Speech'].freeze
 
   TEXT_TYPES = [
-    'Article', 'Book', 'Book chapter', 'Correspondence', 'Essay',
-    'Government document', 'Journal/periodical', 'Manuscript', 'Poster',
-    'Presentation slides', 'Report', 'Speech', 'Syllabus', 'Teaching materials',
-    'Technical report', 'Thesis', 'Transcription', 'White paper', 'Working paper'
+    'Article', 'Government document', 'Preprint', 'Report', 'Technical report',
+    'Thesis', 'Working paper'
   ].freeze
 
   SOFTWARE_TYPES = %w[Code Documentation Game].freeze
 
-  IMAGE_TYPES = [
-    'CAD', 'Map', 'Photograph', 'Poster', 'Presentation slides'
+  IMAGE_TYPES = ['CAD', 'Map', 'Photograph', 'Poster', 'Presentation slides'].freeze
+
+  # These types appear below the fold and may be expanded
+  MORE_TYPES = [
+    '3D model', 'Animation', 'Article', 'Book', 'Book chapter', 'Broadcast', 'CAD',
+    'Code', 'Conference session', 'Correspondence', 'Course/instructional materials',
+    'Data', 'Database', 'Documentary', 'Documentation', 'Dramatic performance',
+    'Essay', 'Ethnography', 'Event', 'Experimental audio/video', 'Field recording',
+    'Game', 'Geospatial data', 'Government document', 'Image', 'Interview',
+    'Journal/periodical issue', 'Manuscript', 'Map', 'MIDI', 'Musical transcription',
+    'Narrative film', 'Notated music', 'Oral history', 'Other spoken word',
+    'Performance', 'Photograph', 'Piano roll', 'Podcast', 'Poetry reading',
+    'Policy brief', 'Poster', 'Preprint', 'Presentation recording',
+    'Presentation slides', 'Questionnaire', 'Remote sensing imagery', 'Report',
+    'Software', 'Sound recording', 'Speaker notes', 'Speech', 'Story', 'Syllabus',
+    'Tabular data', 'Technical report', 'Text', 'Text corpus', 'Thesis',
+    'Transcript', 'Unedited recording', 'Video recording', 'Video art',
+    'White paper', 'Working paper'
   ].freeze
 
   sig { returns(String) }

--- a/app/validators/work_subtype_validator.rb
+++ b/app/validators/work_subtype_validator.rb
@@ -13,12 +13,12 @@ class WorkSubtypeValidator < ActiveModel::EachValidator
   # validate these on the incoming works/new request before there is a model
   # instance to validate.
   def self.valid?(work_type, value)
+    # A subtype is required for the "other" work type
     return Array(value).first.present? if work_type == 'other'
 
-    # Subtype is not required for work types other than 'other'
     return true if value.nil?
 
-    value.all? { |subtype| subtype.in?(WorkType.subtypes_for(work_type)) }
+    value.all? { |subtype| subtype.in?(WorkType.subtypes_for(work_type, include_more_types: true)) }
   rescue WorkType::InvalidType
     false
   end

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -22,13 +22,7 @@
         </ul>
       <% end %>
 
-      <div class="modal fade" id="workTypeModal" tabindex="-1" aria-labelledby="content-type-prompt" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered modal-lg">
-          <div class="modal-content">
-            <%= render Works::WorkTypeModalComponent.new %>
-          </div>
-        </div>
-      </div>
+      <%= render Works::WorkTypeModalComponent.new %>
     </section>
 
     <%= render Dashboard::AllCollectionsComponent.new(stats: @presenter.work_stats) %>

--- a/config/mappings/types_to_genres.yml
+++ b/config/mappings/types_to_genres.yml
@@ -6,76 +6,24 @@ Text:
         uri: http://vocab.getty.edu/aat/300048715
         source:
           code: aat
-    Book:
-      - type: genre
-        value: books
-        uri: http://vocab.getty.edu/aat/300028051
-        source:
-          code: aat
-    Book chapter:
-      - type: genre
-        value: Book chapters
-    Correspondence:
-      - type: genre
-        value: correspondence
-        uri: http://vocab.getty.edu/aat/300026877
-        source:
-          code: aat
-    Essay:
-      - type: genre
-        value: Essays
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026094
-        source:
-          code: lcgft
     Government document:
       - type: genre
         value: government records
         uri: http://vocab.getty.edu/aat/300027777
         source:
           code: aat
-    Journal/periodical:
+    Preprint:
       - type: genre
-        value: Periodicals
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026139
-    Manuscript:
-      - type: genre
-        value: manuscripts (documents)
-        uri: http://vocab.getty.edu/aat/300028569
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
         source:
           code: aat
-    Poster:
-      - type: genre
-        value: Posters
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026152
-        source:
-          code: lcgft
-    Presentation slides:
-      - type: genre
-        value: Presentation slides
     Report:
       - type: genre
         value: reports
         uri: http://vocab.getty.edu/aat/300027267
         source:
           code: aat
-    Speech:
-      - type: genre
-        value: Speeches
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026363
-        source:
-          code: lcgft
-    Syllabus:
-      - type: genre
-        value: Outlines and syllabi
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026136
-        source:
-          code: lcgft
-    Teaching materials:
-      - type: genre
-        value: Instructional and educational works
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-        source:
-          code: lcgft
     Technical report:
       - type: genre
         value: Technical reports
@@ -88,18 +36,6 @@ Text:
         uri: http://id.loc.gov/authorities/genreForms/gf2014026039
         source:
           code: lcgft
-    Transcription:
-      - type: genre
-        value: transcripts
-        uri: http://vocab.getty.edu/aat/300027388
-        source:
-          code: aat
-    White paper:
-      - type: genre
-        value: grey literature
-        uri: http://vocab.getty.edu/aat/300256200
-        source:
-          code: aat
     Working paper:
       - type: genre
         value: grey literature
@@ -117,14 +53,6 @@ Data:
     3D model:
       - type: genre
         value: Three dimensional scan
-    Audio:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Database:
       - type: genre
         value: dataset
@@ -133,7 +61,7 @@ Data:
         uri: http://id.loc.gov/authorities/genreForms/gf2014026081
         source:
           code: lcgft
-    GIS:
+    Geospatial data:
       - type: genre
         value: dataset
       - type: genre
@@ -149,38 +77,6 @@ Data:
         uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
-    Questionnaire:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: Questionnaires
-        uri: http://id.loc.gov/authorities/genreForms/gf2018026144
-        source:
-          code: lcgft
-    Remote sensing imagery:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: Remote-sensing images
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026530
-        source:
-          code: lcgft
-    Software/code:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: software
-        uri: http://vocab.getty.edu/aat/300028566
-        source:
-          code: aat
-    Statistical model:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: mathematical models
-        uri: http://vocab.getty.edu/aat/300065075
-        source:
-          code: aat
     Tabular data:
       - type: genre
         value: dataset
@@ -197,23 +93,7 @@ Data:
         uri: http://id.loc.gov/authorities/genreForms/gf2019026083
         source:
           code: lcgft
-    Text documentation:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: Data dictionaries
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026080
-        source:
-          code: lcgft
-    Video:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
-Software or Code:
+Software/Code:
   subtypes:
     Code:
       - type: genre
@@ -276,79 +156,22 @@ Sound:
       source:
         code: lcgft
   subtypes:
-    Course/instruction:
-      - type: genre
-        value: Instructional and educational works
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-        source:
-          code: lcgft
-    Documentary:
-      - type: genre
-        value: documentaries (documents)
-        uri: http://vocab.getty.edu/aat/300249172
-        source:
-          code: aat
-    Dramatic performance:
-      - type: genre
-        value: Drama
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026297
-        source:
-          code: lcgft
-    Ethnography:
-      - type: genre
-        value: Ethnographies
-        uri: http://id.loc.gov/authorities/genreForms/gf2018026013
-        source:
-          code: lcgft
-    Field recordings:
-      - type: genre
-        value: Field recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026253
-        source:
-          code: lcgft
     Interview:
       - type: genre
         value: Interviews
         uri: http://id.loc.gov/authorities/genreForms/gf2014026115
         source:
           code: lcgft
-    MIDI:
-      - type: genre
-        value: MIDI (information technology)
-        uri: http://vocab.getty.edu/aat/300266746
-        source:
-          code: aat
-    Musical notation:
-      - type: genre
-        value: Notated music
-        uri: http://id.loc.gov/authorities/genreForms/gf2014027184
-        source:
-          code: lcgft
-    Musical performance:
-      - type: genre
-        value: musical performances
-        uri: http://vocab.getty.edu/aat/300262956
-        source:
-          code: aat
     Oral history:
       - type: genre
         value: Oral histories
         uri: http://id.loc.gov/authorities/genreForms/gf2011026431
         source:
           code: lcgft
-    Other spoken word:
-      - type: genre
-        value: Spoken word
     Podcast:
       - type: genre
         value: Podcasts
         uri: http://id.loc.gov/authorities/genreForms/gf2011026450
-        source:
-          code: lcgft
-    Poetry reading:
-      - type: genre
-        value: Poetry
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026481
         source:
           code: lcgft
     Speech:
@@ -357,21 +180,6 @@ Sound:
         uri: http://id.loc.gov/authorities/genreForms/gf2011026363
         source:
           code: lcgft
-    Story:
-      - type: genre
-        value: Fiction
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026339
-        source:
-          code: lcgft
-    Transcript:
-      - type: genre
-        value: transcripts
-        uri: http://vocab.getty.edu/aat/300027388
-        source:
-          code: aat
-    Unedited recording:
-      - type: genre
-        value: Unedited sound recordings
 Video:
   type:
     - type: genre
@@ -380,37 +188,13 @@ Video:
       source:
         code: aat
   subtypes:
-    Animation:
-      - type: genre
-        value: animations (visual works)
-        uri: http://vocab.getty.edu/aat/300411663
-        source:
-          code: aat
-    Broadcast:
-      - type: genre
-        value: Television programs
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026673
-        source:
-          code: lcgft
     Conference session:
       - type: genre
         value: Conference sessions
-    Course/instruction:
-      - type: genre
-        value: Instructional and educational works
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-        source:
-          code: lcgft
     Documentary:
       - type: genre
         value: Documentary films
         uri: http://id.loc.gov/authorities/genreForms/gf201102620
-        source:
-          code: lcgft
-    Ethnography:
-      - type: genre
-        value: Ethnographic films
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026232
         source:
           code: lcgft
     Event:
@@ -419,24 +203,6 @@ Video:
         uri: http://vocab.getty.edu/aat/300069084
         source:
           code: aat
-    Experimental:
-      - type: genre
-        value: Experimental films
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026235
-        source:
-          code: lcgft
-    Field recordings:
-      - type: genre
-        value: Field recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026253
-        source:
-          code: lcgft
-    Narrative film:
-      - type: genre
-        value: Fiction films
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026250
-        source:
-          code: lcgft
     Oral history:
       - type: genre
         value: Oral histories
@@ -447,24 +213,6 @@ Video:
       - type: genre
         value: Filmed performances
         uri: http://id.loc.gov/authorities/genreForms/gf2011026276
-        source:
-          code: lcgft
-    Presentation:
-      - type: genre
-        value: presentations (communicative events)
-        uri: http://vocab.getty.edu/aat/300258677
-        source:
-          code: aat
-    Unedited footage:
-      - type: genre
-        value: Unedited footage
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026712
-        source:
-          code: lcgft
-    Video art:
-      - type: genre
-        value: Video art
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027265
         source:
           code: lcgft
 Mixed Materials:
@@ -505,5 +253,225 @@ Mixed Materials:
       - type: genre
         value: moving images
         uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+General:
+  subtypes:
+    Animation:
+      - type: genre
+        value: animations (visual works)
+        uri: http://vocab.getty.edu/aat/300411663
+        source:
+          code: aat
+    Book:
+      - type: genre
+        value: books
+        uri: http://vocab.getty.edu/aat/300028051
+        source:
+          code: aat
+    Book chapter:
+      - type: genre
+        value: Book chapters
+    Broadcast:
+      - type: genre
+        value: Television programs
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026673
+        source:
+          code: lcgft
+    Correspondence:
+      - type: genre
+        value: correspondence
+        uri: http://vocab.getty.edu/aat/300026877
+        source:
+          code: aat
+    Course/instructional materials:
+      - type: genre
+        value: Instructional and educational works
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+        source:
+          code: lcgft
+    Documentary:
+      - type: genre
+        value: documentaries (documents)
+        uri: http://vocab.getty.edu/aat/300249172
+        source:
+          code: aat
+    Dramatic performance:
+      - type: genre
+        value: Drama
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+        source:
+          code: lcgft
+    Essay:
+      - type: genre
+        value: Essays
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+        source:
+          code: lcgft
+    Ethnography:
+      - type: genre
+        value: Ethnographies
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+        source:
+          code: lcgft
+    Experimental audio/video:
+      - type: genre
+        value: Experimental films
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026235
+        source:
+          code: lcgft
+    Field recording:
+      - type: genre
+        value: Field recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+        source:
+          code: lcgft
+    Journal/periodical issue:
+      - type: genre
+        value: Periodicals
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+    Manuscript:
+      - type: genre
+        value: manuscripts (documents)
+        uri: http://vocab.getty.edu/aat/300028569
+        source:
+          code: aat
+    MIDI:
+      - type: genre
+        value: MIDI (information technology)
+        uri: http://vocab.getty.edu/aat/300266746
+        source:
+          code: aat
+    Musical transcription:
+      - type: genre
+        value: transcriptions (documents)
+        uri: http://vocab.getty.edu/aat/300404333
+        source:
+          code: aat
+    Narrative film:
+      - type: genre
+        value: Fiction films
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+        source:
+          code: lcgft
+    Notated music:
+      - type: genre
+        value: Notated music
+        uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+        source:
+          code: lcgft
+    Other spoken word:
+      - type: genre
+        value: Spoken word
+    Piano roll:
+      - type: genre
+        value: music rolls
+        uri: http://vocab.getty.edu/aat/300429369
+        source:
+          code: aat
+    Poetry reading:
+      - type: genre
+        value: Poetry
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+        source:
+          code: lcgft
+    Poster:
+      - type: genre
+        value: Posters
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+        source:
+          code: lcgft
+    Preprint:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+    Presentation recording:
+      - type: genre
+        value: presentations (communicative events)
+        uri: http://vocab.getty.edu/aat/300258677
+        source:
+          code: aat
+    Presentation slides:
+      - type: genre
+        value: Presentation slides
+    Questionnaire:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: Questionnaires
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+        source:
+          code: lcgft
+    Remote sensing imagery:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: Remote-sensing images
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+        source:
+          code: lcgft
+    Software:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: software
+        uri: http://vocab.getty.edu/aat/300028566
+        source:
+          code: aat
+    Sound recording:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Speech:
+      - type: genre
+        value: Speeches
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+        source:
+          code: lcgft
+    Story:
+      - type: genre
+        value: Fiction
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+        source:
+          code: lcgft
+    Syllabus:
+      - type: genre
+        value: Outlines and syllabi
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+        source:
+          code: lcgft
+    Transcript:
+      - type: genre
+        value: transcripts
+        uri: http://vocab.getty.edu/aat/300027388
+        source:
+          code: aat
+    Unedited recording:
+      - type: genre
+        value: Unedited sound recordings
+    Video recording:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Video art:
+      - type: genre
+        value: Video art
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+        source:
+          code: lcgft
+    White paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
         source:
           code: aat

--- a/config/mappings/types_to_resource_types.yml
+++ b/config/mappings/types_to_resource_types.yml
@@ -10,67 +10,22 @@ Text:
         value: text
         source:
           value: MODS resource types
-    Book:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Book chapter:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Correspondence:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Essay:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     Government document:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-    Journal/periodical:
+    Policy brief:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-    Manuscript:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Poster:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Presentation slides:
+    Preprint:
       - type: resource type
         value: text
         source:
           value: MODS resource types
     Report:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Speech:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Syllabus:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Teaching materials:
       - type: resource type
         value: text
         source:
@@ -81,16 +36,6 @@ Text:
         source:
           value: MODS resource types
     Thesis:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Transcription:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    White paper:
       - type: resource type
         value: text
         source:
@@ -112,17 +57,17 @@ Data:
         value: three dimensional object
         source:
           value: MODS resource types
-    Audio:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Database:
       - type: resource type
         value: software, multimedia
         source:
           value: MODS resource types
-    GIS:
+    Documentation:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Geospatial data:
       - type: resource type
         value: cartographic
         source:
@@ -136,26 +81,6 @@ Data:
         value: still image
         source:
           value: MODS resource types
-    Questionnaire:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Remote sensing imagery:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
-    Software/code:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
-    Statistical model:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Tabular data:
       - type: resource type
         value: text
@@ -166,17 +91,7 @@ Data:
         value: text
         source:
           value: MODS resource types
-    Text documentation:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Video:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-Software or Code:
+Software/Code:
   type:
     type: resource type
     value: software, multimedia
@@ -237,57 +152,12 @@ Sound:
     source:
       value: MODS resource types
   subtypes:
-    Course/instruction:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Documentary:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Dramatic performance:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Ethnography:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Field recordings:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Interview:
       - type: resource type
         value: sound recording
         source:
           value: MODS resource types
-    MIDI:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Musical notation:
-      - type: resource type
-        value: notated music
-        source:
-          value: MODS resource types
-    Musical performance:
-      - type: resource type
-        value: sound recording-musical
-        source:
-          value: MODS resource types
     Oral history:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Other spoken word:
       - type: resource type
         value: sound recording
         source:
@@ -297,27 +167,7 @@ Sound:
         value: Podcasts
         source:
           value: MODS resource types
-    Poetry reading:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Speech:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Story:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Transcript:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Unedited recording:
       - type: resource type
         value: sound recording
         source:
@@ -329,22 +179,7 @@ Video:
     source:
       value: MODS resource types
   subtypes:
-    Animation:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Broadcast:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Conference session:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Course/instruction:
       - type: resource type
         value: moving image
         source:
@@ -354,27 +189,7 @@ Video:
         value: moving image
         source:
           value: MODS resource types
-    Ethnography:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Event:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Experimental:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Field recordings:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Narrative film:
       - type: resource type
         value: moving image
         source:
@@ -389,22 +204,7 @@ Video:
         value: moving image
         source:
           value: MODS resource types
-    Presentation:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Unedited footage:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Video art:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-Mixed materials:
+Mixed Materials:
   type:
     type: resource type
     value: mixed material
@@ -439,5 +239,216 @@ Mixed materials:
     Video:
       - type: resource type
         value: moving image
+        source:
+          value: MODS resource types
+General:
+  subtypes:
+    Animation:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Book:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Book chapter:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Broadcast:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Correspondence:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    # TODO: How to deal with this duplication?
+    Course/instructional materials:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Course/instructional materials:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Documentary:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Dramatic performance:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Essay:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    # TODO: How to deal with this duplication?
+    Ethnography:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Ethnography:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Experimental audio/video:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    # TODO: How to deal with this duplication?
+    Field recording:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Field recording:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Journal/periodical issue:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Manuscript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    MIDI:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Musical transcription:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+    Narrative film:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Notated music:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+    Other spoken word:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Piano roll:
+      - type: resource type
+        value: sound recording-musical
+        source:
+          value: MODS resource types
+    Poetry reading:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Poster:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Presentation recording:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Presentation slides:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Questionnaire:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Remote sensing imagery:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Software:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Sound recording:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Speaker notes:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Speech:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Story:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Syllabus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Transcript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    # TODO: How to deal with this duplication?
+    Unedited recording:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Unedited recording:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Video art:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Video recording:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    White paper:
+      - type: resource type
+        value: text
         source:
           value: MODS resource types

--- a/spec/components/works/description_component_spec.rb
+++ b/spec/components/works/description_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Works::DescriptionComponent do
   end
 
   it 'has a checkbox with a label' do
-    expect(rendered.css('#work_subtype_journalperiodical')).to be_present
-    expect(rendered.css("label[for='work_subtype_journalperiodical']")).to be_present
+    expect(rendered.css('#work_subtype_government_document')).to be_present
+    expect(rendered.css("label[for='work_subtype_government_document']")).to be_present
   end
 end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
       "Test title #{n}"
     end
     work_type { 'text' }
-    subtype { ['Article', 'Presentation slides'] } # Subtype values intentionally include an item with whitespace
+    subtype { ['Article', 'Technical report'] } # Subtype values intentionally include an item with whitespace
     abstract { 'test abstract' }
     citation { 'test citation' }
     license { 'CC0-1.0' }

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -27,8 +27,13 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
         expect(page).to have_css('input#subtype_other')
         find('label', text: 'Sound').click
 
-        check 'Course/instruction'
+        check 'Podcast'
+        expect(page).not_to have_content('Poetry reading')
+        click_link 'See more options'
+        expect(page).to have_content('Poetry reading')
         check 'Poetry reading'
+        click_link 'See fewer options'
+        expect(page).not_to have_content('Poetry reading')
 
         click_button 'Continue'
 
@@ -92,7 +97,7 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
         select 'Everyone', from: 'Who can access?'
 
         fill_in 'Abstract', with: 'User provided abstract'
-        check 'Musical notation'
+        check 'Oral history'
 
         check 'I agree to the SDR Terms of Deposit'
 
@@ -126,7 +131,8 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
         expect(page).to have_link(Collection.last.name)
         expect(page).to have_content(user.email)
         expect(page).to have_content('sound')
-        expect(page).to have_content('Course/instruction, Musical notation, Poetry reading')
+        # expect(page).to have_content('Oral history, Podcast, Poetry reading')
+        expect(page).to have_content('Oral history, Podcast') # TODO: replace with prior line as part of #972
         expect(page).to have_content('Best Publisher')
         expect(page).to have_content('2020-03-06/2020-10-30')
         expect(page).to have_content 'User provided abstract'

--- a/spec/features/mediated_deposit_versioning_spec.rb
+++ b/spec/features/mediated_deposit_versioning_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Edit a new version of a work in a collection using mediated depo
       check 'I agree to the SDR Terms of Deposit'
       click_button 'Submit for approval'
 
-      expect(page).to have_content(newest_work_title)
+      expect(page).to have_content(:visible, newest_work_title)
       expect(page).to have_content('Pending approval')
 
       visit dashboard_path

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -159,10 +159,9 @@ RSpec.describe WorkForm do
     let(:errors) { form.errors.where(:subtype) }
     let(:messages) { errors.map(&:message) }
 
-    it 'does not validate with an invalid subtype/work_type combo' do
+    it 'validates with a valid work_type and a "more" type' do
       form.validate(work_type: 'data', subtype: ['Animation'])
-      expect(form).not_to be_valid
-      expect(messages).to eq ['is not a valid subtype for work type data']
+      expect(messages).to be_empty
     end
 
     it 'does not validate with a work_type that requires a user-supplied subtype and is empty' do
@@ -172,7 +171,7 @@ RSpec.describe WorkForm do
     end
 
     it 'validates with a valid subtype/work_type combo' do
-      form.validate(work_type: 'data', subtype: ['Software/code'])
+      form.validate(work_type: 'data', subtype: ['Documentation'])
       expect(messages).to be_empty
     end
   end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -135,14 +135,6 @@ RSpec.describe Work do
       end
     end
 
-    context 'with an invalid subtype/work_type combo' do
-      let(:work) { build(:work, work_type: 'data', subtype: ['Animation']) }
-
-      it 'does not validate' do
-        expect(work).not_to be_valid
-      end
-    end
-
     context 'with a work_type that requires a user-supplied subtype and is empty' do
       let(:work) { build(:work, work_type: 'other', subtype: []) }
 
@@ -159,8 +151,16 @@ RSpec.describe Work do
       end
     end
 
-    context 'with a valid subtype/work_type combo ' do
-      let(:work) { build(:work, work_type: 'data', subtype: ['Software/code']) }
+    context 'with a work_type and a primary subtype' do
+      let(:work) { build(:work, work_type: 'data', subtype: ['Database']) }
+
+      it 'validates' do
+        expect(work).to be_valid
+      end
+    end
+
+    context 'with a work_type and a "more" subtype' do
+      let(:work) { build(:work, work_type: 'data', subtype: ['Essay']) }
 
       it 'validates' do
         expect(work).to be_valid

--- a/spec/models/work_type_spec.rb
+++ b/spec/models/work_type_spec.rb
@@ -4,6 +4,28 @@
 require 'rails_helper'
 
 RSpec.describe WorkType do
+  describe '.subtypes_for' do
+    let(:subtypes) { described_class::IMAGE_TYPES }
+    # This value is arbitrary
+    let(:type) { 'image' }
+
+    context 'with more types arg' do
+      it 'includes the extra types' do
+        expect(
+          described_class.subtypes_for(type, include_more_types: true)
+        ).to eq(subtypes + described_class.more_types)
+      end
+    end
+
+    context 'without more types arg' do
+      it 'defaults to excluding the extra types' do
+        expect(
+          described_class.subtypes_for(type)
+        ).to eq(subtypes)
+      end
+    end
+  end
+
   describe '.to_h' do
     let(:work_types_hash) { described_class.to_h }
 

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -70,13 +70,13 @@ RSpec.describe 'Create a new work' do
         end
       end
 
-      context 'with an invalid subtype/work_type combo' do
+      context 'with a valid work_type and a missing subtype' do
         it 'redirects to dashboard with an informative flash message' do
-          get "/collections/#{collection.id}/works/new?work_type=sound&subtype%5B%5D=Essay"
+          get "/collections/#{collection.id}/works/new?work_type=sound&subtype%5B%5D=Foobar"
           expect(response).to redirect_to(dashboard_path)
           follow_redirect!
           expect(response).to have_http_status(:ok)
-          expect(response.body).to include 'Invalid subtype value for work_type &#39;sound&#39;: Essay'
+          expect(response.body).to include 'Invalid subtype value for work_type &#39;sound&#39;: Foobar'
         end
       end
 
@@ -99,6 +99,14 @@ RSpec.describe 'Create a new work' do
       end
 
       context 'with a valid subtype/work_type combo' do
+        it 'renders the form' do
+          get "/collections/#{collection.id}/works/new?work_type=text&subtype%5B%5D=Article"
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include 'text'
+        end
+      end
+
+      context 'with a valid "more" type/work_type combo' do
         it 'renders the form' do
           get "/collections/#{collection.id}/works/new?work_type=text&subtype%5B%5D=Essay"
           expect(response).to have_http_status(:ok)
@@ -289,7 +297,7 @@ RSpec.describe 'Create a new work' do
           expect(work.published_edtf.to_edtf).to eq '2020-02-14'
           expect(work.created_edtf.to_s).to eq '2020-03-04/2020-10-31'
           expect(work.embargo_date).to eq Date.parse("#{embargo_year}-04-04")
-          expect(work.subtype).to eq ['Article', 'Presentation slides']
+          expect(work.subtype).to eq ['Article', 'Technical report']
           expect(DepositJob).to have_received(:perform_later).with(work)
           expect(work.state).to eq 'depositing'
           expect(work.access).to eq 'world' # shows that `stanford` was overwritten

--- a/spec/services/description_generator_spec.rb
+++ b/spec/services/description_generator_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe DescriptionGenerator do
           },
           {
             type: 'subtype',
-            value: 'Presentation slides'
+            value: 'Technical report'
           }
         ],
         type: 'resource type'
@@ -51,7 +51,11 @@ RSpec.describe DescriptionGenerator do
       },
       {
         type: 'genre',
-        value: 'Presentation slides'
+        value: 'Technical reports',
+        uri: 'http://id.loc.gov/authorities/genreForms/gf2015026093',
+        source: {
+          code: 'lcgft'
+        }
       },
       {
         source: {

--- a/spec/services/request_generator_spec.rb
+++ b/spec/services/request_generator_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RequestGenerator do
           },
           {
             type: 'subtype',
-            value: 'Presentation slides'
+            value: 'Technical report'
           }
         ],
         type: 'resource type'
@@ -39,7 +39,11 @@ RSpec.describe RequestGenerator do
       },
       {
         type: 'genre',
-        value: 'Presentation slides'
+        value: 'Technical reports',
+        uri: 'http://id.loc.gov/authorities/genreForms/gf2015026093',
+        source: {
+          code: 'lcgft'
+        }
       },
       {
         source: {

--- a/spec/services/types_generator_spec.rb
+++ b/spec/services/types_generator_spec.rb
@@ -162,4 +162,80 @@ RSpec.describe TypesGenerator do
       end
     end
   end
+
+  describe 'cocina mapping' do
+    non_other_work_types = WorkType.all.reject { |work_type| work_type.id == 'other' }
+
+    let(:generator) { described_class.new(work: work) }
+    let(:types_to_genres) { generator.send(:types_to_genres) }
+    let(:types_to_resource_types) { generator.send(:types_to_resource_types) }
+
+    describe 'for work types' do
+      # NOTE: the Other type has no mappings
+      let(:work_type_labels) { non_other_work_types.map(&:label) }
+
+      it 'has one genre for each' do
+        # NOTE: General mappings do not correspond to a particular type
+        expect(work_type_labels).to match_array(types_to_genres.keys - ['General'])
+      end
+
+      it 'has one resource type for each' do
+        # NOTE: General mappings do not correspond to a particular type
+        expect(work_type_labels).to match_array(types_to_resource_types.keys - ['General'])
+      end
+    end
+
+    describe 'for subtypes' do
+      non_other_work_types.each do |work_type|
+        context "with type #{work_type.label}" do
+          let(:known_genreless) do
+            case work_type.label
+            when 'Data'
+              ['Documentation']
+            when 'Text'
+              ['Policy brief']
+            else
+              []
+            end
+          end
+
+          it 'has a one-to-one genre mapping to subtypes' do
+            expect(work_type.subtypes - known_genreless).to eq(types_to_genres[work_type.label]['subtypes'].keys)
+          end
+
+          it 'has a one-to-one resource type mapping to subtypes' do
+            expect(work_type.subtypes).to eq(types_to_resource_types[work_type.label]['subtypes'].keys)
+          end
+        end
+      end
+    end
+
+    describe 'for "more" types' do
+      let(:all_type_genres) do
+        types_to_genres
+          .values
+          .map { |work_type| work_type['subtypes'].keys }
+          .flatten
+          .sort
+          .uniq
+      end
+      let(:all_type_resource_types) do
+        types_to_resource_types
+          .values
+          .map { |work_type| work_type['subtypes'].keys }
+          .flatten
+          .sort
+          .uniq
+      end
+      let(:known_genreless) { ['Policy brief', 'Speaker notes'] }
+
+      it 'has one genre for each' do
+        expect(all_type_genres).to include(*(WorkType.more_types - known_genreless))
+      end
+
+      it 'has one resource type for each' do
+        expect(all_type_resource_types).to include(*WorkType.more_types)
+      end
+    end
+  end
 end

--- a/spec/services/types_generator_spec.rb
+++ b/spec/services/types_generator_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe TypesGenerator do
               ),
               Cocina::Models::DescriptiveValue.new(
                 type: 'subtype',
-                value: 'Presentation slides'
+                value: 'Technical report'
               )
             ]
           )
@@ -56,7 +56,9 @@ RSpec.describe TypesGenerator do
           ),
           Cocina::Models::DescriptiveValue.new(
             type: 'genre',
-            value: 'Presentation slides'
+            value: 'Technical reports',
+            uri: 'http://id.loc.gov/authorities/genreForms/gf2015026093',
+            source: { code: 'lcgft' }
           )
         )
       end


### PR DESCRIPTION
Fixes #716

## Why was this change made?

Includes:

* Pull surrounding `<div>`s into the work type modal component to reduce copypasta
* Allow work types to contain *any* subtypes including "more" types
* Add `WorkType.more_types` to prevent collaborators from needing to know the internal structure of the class; prefer message-sending
  * Use the message-sending approach from within the work type modal ERB
* Add optional param to `WorkType.subtypes_for` that allows adding "more" types to subtypes which are now valid subtypes
* Add feature spec to test "See more options" link in work type modal
* Adjust tests to reflect changes to work type and subtype validation

NOTE: Until #972 is done, the "more" types selected for a work type **WILL NOT** be visible in the work form. I'm taking that issue next.

### SCREENCAST

![Peek 2021-02-05 10-18](https://user-images.githubusercontent.com/131982/107073098-c2c1ba80-679b-11eb-82a5-c24864c7e14c.gif)

## How was this change tested?

CI, local browser

## Which documentation and/or configurations were updated?

None

