### PR TITLE
add collections in progress section for collection managers

### DIFF
--- a/app/components/dashboard/in_progress_collection_component.html.erb
+++ b/app/components/dashboard/in_progress_collection_component.html.erb
@@ -1,0 +1,4 @@
+<section class="mb-5" id="collections-in-progress">
+  <header>Collections in progress</header>
+  <%= render Dashboard::InProgressCollectionRowComponent.with_collection(collection_managers_in_progress) %>
+</section>

--- a/app/components/dashboard/in_progress_collection_component.rb
+++ b/app/components/dashboard/in_progress_collection_component.rb
@@ -1,0 +1,22 @@
+# typed: true
+# frozen_string_literal: true
+
+module Dashboard
+  # Renders a list of collections in progress
+  class InProgressCollectionComponent < ApplicationComponent
+    sig { params(presenter: DashboardPresenter).void }
+    def initialize(presenter:)
+      @presenter = presenter
+    end
+
+    attr_reader :presenter
+
+    delegate :collection_managers_in_progress, to: :presenter
+    delegate :user_with_groups, to: :helpers
+
+    sig { returns(T::Boolean) }
+    def render?
+      user_with_groups.administrator? || collection_managers_in_progress.size.positive?
+    end
+  end
+end

--- a/app/components/dashboard/in_progress_collection_component.rb
+++ b/app/components/dashboard/in_progress_collection_component.rb
@@ -16,7 +16,7 @@ module Dashboard
 
     sig { returns(T::Boolean) }
     def render?
-      user_with_groups.administrator? || collection_managers_in_progress.size.positive?
+      user_with_groups.administrator? || collection_managers_in_progress.present?
     end
   end
 end

--- a/app/components/dashboard/in_progress_collection_row_component.html.erb
+++ b/app/components/dashboard/in_progress_collection_row_component.html.erb
@@ -1,4 +1,4 @@
-<div style="margin-bottom: 0.5rem;" class="row">
+<div class="mb-2" class="row">
   <div class="col-4">
     <%= show_collection_link %>
   </div>

--- a/app/components/dashboard/in_progress_collection_row_component.html.erb
+++ b/app/components/dashboard/in_progress_collection_row_component.html.erb
@@ -1,0 +1,11 @@
+<div style="margin-bottom: 0.5rem;" class="row">
+  <div class="col-4">
+    <%= show_collection_link %>
+  </div>
+  <div class="col-3">
+    <%= link_to 'Complete draft', edit_collection_path(collection), class: "btn btn-primary" %>
+  </div>
+  <div class="col-5">
+    <%= helpers.turbo_frame_tag dom_id(collection, :delete), src: delete_button_collection_path(collection) if collection.first_draft?%>
+  </div>
+</div>

--- a/app/components/dashboard/in_progress_collection_row_component.rb
+++ b/app/components/dashboard/in_progress_collection_row_component.rb
@@ -1,0 +1,24 @@
+# typed: false
+# frozen_string_literal: true
+
+module Dashboard
+  # Display some information about a work that is in progress
+  class InProgressCollectionRowComponent < ApplicationComponent
+    with_collection_parameter :collection
+
+    def initialize(collection:)
+      @collection = collection
+    end
+
+    attr_reader :collection
+
+    def collection_name
+      Dashboard::CollectionHeaderComponent.new(collection: collection).name
+    end
+
+    def show_collection_link
+      truncated_collection_name = truncate(collection_name, length: 100, separator: ' ')
+      link_to truncated_collection_name, collection, title: collection_name
+    end
+  end
+end

--- a/app/components/works/contact_email_component.rb
+++ b/app/components/works/contact_email_component.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module Works

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -6,6 +6,7 @@ class DashboardsController < ApplicationController
   before_action :authenticate_user!
   verify_authorized
 
+  # rubocop:disable Metrics/AbcSize
   def show
     authorize! :dashboard
     @presenter = DashboardPresenter.new(
@@ -14,9 +15,12 @@ class DashboardsController < ApplicationController
                      .joins(collection: :reviewed_by)
                      .where('reviewers.user_id' => current_user),
       in_progress: Work.with_state(:first_draft, :version_draft, :rejected)
-                       .where(depositor: current_user)
+                       .where(depositor: current_user),
+      collection_managers_in_progress: Collection.with_state(:first_draft, :version_draft)
+                                                 .joins(:managers).where("managers.user_id = #{current_user.id}")
     )
 
     @presenter.work_stats = StatBuilder.build_stats if user_with_groups.administrator?
   end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -16,8 +16,7 @@ class DashboardsController < ApplicationController
                      .where('reviewers.user_id' => current_user),
       in_progress: Work.with_state(:first_draft, :version_draft, :rejected)
                        .where(depositor: current_user),
-      collection_managers_in_progress: Collection.with_state(:first_draft, :version_draft)
-                                                 .joins(:managers).where("managers.user_id = #{current_user.id}")
+      collection_managers_in_progress: current_user.manages_collections.with_state(:first_draft, :version_draft)
     )
 
     @presenter.work_stats = StatBuilder.build_stats if user_with_groups.administrator?

--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -8,16 +8,21 @@ class DashboardPresenter
   sig do
     params(in_progress: ActiveRecord::Relation,
            approvals: ActiveRecord::Relation,
-           collections: ActiveRecord::Relation).void
+           collections: ActiveRecord::Relation,
+           collection_managers_in_progress: ActiveRecord::Relation).void
   end
