### PR TITLE
update text in terms of use modal, add print window, and link in nav

### DIFF
--- a/app/components/works/agreement_component.html.erb
+++ b/app/components/works/agreement_component.html.erb
@@ -13,31 +13,3 @@
     </div>
   </div>
 </section>
-
-<div class="modal" id="termsOfDepositModal" tabindex="-1" aria-labelledby="content-type-prompt" aria-hidden="true">
-  <div class="modal-lg modal-dialog modal-dialog-centered modal-dialog-scrollable">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h3 class="modal-title" id="content-type-prompt">Terms of Deposit</h3>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-        <p>
-          In depositing content to the Stanford Digital Repository (SDR), the Depositor grants The Trustees of Leland Stanford Junior University through the Stanford University Libraries (Stanford Libraries) the non-exclusive, worldwide, perpetual, irrevocable right to reproduce, distribute, display and transmit Depositor’s content (the Work), in whole or in part, in such print and electronic formats as may be in existence now or developed in the future, to sub-license others to do the same, and to preserve and protect the Work, subject to any third-party release or display restrictions specified by Depositor. Stanford Libraries may make the content available to users, subject to the applicable Terms of Use and to any license applied by Depositor. Terms of Use are subject to change by Stanford Libraries; Stanford Libraries will make a reasonable effort to notify the Depositor when changes occur. More information is available at the <a href="https://sdr.stanford.edu/" target="_blank">SDR web site</a>.
-        </p>
-        <p>
-        Stanford Libraries is free to reformat, delete or remove access to any or all of the Work in the SDR. If Stanford Libraries determines it is necessary to remove access to or delete permanently a Work, it will make a reasonable effort to notify the Depositor and, provided it would be lawful in Stanford Libraries’ determination to do so, make available a copy of the Work to Depositor (at Depositor’s expense). Depositor grants no other rights under this license, including, without limitation, any copyright interests in the Work.
-        </p>
-        <p>
-        Depositor represents and warrants that Depositor is the copyright holder of the Work, and/or has obtained the unrestricted permission of other copyright owner(s) to grant Stanford Libraries the rights required by this license or any applied license, including necessary licenses relating to any non-public, third-party software necessary to access, display, and run or print the Work. Depositor warrants that any jointly-owned or third-party owned material, such as graphs, images, photos, music, etc., is clearly identified and acknowledged within the content of the Work, and Depositor is solely responsible and will indemnify Stanford Libraries for any third party claims related to the Work as submitted.
-        </p>
-        <p>
-        Depositor further warrants that the Work does not violate any law or agreement or infringe upon anyone's publicity, privacy or confidentiality rights, including but not limited to privacy rights protected by HIPAA or FERPA. Depositor warrants that the Work does not contain any Restricted or Prohibited Data, such as Social Security Numbers, Driver’s License Numbers or bank account information. (More information is available at Stanford Data Classification Guidelines. Depositor represents that, depositing to the SDR does not violate an existing publication agreement, Internal Review Board (IRB), or contract governing deposited content. If the content is original work derived from a source work produced and/or owned by a third-party, Depositor represents compliance with the terms of use associated with that source work.
-        </p>
-        <p>
-        Depositor agrees to indemnify Stanford harmless against any third party claim based on an allegation that Stanford’s actions under this agreement violate that third party’s copyrights, trademarks, other intellectual property, privacy, publicity or other legal rights.
-        </p>
-      </div>
-    </div>
-  </div>
-</div>

--- a/app/controllers/print_controller.rb
+++ b/app/controllers/print_controller.rb
@@ -1,0 +1,9 @@
+# typed: true
+# frozen_string_literal: true
+
+# The endpoint for the print terms of deposit window
+class PrintController < ApplicationController
+  def terms_of_deposit
+    render layout: false
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,6 +46,12 @@
                           bs_target: '#contactUsModal',
                           controller: 'contact-us'
                         }) %>
+            <%= link_to('Terms of Deposit', '#termsOfDepositModal', 
+                        class: 'nav-link',
+                        data: { 
+                          bs_toggle: 'modal', 
+                          bs_target: '#termsOfDepositModal'
+                        }) %>                        
           </nav>
         </header>
         <% if controller_name != 'welcome' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,6 +61,7 @@
 
 
         <%= render 'shared/flashes' %>
+        <%= render 'shared/terms_of_deposit' %>
         <%= render Help::FormComponent.new(user: current_user) %>
         <%= yield %>
 

--- a/app/views/print/terms_of_deposit.html.erb
+++ b/app/views/print/terms_of_deposit.html.erb
@@ -1,0 +1,9 @@
+<script language='javascript'>
+  window.onload = function() { 
+    document.getElementById("print-link").style.display='none';
+    window.print(); 
+  }
+</script>
+<link rel="stylesheet" type="text/css" media="print" href="bootstrap.min.css"> 
+<a href="javascript:window.close();">Close window</a>
+<%= render partial: 'shared/terms_of_deposit' %>

