### PR TITLE
Make approvals visible to collection managers

### DIFF
--- a/app/components/collections/participants_component.rb
+++ b/app/components/collections/participants_component.rb
@@ -19,7 +19,7 @@ module Collections
 
     sig { returns(T.nilable(String)) }
     def managers
-      collection.managers.map(&:sunetid).join(', ')
+      collection.managed_by.map(&:sunetid).join(', ')
     end
   end
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -10,9 +10,7 @@ class DashboardsController < ApplicationController
     authorize! :dashboard
     @presenter = DashboardPresenter.new(
       collections: authorized_scope(Collection.all, as: :deposit),
-      approvals: Work.with_state(:pending_approval)
-                     .joins(collection: :reviewed_by)
-                     .where('reviewers.user_id' => current_user),
+      approvals: Work.awaiting_review_by(current_user),
       in_progress: Work.with_state(:first_draft, :version_draft, :rejected)
                        .where(depositor: current_user)
     )

--- a/app/forms/draft_collection_form.rb
+++ b/app/forms/draft_collection_form.rb
@@ -83,7 +83,7 @@ class DraftCollectionForm < Reform::Form
 
   sig { void }
   def update_managers
-    model.managers = field_to_users(manager_sunets)
+    model.managed_by = field_to_users(manager_sunets)
   end
 
   sig { void }
@@ -116,6 +116,6 @@ class DraftCollectionForm < Reform::Form
 
   sig { returns(T::Array[String]) }
   def manager_sunets_from_model
-    (model.managers.presence || [model.creator]).map(&:sunetid)
+    (model.managed_by.presence || [model.creator]).map(&:sunetid)
   end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -12,7 +12,7 @@ class Collection < ApplicationRecord
   belongs_to :creator, class_name: 'User'
   has_and_belongs_to_many :depositors, class_name: 'User', join_table: 'depositors'
   has_and_belongs_to_many :reviewed_by, class_name: 'User', join_table: 'reviewers'
-  has_and_belongs_to_many :managers, class_name: 'User', join_table: 'managers'
+  has_and_belongs_to_many :managed_by, class_name: 'User', join_table: 'managers'
 
   after_update_commit -> { broadcast_replace_to self }
   after_update_commit :broadcast_update_collection_summary

--- a/app/models/collection_change_set.rb
+++ b/app/models/collection_change_set.rb
@@ -71,7 +71,7 @@ class CollectionChangeSet
       # underlying data in the database is mutable
       @depositors = T.let(collection.depositors.to_a, T::Array[User])
       @reviewers = T.let(collection.reviewed_by.to_a, T::Array[User])
-      @managers = T.let(collection.managers.to_a, T::Array[User])
+      @managers = T.let(collection.managed_by.to_a, T::Array[User])
     end
 
     sig { returns(T::Array[User]) }

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -25,6 +25,14 @@ class Work < ApplicationRecord
   after_update_commit -> { broadcast_replace_to self }
   after_update_commit -> { collection.broadcast_update_collection_summary }
 
