### PR TITLE
Add a field for license_option

### DIFF
--- a/app/components/collections/terms_of_use_component.html.erb
+++ b/app/components/collections/terms_of_use_component.html.erb
@@ -12,15 +12,15 @@
       <th>Terms of use</th>
       <td><%= I18n.t(:terms_of_use) %></td>
     </tr>
-    <% if required_license.present? %>
-      <tr>
-        <th>Required license</th>
-        <td><%= required_license %></td>
-      </tr>
-    <% elsif default_license.present? %>
+    <% if user_can_set_license? %>
       <tr>
         <th>Default license (depositor selects)</th>
         <td><%= default_license %></td>
+      </tr>
+    <% else %>
+      <tr>
+        <th>Required license</th>
+        <td><%= required_license %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/components/collections/terms_of_use_component.rb
+++ b/app/components/collections/terms_of_use_component.rb
@@ -12,6 +12,6 @@ module Collections
     sig { returns(Collection) }
     attr_reader :collection
 
-    delegate :default_license, :required_license, to: :collection
+    delegate :default_license, :required_license, :user_can_set_license?, to: :collection
   end
 end

--- a/app/forms/draft_collection_form.rb
+++ b/app/forms/draft_collection_form.rb
@@ -24,9 +24,7 @@ class DraftCollectionForm < Reform::Form
   property :release_duration
   property :release_date, embargo_date: true, assign_if: ->(params) { params['release_option'] == 'delay' }
 
-  property :license_option, virtual: true, prepopulator: (proc do |*|
-    self.license_option = default_license.present? ? 'depositor-selects' : 'required'
-  end)
+  property :license_option
   property :required_license
   property :default_license
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -35,7 +35,7 @@ class Collection < ApplicationRecord
   # The collection has allowed the user to select a license for the member works
   sig { returns(T::Boolean) }
   def user_can_set_license?
-    required_license.nil?
+    license_option == 'depositor-selects'
   end
 
   sig { returns(T.nilable(String)) }

--- a/db/migrate/20210208201246_add_license_option_to_collection.rb
+++ b/db/migrate/20210208201246_add_license_option_to_collection.rb
@@ -1,0 +1,10 @@
+class AddLicenseOptionToCollection < ActiveRecord::Migration[6.1]
+  def change
+    add_column :collections, :license_option, :string
+    Collection.all.each do |col|
+      col.update(license_option: col.required_license.nil? ? 'depositor-selects' : 'required')
+    end
+    change_column_null :collections, :license_option, false
+    change_column_default :collections, :license_option, from: nil, to: 'required'
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -224,7 +224,8 @@ CREATE TABLE public.collections (
     druid character varying,
     version integer DEFAULT 0 NOT NULL,
     email_depositors_status_changed boolean,
-    review_enabled boolean DEFAULT false
+    review_enabled boolean DEFAULT false,
+    license_option character varying DEFAULT 'required'::character varying NOT NULL
 );
 
 
@@ -1127,6 +1128,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210114221943'),
 ('20210127133325'),
 ('20210201155622'),
-('20210202044303');
+('20210202044303'),
+('20210208201246');
 
 

--- a/spec/components/collections/terms_of_use_component_spec.rb
+++ b/spec/components/collections/terms_of_use_component_spec.rb
@@ -6,10 +6,8 @@ require 'rails_helper'
 RSpec.describe Collections::TermsOfUseComponent, type: :component do
   subject(:rendered) { render_inline(described_class.new(collection: collection)).to_html }
 
-  let(:collection) { build_stubbed(:collection, required_license: required_license, default_license: default_license) }
-
   context 'with a collection that has a required license' do
-    let(:default_license) { nil }
+    let(:collection) { build_stubbed(:collection, :with_required_license, required_license: required_license) }
     let(:required_license) { 'MIT' }
 
     it { is_expected.to include(required_license) }
@@ -17,18 +15,10 @@ RSpec.describe Collections::TermsOfUseComponent, type: :component do
   end
 
   context 'with a collection that has a default license' do
+    let(:collection) { build_stubbed(:collection, default_license: default_license) }
     let(:default_license) { 'Apache-2.0' }
-    let(:required_license) { nil }
 
     it { is_expected.to include(default_license) }
     it { is_expected.to include('Default license (depositor selects)') }
-  end
-
-  context 'with a collection that has no licenses' do
-    let(:default_license) { nil }
-    let(:required_license) { nil }
-
-    it { is_expected.not_to include('Required license') }
-    it { is_expected.not_to include('Default license (depositor selects)') }
   end
 end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     release_option { 'immediate' }
     release_date { '2020-10-09' }
     access { 'world' }
-    default_license { nil }
+    license_option { 'depositor-selects' }
     email_when_participants_changed { false }
     state { 'first_draft' }
     creator
@@ -16,6 +16,7 @@ FactoryBot.define do
 
   trait :with_required_license do
     required_license { 'CC-BY-4.0' }
+    license_option { 'required' }
   end
 
   trait :with_works do

--- a/spec/features/single_radio_selection_spec.rb
+++ b/spec/features/single_radio_selection_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Selecting a radio button causes other radio button inputs to be 
     end
 
     describe 'license option' do
-      let(:collection) { create(:collection, managers: [user]) }
+      let(:collection) { create(:collection, managers: [user], license_option: 'required') }
 
       before { visit edit_collection_path(collection) }
 

--- a/spec/forms/collection_form_spec.rb
+++ b/spec/forms/collection_form_spec.rb
@@ -10,30 +10,6 @@ RSpec.describe CollectionForm do
   let(:default_license) { nil }
   let(:required_license) { nil }
 
-  # NOTE: license validation is not tested in this spec; it is tested in the
-  #       CollectionLicenseValidator spec.
-  describe 'license_option prepopulator' do
-    before do
-      form.prepopulate!
-    end
-
-    context 'when default_license is set' do
-      let(:default_license) { 'CC0-1.0' }
-
-      it 'sets license_option to "depositor-selects"' do
-        expect(form.license_option).to eq('depositor-selects')
-      end
-    end
-
-    context 'when required_license is set' do
-      let(:required_license) { 'Apache-2.0' }
-
-      it 'sets license_option to "required"' do
-        expect(form.license_option).to eq('required')
-      end
-    end
-  end
-
   describe '#deserialize!' do
     subject(:deserialized) { form.deserialize!(params) }
 


### PR DESCRIPTION


## Why was this change made?
So we can store the radio button choice separate from whether a license was chosen.
Fixes #958 


## How was this change tested?



## Which documentation and/or configurations were updated?