--- a/app/views/print/terms_of_deposit.html.erb
+++ b/app/views/print/terms_of_deposit.html.erb
@@ -4,6 +4,5 @@
     window.print(); 
   }
 </script>
-<link rel="stylesheet" type="text/css" media="print" href="bootstrap.min.css"> 
 <a href="javascript:window.close();">Close window</a>
 <%= render partial: 'shared/terms_of_deposit' %>

--- a/app/views/print/terms_of_deposit.html.erb
+++ b/app/views/print/terms_of_deposit.html.erb
@@ -1,6 +1,7 @@
 <script language='javascript'>
   window.onload = function() { 
     document.getElementById("print-link").style.display='none';
+    document.getElementById("save-link").style.display='none';
     window.print(); 
   }
 </script>

--- a/app/views/shared/_terms_of_deposit.html.erb
+++ b/app/views/shared/_terms_of_deposit.html.erb
@@ -2,11 +2,16 @@
   <div class="modal-lg modal-dialog modal-dialog-centered modal-dialog-scrollable">
     <div class="modal-content">
       <div class="row justify-content-between modal-header">
-          <div class="col-9">
+          <div class="col-7">
             <h3 class="modal-title" id="content-type-prompt">Terms of Deposit</h3>
           </div>
           <div class="col-2">
-            <%= link_to print_terms_of_deposit_path, aria: { label: 'Print Terms of Deposit' }, id: 'print-link', class: 'text-decoration-none', target: '_blank' do %>
+            <%= link_to Settings.terms_url, aria: { label: 'Save Terms of Deposit' }, id: 'print-link', class: 'text-decoration-none', target: '_blank' do %>
+              <span class="fa fa-save"></span> Save
+            <% end %>
+          </div>
+          <div class="col-2">
+            <%= link_to print_terms_of_deposit_path, aria: { label: 'Print Terms of Deposit' }, id: 'save-link', class: 'text-decoration-none', target: '_blank' do %>
               <span class="fa fa-print"></span> Print
             <% end %>
           </div>

--- a/app/views/shared/_terms_of_deposit.html.erb
+++ b/app/views/shared/_terms_of_deposit.html.erb
@@ -1,0 +1,42 @@
+<div class="modal" id="termsOfDepositModal" tabindex="-1" aria-labelledby="content-type-prompt" aria-hidden="true">
+  <div class="modal-lg modal-dialog modal-dialog-centered modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="row justify-content-between modal-header">
+          <div class="col-9">
+            <h3 class="modal-title" id="content-type-prompt">Terms of Deposit</h3>
+          </div>
+          <div class="col-2">
+            <%= link_to print_terms_of_deposit_path, aria: { label: 'Print Terms of Deposit' }, id: 'print-link', class: 'text-decoration-none', target: '_blank' do %>
+              <span class="fa fa-print"></span> Print
+            <% end %>
+          </div>
+          <div class="col-1">
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+        </div>
+      <div class="modal-body">
+        <p>
+          In depositing content to the Stanford Digital Repository (SDR), the Depositor grants The Trustees of Leland Stanford Junior University through the Stanford University Libraries (Stanford Libraries) the non-exclusive, worldwide, perpetual, irrevocable right to reproduce, distribute, display and transmit Depositor’s content (the Work), in whole or in part, in such print and electronic formats as may be in existence now or developed in the future, to sub-license others to do the same, and to preserve and protect the Work, subject to any third-party release or display restrictions specified by Depositor. Stanford Libraries may make the content available to users, subject to the applicable Terms of Use<sup>[1]</sup> and to any license applied by Depositor. Terms of Use are subject to change by Stanford Libraries; Stanford Libraries will make a reasonable effort to notify the Depositor when changes occur. More information is available at <a href="https://library.stanford.edu/research/stanford-digital-repository/depositor-services" target="_blank">https://library.stanford.edu/research/stanford-digital-repository/depositor-services</a>.
+        </p>
+        <p>
+          Stanford Libraries is free to reformat, delete or remove access to any or all of the Work in the SDR. If Stanford Libraries determines it is necessary to remove access to or delete permanently a Work, it will make a reasonable effort to notify the Depositor and, provided it would be lawful in Stanford Libraries’ determination to do so, make available a copy of the Work to Depositor (at Depositor’s expense). Depositor grants no other rights under this license, including, without limitation, any copyright interests in the Work.
+        </p>
+        <p>
+          Depositor represents and warrants that Depositor is the copyright holder of the Work, and/or has obtained the unrestricted permission of other copyright owner(s) to grant Stanford Libraries the rights required by this license or any applied license, including necessary licenses relating to any non-public, third-party software necessary to access, display, and run or print the Work. Depositor warrants that any jointly-owned or third-party owned material, such as graphs, images, photos, music, etc., is clearly identified and acknowledged within the content of the Work, and Depositor is solely responsible and will indemnify Stanford Libraries for any third party claims related to the Work as submitted.
+        </p>
+        <p>
+          Depositor further warrants that the Work does not violate any law or agreement or infringe upon anyone's publicity, privacy or confidentiality rights, including but not limited to privacy rights protected by HIPAA or FERPA. Depositor warrants that the Work does not contain any high risk data, including but not limited to  Social Security Numbers, driver’s license numbers or bank account information. (More information is available at available at <a href="https://itservices.stanford.edu/guide/riskclassifications" target="_blank">https://itservices.stanford.edu/guide/riskclassifications</a>).
+        </p>
+        <p>
+          Depositor represents that, depositing to the SDR does not violate an existing publication agreement, Institutional Review Board (IRB), or contract governing deposited content. If the content is original work derived from a source work produced and/or owned by a third-party, Depositor represents compliance with the terms of use associated with that source work.
+        </p>
+        <p>
+          Depositor agrees to indemnify Stanford harmless against any third-party claim based on an allegation that Stanford’s actions under this agreement violate that third party’s copyrights, trademarks, other intellectual property, privacy, publicity or other legal rights.
+        </p>
+        <p>
+          <sup>[1]</sup> <small>Stanford Digital Repository Terms of Use: User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.</small>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -2,11 +2,8 @@
   style="background-image: url(<%= asset_pack_path 'media/images/splash.webp' %>); background-position: center; ">
   <div class="container flex-wrap flex-md-nowrap">
     <div class="row">