+  scope :awaiting_review_by, lambda { |user|
+    with_state(:pending_approval)
+      .left_outer_joins(collection: :reviewed_by)
+      .left_outer_joins(collection: :managed_by)
+      .where('reviewers.user_id' => user)
+      .or(where('managers.user_id' => user))
+  }
+
   enum access: {
     stanford: 'stanford',
     world: 'world'

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -10,6 +10,6 @@ class ApplicationPolicy < ActionPolicy::Base
 
   sig { params(collection: Collection).returns(T::Boolean) }
   def manages_collection?(collection)
-    collection.managers.include?(user)
+    collection.managed_by.include?(user)
   end
 end

--- a/app/policies/collection_policy.rb
+++ b/app/policies/collection_policy.rb
@@ -27,7 +27,7 @@ class CollectionPolicy < ApplicationPolicy
   sig { returns(T::Boolean) }
   def show?
     administrator? ||
-      record.managers.include?(user) ||
+      record.managed_by.include?(user) ||
       record.reviewed_by.include?(user) ||
       record.depositor_ids.include?(user.id)
   end

--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -39,7 +39,7 @@ class WorkPolicy < ApplicationPolicy
   sig { returns(T::Boolean) }
   def update?
     return true if administrator? ||
-                   record.collection.managers.include?(user) ||
+                   record.collection.managed_by.include?(user) ||
                    record.collection.reviewed_by.include?(user)
 
     record.depositor == user && record.can_update_metadata? && !record.pending_approval?
@@ -55,7 +55,7 @@ class WorkPolicy < ApplicationPolicy
   def show?
     administrator? ||
       record.depositor == user ||
-      record.collection.managers.include?(user) ||
+      record.collection.managed_by.include?(user) ||
       record.collection.reviewed_by.include?(user)
   end
 

--- a/app/services/collection_observer.rb
+++ b/app/services/collection_observer.rb
@@ -4,7 +4,7 @@
 # Actions that happen when something happens to a collection
 class CollectionObserver
   def self.collection_activity(work, _transition)
-    work.collection.managers.reject { |manager| manager == work.depositor }.each do |user|
+    work.collection.managed_by.reject { |manager| manager == work.depositor }.each do |user|
       mailer = CollectionsMailer.with(user: user, collection: work.collection, depositor: work.depositor)
       mailer.collection_activity.deliver_later
     end
@@ -80,7 +80,7 @@ class CollectionObserver
     change_set = collection.event_context.fetch(:change_set, nil) # there isn't always a change set at this point
     return unless collection.email_when_participants_changed? && change_set&.participants_changed?
 
-    (collection.managers + collection.reviewed_by).each do |user|
+    (collection.managed_by + collection.reviewed_by).each do |user|
       CollectionsMailer.with(collection: collection, user: user)
                        .participants_changed_email.deliver_later
     end

--- a/app/services/work_observer.rb
+++ b/app/services/work_observer.rb
@@ -38,7 +38,7 @@ class WorkObserver
   # rubocop:disable Metrics/AbcSize
   def self.after_submit_for_review(work, _transition)
     work_mailer(work).reject_email.deliver_later
-    (work.collection.reviewed_by + work.collection.managers - [work.depositor]).each do |recipient|
+    (work.collection.reviewed_by + work.collection.managed_by - [work.depositor]).each do |recipient|
       ReviewersMailer.with(user: recipient, work: work).submitted_email.deliver_later
     end
     work_mailer(work).submitted_email.deliver_later

--- a/app/views/collections_mailer/deposit_access_removed_email.html.erb
+++ b/app/views/collections_mailer/deposit_access_removed_email.html.erb
@@ -6,7 +6,7 @@
    if you have questions about this change.</p>
 
 <p>Collection Managers:<br>
-  <% @collection.managers.each do |manager| %>
+  <% @collection.managed_by.each do |manager| %>
     <%= manager.email %><br>
   <% end %>
 </p>

--- a/app/views/collections_mailer/manage_access_removed_email.html.erb
+++ b/app/views/collections_mailer/manage_access_removed_email.html.erb
@@ -6,7 +6,7 @@
    if you have questions about this change.</p>
 
 <p>Collection Managers:<br>
-  <% @collection.managers.each do |manager| %>
+  <% @collection.managed_by.each do |manager| %>
     <%= manager.email %><br>
   <% end %>
 </p>

--- a/app/views/collections_mailer/review_access_removed_email.html.erb
+++ b/app/views/collections_mailer/review_access_removed_email.html.erb
@@ -5,7 +5,7 @@
    in this collection. Please contact the collection Managers below if you have questions about this change.</p>
 
 <p>Collection Managers:<br>
-  <% @collection.managers.each do |manager| %>
+  <% @collection.managed_by.each do |manager| %>
     <%= manager.email %><br>
   <% end %>
 </p>

--- a/sorbet/rails-rbi/models/collection.rbi
+++ b/sorbet/rails-rbi/models/collection.rbi
@@ -90,6 +90,15 @@ module Collection::GeneratedAttributeMethods
   def id?; end
 
   sig { returns(String) }
+  def license_option; end
+
+  sig { params(value: T.any(String, Symbol)).void }
+  def license_option=(value); end
+
+  sig { returns(T::Boolean) }
+  def license_option?; end
+
+  sig { returns(String) }
   def name; end
 
   sig { params(value: T.any(String, Symbol)).void }
@@ -215,13 +224,13 @@ module Collection::GeneratedAssociationMethods
   def events=(value); end
 
   sig { returns(::User::ActiveRecord_Associations_CollectionProxy) }
-  def managers; end
+  def managed_by; end
 
   sig { returns(T::Array[Integer]) }
-  def manager_ids; end
+  def managed_by_ids; end
 
   sig { params(value: T::Enumerable[::User]).void }
-  def managers=(value); end
+  def managed_by=(value); end
 
   sig { returns(::RelatedLink::ActiveRecord_Associations_CollectionProxy) }
   def related_links; end

--- a/sorbet/rails-rbi/models/work.rbi
+++ b/sorbet/rails-rbi/models/work.rbi
@@ -335,6 +335,9 @@ class Work < ApplicationRecord
   def self.accesses; end
 
   sig { params(args: T.untyped).returns(Work::ActiveRecord_Relation) }
+  def self.awaiting_review_by(*args); end
+
+  sig { params(args: T.untyped).returns(Work::ActiveRecord_Relation) }
   def self.not_stanford(*args); end
 
   sig { params(args: T.untyped).returns(Work::ActiveRecord_Relation) }
@@ -360,6 +363,9 @@ class Work::ActiveRecord_Relation < ActiveRecord::Relation
   Elem = type_member(fixed: Work)
 
   sig { params(args: T.untyped).returns(Work::ActiveRecord_Relation) }
+  def awaiting_review_by(*args); end
+
+  sig { params(args: T.untyped).returns(Work::ActiveRecord_Relation) }
   def not_stanford(*args); end
 
   sig { params(args: T.untyped).returns(Work::ActiveRecord_Relation) }
@@ -379,6 +385,9 @@ class Work::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelation
   Elem = type_member(fixed: Work)
 
   sig { params(args: T.untyped).returns(Work::ActiveRecord_AssociationRelation) }
+  def awaiting_review_by(*args); end
+
+  sig { params(args: T.untyped).returns(Work::ActiveRecord_AssociationRelation) }
   def not_stanford(*args); end
 
   sig { params(args: T.untyped).returns(Work::ActiveRecord_AssociationRelation) }
@@ -395,6 +404,9 @@ class Work::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associatio
   include Work::CustomFinderMethods
   include Work::QueryMethodsReturningAssociationRelation
   Elem = type_member(fixed: Work)
+
+  sig { params(args: T.untyped).returns(Work::ActiveRecord_AssociationRelation) }
+  def awaiting_review_by(*args); end
 
   sig { params(args: T.untyped).returns(Work::ActiveRecord_AssociationRelation) }
   def not_stanford(*args); end

--- a/spec/components/collections/participants_component_spec.rb
+++ b/spec/components/collections/participants_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Collections::ParticipantsComponent, type: :component do
 
   context 'when displaying a collection' do
     let(:depositors) { collection.depositors.map(&:sunetid).join(', ') }
-    let(:managers) { collection.managers.map(&:sunetid).join(', ') }
+    let(:managers) { collection.managed_by.map(&:sunetid).join(', ') }
     let(:collection) { build_stubbed(:collection, :with_managers, :with_depositors) }
 
     it 'renders the participant component' do

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -41,7 +41,7 @@ FactoryBot.define do
       manager_count { 2 }
     end
 
-    managers { build_list(:user, manager_count) }
+    managed_by { build_list(:user, manager_count) }
   end
 
   trait :with_depositors do

--- a/spec/features/delete_draft_collection_spec.rb
+++ b/spec/features/delete_draft_collection_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 
 RSpec.describe 'Delete a draft collection', js: true do
   let(:user) { create(:user) }
-  let!(:collection) { create(:collection, managers: [user]) }
+  let!(:collection) { create(:collection, managed_by: [user]) }
 
   before do
     sign_in user, groups: ['dlss:hydrus-app-collection-creators']

--- a/spec/features/single_radio_selection_spec.rb
+++ b/spec/features/single_radio_selection_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Selecting a radio button causes other radio button inputs to be 
 
   context 'with collection form' do
     describe 'release option' do
-      let(:collection) { create(:collection, managers: [user], release_option: 'depositor-selects') }
+      let(:collection) { create(:collection, managed_by: [user], release_option: 'depositor-selects') }
 
       before { visit edit_collection_path(collection) }
 
@@ -56,7 +56,7 @@ RSpec.describe 'Selecting a radio button causes other radio button inputs to be 
     end
 
     describe 'license option' do
-      let(:collection) { create(:collection, managers: [user], license_option: 'required') }
+      let(:collection) { create(:collection, managed_by: [user], license_option: 'required') }
 
       before { visit edit_collection_path(collection) }
 

--- a/spec/jobs/deposit_status_job_spec.rb
+++ b/spec/jobs/deposit_status_job_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe DepositStatusJob do
         let(:work) do
           build(:work, :depositing,
                 citation: "Zappa, F. (2013) #{Work::LINK_TEXT}", collection: collection,
-                depositor: collection.managers.first)
+                depositor: collection.managed_by.first)
         end
         let(:collection) { build(:collection, :with_managers) }
 