-  def initialize(in_progress:, approvals:, collections:)
+  def initialize(in_progress:, approvals:, collections:, collection_managers_in_progress:)
     @in_progress = in_progress
     @approvals = approvals
     @collections = collections
+    @collection_managers_in_progress = collection_managers_in_progress
   end
 
   sig { returns(ActiveRecord::Relation) }
   attr_reader :in_progress
+
+  sig { returns(ActiveRecord::Relation) }
+  attr_reader :collection_managers_in_progress
 
   sig { returns(ActiveRecord::Relation) }
   attr_reader :approvals

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -4,9 +4,10 @@
 <main class="mb-3 mb-md-5" id="content">
   <div class="container px-4 px-md-3" id="dashboard">
     <%= render Dashboard::InProgressComponent.new(presenter: @presenter) %>
+    <%= render Dashboard::InProgressCollectionComponent.new(presenter: @presenter) %>
     <%= render Dashboard::ApprovalsComponent.new(presenter: @presenter) %>
 
-    <section data-controller="work-type">
+    <section id="your-collections" data-controller="work-type">
       <header>Your collections
         <% if allowed_to?(:create?, Collection) %>
           <%= link_to '+ Create a new collection', new_collection_path, class: "btn btn-outline-primary float-end" %>

--- a/spec/components/dashboard/in_progress_collection_component_spec.rb
+++ b/spec/components/dashboard/in_progress_collection_component_spec.rb
@@ -1,0 +1,47 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Dashboard::InProgressCollectionComponent, type: :component do
+  let(:presenter) do
+    DashboardPresenter.new(
+      in_progress: Work.none,
+      approvals: Work.none,
+      collections: Collection.none,
+      collection_managers_in_progress: collections
+    )
+  end
+  let(:user_with_groups) { UserWithGroups.new(user: user, groups: []) }
+  let(:user) { create(:user) }
+  let(:rendered) { render_inline(described_class.new(presenter: presenter)) }
+
+  before do
+    allow(controller).to receive_messages(
+      current_user: user,
+      user_with_groups: user_with_groups
+    )
+    create(:collection)
+    create(:collection)
+    create(:collection)
+  end
+
+  context 'when presenter has zero in progress collections' do
+    let(:collections) { Collection.none }
+
+    it 'does not render the component at all' do
+      expect(rendered.to_html).not_to include('Collections in progress')
+    end
+  end
+
+  context 'when presenter has one or more in progress collections' do
+    let(:collections) { Collection.all }
+
+    it 'renders the component with collections' do
+      expect(rendered.to_html).to include('Collections in progress')
+      collections.pluck(:name).each do |name|
+        expect(rendered.to_html).to include(name)
+      end
+    end
+  end
+end

--- a/spec/components/dashboard/in_progress_collection_row_component_spec.rb
+++ b/spec/components/dashboard/in_progress_collection_row_component_spec.rb
@@ -1,0 +1,13 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Dashboard::InProgressCollectionRowComponent, type: :component do
+  let(:rendered) { render_inline(described_class.new(collection: collection)) }
+  let(:collection) { build_stubbed(:collection) }
+
+  it 'renders the component' do
+    expect(rendered.to_html).to include collection.name
+  end
+end

--- a/spec/components/dashboard/in_progress_component_spec.rb
+++ b/spec/components/dashboard/in_progress_component_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Dashboard::InProgressComponent, type: :component do
     DashboardPresenter.new(
       in_progress: works,
       approvals: Work.none,
-      collections: Collection.none
+      collections: Collection.none,
+      collection_managers_in_progress: Collection.none
     )
   end
   let(:rendered) { render_inline(described_class.new(presenter: presenter)) }

--- a/spec/features/delete_draft_collection_spec.rb
+++ b/spec/features/delete_draft_collection_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe 'Delete a draft collection', js: true do
       visit dashboard_path
 
       accept_confirm do
-        click_link "Delete #{collection.name}"
+        within '#your-collections' do
+          click_link "Delete #{collection.name}"
+        end
       end
       expect(Collection.find_by(id: collection.id)).to be(nil)
     end

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 
 RSpec.describe 'Dashboard requests' do
   let(:user) { create(:user) }
+  let(:collection_manager) { create(:user) }
 
   context 'when user has no deposits' do
     before { sign_in user }
@@ -45,6 +46,24 @@ RSpec.describe 'Dashboard requests' do
       expect(response).to be_successful
       expect(response.body).to include 'No title' # this is the default title when none is provided for a draft
       expect(response.body).not_to include 'Secret'
+    end
+  end
+
+  context 'when user is a collection manager and there is a collection in progress' do
+    let(:collection) do
+      create(:collection, :first_draft, creator: user, managers: [collection_manager], name: 'Happy little collection')
+    end
+
+    before do
+      sign_in collection_manager
+      create(:work, collection: collection, depositor: collection_manager)
+    end
+
+    it 'shows the collection in progress' do
+      get '/dashboard'
+      expect(response).to be_successful
+      expect(response.body).to include('Collections in progress')
+      expect(response.body).to include(collection.name)
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Fixes #946 - add an in progress section to the top of the dashboard, but for collections (not works) that are in a draft state and for which the user is defined as a collection manager

To do:
- [x] NO ~~do admins get to see all collections in draft state?  best way to add this to the query if so?~~

## How was this change tested?

Todo

- [x] create a new spec for `in_progress_collection_component`
- [x] verify in a feature spec?


