### PR TITLE
Reorder the license groups so that CC-PDDC is lower on the list

### DIFF
--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -42,8 +42,8 @@ class License
   # list for the work form pulldown
   sig { returns(T::Array[T::Array[T.any(String, T::Array[String])]]) }
   def self.grouped_options
-    GROUPINGS.map do |key, group_label|
-      [group_label, GROUPED_LICENSES.fetch(key).map { |license_id| [label_for(license_id), license_id] }]
+    GROUPINGS.map do |group|
+      [group.fetch(:label), group.fetch(:options).map { |license_id| [label_for(license_id), license_id] }]
     end
   end
 
@@ -52,18 +52,10 @@ class License
     ID_LABEL_HASH.fetch(license_id)
   end
 
-  GROUPINGS = {
-    'cc-pdcc' => 'CC-PDDC Public Domain Dedication and Certification',
-    'cc' => 'Creative Commons',
-    'odc' => 'Open Data Commons (ODC) licenses',
-    'software' => 'Software Licenses',
-    'none' => 'No License'
-  }.freeze
-
-  GROUPED_LICENSES = {
-    'cc-pdcc' => ['CC-PDDC'],
-    'cc' =>
-      [
+  GROUPINGS = [
+    {
+      label: 'Creative Commons',
+      options: [
         'CC0-1.0',
         'CC-BY-4.0',
         'CC-BY-SA-4.0',
@@ -71,15 +63,23 @@ class License
         'CC-BY-NC-4.0',
         'CC-BY-NC-SA-4.0',
         'CC-BY-NC-ND-4.0'
-      ],
-    'odc' =>
-      [
+      ]
+    },
+    {
+      label: 'CC-PDDC Public Domain Dedication and Certification',
+      options: ['CC-PDDC']
+    },
+    {
+      label: 'Open Data Commons (ODC) licenses',
+      options: [
         'PDDL-1.0',
         'ODC-By-1.0',
         'ODbL-1.0'
-      ],
-    'software' =>
-      [
+      ]
+    },
+    {
+      label: 'Software Licenses',
+      options: [
         'AGPL-3.0-only',
         'Apache-2.0',
         'BSD-2-Clause',
@@ -91,7 +91,11 @@ class License
         'LGPL-3.0-only',
         'MIT',
         'MPL-2.0'
-      ],
-    'none' => ['none']
-  }.freeze
+      ]
+    },
+    {
+      label: 'No License',
+      options: ['none']
+    }
+  ].freeze
 end

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
         expect(page).to have_content 'User provided abstract'
         expect(page).to have_content 'Citation from user input'
         expect(page).to have_content 'Everyone'
-        expect(page).to have_content('CC-PDDC Public Domain Dedication and Certification')
+        expect(page).to have_content 'CC0-1.0'
 
         visit dashboard_path
 

--- a/spec/models/license_spec.rb
+++ b/spec/models/license_spec.rb
@@ -42,12 +42,6 @@ RSpec.describe License do
     it 'makes groups with headings' do
       expect(grouped_options).to eq [
         [
-          'CC-PDDC Public Domain Dedication and Certification',
-          [
-            ['CC-PDDC Public Domain Dedication and Certification', 'CC-PDDC']
-          ]
-        ],
-        [
           'Creative Commons',
           [
             ['CC0-1.0', 'CC0-1.0'],
@@ -57,6 +51,12 @@ RSpec.describe License do
             ['CC-BY-NC-4.0 Attribution-NonCommercial International', 'CC-BY-NC-4.0'],
             ['CC-BY-NC-SA-4.0 Attribution-NonCommercial-Share Alike International', 'CC-BY-NC-SA-4.0'],
             ['CC-BY-NC-ND-4.0 Attribution-NonCommercial-No Derivatives', 'CC-BY-NC-ND-4.0']
+          ]
+        ],
+        [
+          'CC-PDDC Public Domain Dedication and Certification',
+          [
+            ['CC-PDDC Public Domain Dedication and Certification', 'CC-PDDC']
           ]
         ],
         [


### PR DESCRIPTION


Fixes #1038

## Why was this change made?



## How was this change tested?

<img width="1325" alt="Screen Shot 2021-02-08 at 1 22 39 PM" src="https://user-images.githubusercontent.com/92044/107270688-df1a5d00-6a10-11eb-879c-7ddbaabde9d3.png">

## Which documentation and/or configurations were updated?