-      <div class="col-md-10">
+      <div class="col-md-12">
         <h1 class="me-auto">Digital Repository</h1>
-      </div>
-      <div class="col-md-2">
-        <a href="#terms-of-deposit" class="terms">Terms of deposit</a>
       </div>
     </div
     <p class="fs-4">Long term preservation of scholarly works at Stanford</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
     { controller: 'welcome', action: 'show', anchor: 'help' }
   end
   resource :help, only: :create
+  get 'print_terms_of_deposit', to: 'print#terms_of_deposit'
 
   # @note Only admins should be able to access the Sidekiq web UI.  But this is accomplished by Puppet
   # configuration restricting access using a shib workgroup, so the request doesn't reach the app if the user

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -34,6 +34,7 @@ authorization_workgroup_names:
 file_uploads_root: tmp/uploads
 
 purl_url: https://purl.stanford.edu
+terms_url: https://stanford.app.box.com/s/lozngarhdzj56z44la38v1zn3a1ggbyu
 
 host: <%= Socket.gethostname %>
 

--- a/spec/features/print_spec.rb
+++ b/spec/features/print_spec.rb
@@ -1,0 +1,11 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Print terms of deposit' do
+  it 'renders the terms of deposit' do
+    visit print_terms_of_deposit_path
+    expect(page).to have_content('Terms of Deposit')
+  end
+end

--- a/spec/requests/print_spec.rb
+++ b/spec/requests/print_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 
 RSpec.describe 'Print terms of deposit' do
   it 'renders the terms of deposit' do
-    visit print_terms_of_deposit_path
-    expect(page).to have_content('Terms of Deposit')
+    get print_terms_of_deposit_path
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('Terms of Deposit')
   end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #1020 and prep for #1022:

- update text of terms of deposit as shown in https://docs.google.com/document/d/1fcr2DYo7OrX-qTdeUOTWKSS1rlq_47sehESmbvgUsrk/edit#heading=h.ab2g8b5m7wat
- move text to a shared partial and add to app layout so we can add a link to the top nav
- add print button to top of terms of deposit modal that links to new print page 
- add new page with no layout/css to ensure clean printing of of terms of deposit
- add link to the terms of deposit modal from the top nav of every page
- add save button to top of modal which links to PDF version of terms (after discussion with Amy)

Note: approach approved by Amy

**New link in header:**
![Screen Shot 2021-02-12 at 10 01 53 AM](https://user-images.githubusercontent.com/47137/107804964-84874680-6d19-11eb-813b-6587b33afad8.png)

**New buttons on terms modal:**
![Screen Shot 2021-02-12 at 10 02 01 AM](https://user-images.githubusercontent.com/47137/107804984-8b15be00-6d19-11eb-9913-7c430ada2d41.png)

**Plain print window that opens print dialog by default:**
![Screen Shot 2021-02-12 at 10 02 47 AM](https://user-images.githubusercontent.com/47137/107805007-91a43580-6d19-11eb-8ec4-bf8e4c02c06f.png)

## How was this change tested?

Localhost browser, new request spec

## Which documentation and/or configurations were updated?