@@ -35,7 +35,7 @@ RSpec.describe DepositStatusJob do
           end.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
             'CollectionsMailer', 'collection_activity', 'deliver_now',
             { params: {
-              user: collection.managers.last,
+              user: collection.managed_by.last,
               depositor: work.depositor,
               collection: collection
             }, args: [] }

--- a/spec/policies/collection_policy_spec.rb
+++ b/spec/policies/collection_policy_spec.rb
@@ -37,11 +37,11 @@ RSpec.describe CollectionPolicy do
     end
 
     succeed 'when user is a collection manager' do
-      let(:record) { build_stubbed(:collection, managers: [user]) }
+      let(:record) { build_stubbed(:collection, managed_by: [user]) }
     end
 
     failed 'when user is a collection manager and status is depositing' do
-      let(:record) { build_stubbed :collection, :depositing, managers: [user] }
+      let(:record) { build_stubbed :collection, :depositing, managed_by: [user] }
     end
 
     succeed 'when user is an admin' do
@@ -61,7 +61,7 @@ RSpec.describe CollectionPolicy do
     end
 
     succeed 'when the user manages the collection' do
-      let(:record) { build_stubbed(:collection, managers: [user]) }
+      let(:record) { build_stubbed(:collection, managed_by: [user]) }
     end
 
     succeed 'when the user is a collection reviewer' do
