### PR TITLE
allow collections to be saved with no contact emails

### DIFF
--- a/app/forms/collection_form.rb
+++ b/app/forms/collection_form.rb
@@ -5,6 +5,14 @@
 class CollectionForm < DraftCollectionForm
   extend T::Sig
 
+  collection :contact_emails, populator: ContactEmailsPopulator.new(:contact_emails, ContactEmail),
+                              prepopulator: ->(*) { contact_emails << ContactEmail.new if contact_emails.blank? } do
+    property :id
+    property :email
+    property :_destroy, virtual: true
+    validates :email, format: { with: Devise.email_regexp }
+  end
+
   validates :name, :description, :manager_sunets, :access, presence: true
   validates :contact_emails, length: { minimum: 1, message: 'Please add at least contact email.' }
   validates_with CollectionLicenseValidator

--- a/app/forms/draft_collection_form.rb
+++ b/app/forms/draft_collection_form.rb
@@ -41,7 +41,6 @@ class DraftCollectionForm < Reform::Form
     property :id
     property :email
     property :_destroy, virtual: true
-    validates :email, format: { with: Devise.email_regexp }, allow_blank: true
   end
 
   collection :related_links, populator: RelatedLinksPopulator.new(:related_links, RelatedLink),

--- a/app/forms/draft_collection_form.rb
+++ b/app/forms/draft_collection_form.rb
@@ -41,7 +41,7 @@ class DraftCollectionForm < Reform::Form
     property :id
     property :email
     property :_destroy, virtual: true
-    validates :email, format: { with: Devise.email_regexp }
+    validates :email, format: { with: Devise.email_regexp }, allow_blank: true
   end
 
   collection :related_links, populator: RelatedLinksPopulator.new(:related_links, RelatedLink),

--- a/app/models/contact_email.rb
+++ b/app/models/contact_email.rb
@@ -4,6 +4,4 @@
 # Models an email in the database
 class ContactEmail < ApplicationRecord
   belongs_to :emailable, polymorphic: true
-
-  validates :email, format: { with: Devise.email_regexp }, allow_blank: true
 end

--- a/spec/models/contact_email_spec.rb
+++ b/spec/models/contact_email_spec.rb
@@ -12,11 +12,6 @@ RSpec.describe ContactEmail, type: :model do
     expect(contact_email.email).to be_present
   end
 
-  it 'has a valid email' do
-    contact_email.email = 'asdfasdfe'
-    expect { contact_email.save! }.to raise_error(ActiveRecord::RecordInvalid, /Email is invalid/)
-  end
-
   it 'belongs to a work' do
     expect(contact_email.emailable).to eq work
   end

--- a/spec/requests/create_collection_spec.rb
+++ b/spec/requests/create_collection_spec.rb
@@ -116,10 +116,6 @@ RSpec.describe 'Create a collection' do
           { '0' => { '_destroy' => 'false', email: '' } }
         end
 
-        let(:invalid_contact_email) do
-          { '0' => { '_destroy' => 'false', email: 'bogus' } }
-        end
-
         let(:collection_params) do
           {
             name: 'My Test Collection',
@@ -233,7 +229,7 @@ RSpec.describe 'Create a collection' do
             {
               name: '',
               description: '',
-              contact_emails_attributes: invalid_contact_email,
+              contact_emails_attributes: { '0' => { '_destroy' => 'false', email: 'bogus' } },
               manager_sunets: user.sunetid,
               access: 'world',
               depositor_sunets: ''

--- a/spec/requests/create_collection_spec.rb
+++ b/spec/requests/create_collection_spec.rb
@@ -112,6 +112,14 @@ RSpec.describe 'Create a collection' do
           }
         end
 
+        let(:no_contact_emails) do
+          { '0' => { '_destroy' => 'false', email: '' } }
+        end
+
+        let(:invalid_contact_email) do
+          { '0' => { '_destroy' => 'false', email: 'bogus' } }
+        end
+
         let(:collection_params) do
           {
             name: 'My Test Collection',
@@ -203,7 +211,7 @@ RSpec.describe 'Create a collection' do
             {
               name: '',
               description: '',
-              contact_email: '',
+              contact_emails_attributes: no_contact_emails,
               manager_sunets: user.sunetid,
               access: 'world',
               depositor_sunets: ''
@@ -212,10 +220,32 @@ RSpec.describe 'Create a collection' do
 
           it 'saves the draft collection' do
             post '/collections', params: { collection: draft_collection_params, commit: save_draft_button }
+            expect(response).to have_http_status(:found)
             collection = Collection.last
             expect(collection.name).to be_empty
             expect(collection.depositors.size).to eq 0
+            expect(response).to redirect_to(collection_path(collection))
+          end
+        end
+
+        context 'with an invalid contact email' do
+          let(:draft_collection_params) do
+            {
+              name: '',
+              description: '',
+              contact_emails_attributes: invalid_contact_email,
+              manager_sunets: user.sunetid,
+              access: 'world',
+              depositor_sunets: ''
+            }
+          end
+
+          it 'saves the draft collection' do
+            post '/collections', params: { collection: draft_collection_params, commit: save_draft_button }
             expect(response).to have_http_status(:found)
+            collection = Collection.last
+            expect(collection.name).to be_empty
+            expect(collection.depositors.size).to eq 0
             expect(response).to redirect_to(collection_path(collection))
           end
         end
@@ -225,7 +255,7 @@ RSpec.describe 'Create a collection' do
             {
               name: '',
               description: '',
-              contact_email: '',
+              contact_emails_attributes: no_contact_emails,
               manager_sunets: user.sunetid,
               access: 'world',
               depositor_sunets: 'maya.aguirre,jcairns, cchavez, premad, giancarlo, zhengyi'


### PR DESCRIPTION
## Why was this change made?

Fixes #1044 

- need to remove all validation from the `DraftCollectionForm` to have it work properly
- need to remove model level validation for `ContactEmail`, else you cannot save a draft collection with invalid emails (since it needs to persist to the database, and the model level validation will block it)
- add validation for contact emails to the `CollectionForm` to ensure it gets validated when you try and deposit
- added tests to verify you can save draft collections with missing or bogus contact emails
- updated and added tests 

**Notes**:
Seems to be some fallout from #893 and #842 .... you cannot save a draft collection when leaving the contact email blank or when submitting an invalid contact email.  The problem seems to stem from the fact that we do this validation on the `DraftCollectionForm` but our code no longer supports re-rendering the form once saved as draft (which we try to do now if validation fails).  This means we cannot currently do any validation when saving as draft, because any failed validation will result in an exception, but we currently do validation at the draft level for contact emails.

Even though this PR removes all contact email validation from the `DraftCollectionForm` and moves it to the `CollectionForm`, you will still have a problem if you add validation to the draft form later for any field, as our code currently does not support any validation display for an invalid draft save.

## How was this change tested?

Tests and localhost browser


## Which documentation and/or configurations were updated?