@@ -80,7 +80,7 @@ RSpec.describe CollectionPolicy do
     end
 
     context 'when the user is a manager' do
-      let!(:collection) { create(:collection, managers: [user]) }
+      let!(:collection) { create(:collection, managed_by: [user]) }
 
       it { is_expected.to include(collection) }
     end

--- a/spec/policies/work_policy_spec.rb
+++ b/spec/policies/work_policy_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe WorkPolicy do
     end
 
     succeed 'when user is a collection manager' do
-      before { collection.managers = [user] }
+      before { collection.managed_by = [user] }
     end
 
     succeed 'when user is an admin' do
@@ -68,11 +68,11 @@ RSpec.describe WorkPolicy do
     end
 
     succeed 'when user is a collection manager and status is not pending_approval' do
-      let(:collection) { build_stubbed :collection, managers: [user] }
+      let(:collection) { build_stubbed :collection, managed_by: [user] }
     end
 
     succeed 'when user is collection manager and status is pending_approval' do
-      let(:collection) { build_stubbed :collection, managers: [user] }
+      let(:collection) { build_stubbed :collection, managed_by: [user] }
       let(:record) { build_stubbed :work, :pending_approval, collection: collection }
     end
 
@@ -98,7 +98,7 @@ RSpec.describe WorkPolicy do
     end
 
     succeed 'when user is a collection manager' do
-      let(:collection) { build_stubbed :collection, managers: [user] }
+      let(:collection) { build_stubbed :collection, managed_by: [user] }
     end
 
     succeed 'when user is a collection reviewer' do
@@ -155,7 +155,7 @@ RSpec.describe WorkPolicy do
     end
 
     context 'when the user is a manager' do
-      let(:collection) { create(:collection, managers: [user]) }
+      let(:collection) { create(:collection, managed_by: [user]) }
 
       it { is_expected.to include(work) }
     end

--- a/spec/requests/create_collection_spec.rb
+++ b/spec/requests/create_collection_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe 'Create a collection' do
           expect(collection.depositors.size).to eq 6
           expect(collection.depositors).to all(be_kind_of(User))
           expect(collection.depositors).to include(User.find_by!(email: 'maya.aguirre@stanford.edu'))
-          expect(collection.managers).to eq [user]
+          expect(collection.managed_by).to eq [user]
           expect(collection.email_when_participants_changed).to eq true
           expect(collection.email_depositors_status_changed).to eq true
           expect(collection.contact_emails.size).to eq 2
@@ -173,7 +173,7 @@ RSpec.describe 'Create a collection' do
             expect(response).to have_http_status(:found)
             expect(response).to redirect_to(dashboard_path)
             collection = Collection.last
-            expect(collection.managers.map(&:sunetid)).to eq ['maya.aguirre', 'jcairns']
+            expect(collection.managed_by.map(&:sunetid)).to eq ['maya.aguirre', 'jcairns']
             expect(collection.reviewed_by.map(&:email)).to eq %w[maya.aguirre@stanford.edu
                                                                  jcairns@stanford.edu faridz@stanford.edu]
           end

--- a/spec/requests/edit_collection_spec.rb
+++ b/spec/requests/edit_collection_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Updating an existing collection' do
 
   context 'with an authenticated collection manager' do
     let(:user) { create(:user) }
-    let(:collection) { create(:collection, :with_contact_emails, managers: [user]) }
+    let(:collection) { create(:collection, :with_contact_emails, managed_by: [user]) }
 
     before do
       sign_in user
@@ -57,7 +57,7 @@ RSpec.describe 'Updating an existing collection' do
         end
 
         context 'when the review workflow is set to disabled' do
-          let(:collection) { create(:collection, :with_reviewers, :with_contact_emails, managers: [user]) }
+          let(:collection) { create(:collection, :with_reviewers, :with_contact_emails, managed_by: [user]) }
 
           let(:collection_params) do
             {
@@ -84,7 +84,7 @@ RSpec.describe 'Updating an existing collection' do
         context 'when the collection was previously deposited' do
           let(:collection) do
             create(:collection, :deposited, :with_depositors, :email_depositors_status_changed, depositor_count: 2,
-                                                                                                managers: [user])
+                                                                                                managed_by: [user])
           end
           let(:collection_params) do
             {
@@ -127,7 +127,7 @@ RSpec.describe 'Updating an existing collection' do
           let!(:removed_depositor) { collection.depositors.second } # needs to be instantiated before collection edit
           let(:collection) do
             create(:collection, :deposited, :with_depositors, :email_when_participants_changed,
-                   depositor_count: 2, managers: [user], reviewed_by: [reviewer, reviewer2])
+                   depositor_count: 2, managed_by: [user], reviewed_by: [reviewer, reviewer2])
           end
           let(:collection_params) do
             {

--- a/spec/requests/show_collection_spec.rb
+++ b/spec/requests/show_collection_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Show the collection detail page' do
   context 'with an admin user' do
     let(:user) { create(:user) }
     let(:depositors) { collection.depositors.map(&:sunetid).join(', ') }
-    let(:managers) { collection.managers.map(&:sunetid).join(', ') }
+    let(:managers) { collection.managed_by.map(&:sunetid).join(', ') }
     let(:reviewers) { collection2.reviewed_by.map(&:sunetid).join(', ') }
 
     before do

--- a/spec/requests/show_works_in_collection_spec.rb
+++ b/spec/requests/show_works_in_collection_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Show the collection work list page' do
 
   context 'with a manager' do
     let(:collection) { create(:collection, :with_managers, :with_works) }
-    let(:user) { collection.managers.first }
+    let(:user) { collection.managed_by.first }
 
     before do
       sign_in user

--- a/spec/services/collection_observer_spec.rb
+++ b/spec/services/collection_observer_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CollectionObserver do
         let(:manager) { create(:user) }
         let(:collection) do
           create(:collection, :deposited, :with_depositors, :email_when_participants_changed,
-                 managers: [manager], reviewed_by: [reviewer, reviewer2], depositor_count: 2)
+                 managed_by: [manager], reviewed_by: [reviewer, reviewer2], depositor_count: 2)
         end
 
         it 'sends emails to the managers about the participants change' do
@@ -86,7 +86,7 @@ RSpec.describe CollectionObserver do
     context 'when managers are added to a collection' do
       let(:collection) { create(:collection, :deposited) }
       let(:manager) { create(:user) }
-      let(:collection_after) { collection.dup.tap { |col| col.managers = [manager] } }
+      let(:collection_after) { collection.dup.tap { |col| col.managed_by = [manager] } }
 
       it 'sends emails to those removed' do
         expect { action }.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
@@ -97,7 +97,7 @@ RSpec.describe CollectionObserver do
     end
 
     context 'when managers are removed from a collection' do
-      let(:collection_after) { collection.dup.tap { |col| col.managers = [collection.managers.first] } }
+      let(:collection_after) { collection.dup.tap { |col| col.managed_by = [collection.managed_by.first] } }
       let(:collection) do
         create(:collection, :deposited, :with_managers, manager_count: 2)
       end
@@ -105,7 +105,7 @@ RSpec.describe CollectionObserver do
       it 'sends emails to those removed' do
         expect { action }.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
           'CollectionsMailer', 'manage_access_removed_email', 'deliver_now',
-          { params: { user: collection.managers.last, collection: collection }, args: [] }
+          { params: { user: collection.managed_by.last, collection: collection }, args: [] }
         )
       end
     end


### PR DESCRIPTION
This required the association 'managers' to be renamed to 'managed_by' similar to how we use 'reviewed_by'.  See #780 See rails/rails#41010

## Why was this change made?


Fixes #1005


## How was this change tested?



## Which documentation and/or configurations were updated?



