### PR TITLE
Add collapsible "more" work types to work form

### DIFF
--- a/app/components/works/description_component.html.erb
+++ b/app/components/works/description_component.html.erb
@@ -19,30 +19,7 @@
     </div>
   </div>
 
-  <div class="mb-3 row">
-    <div class="col-sm-12 h5">
-      Work types (optional)
-    </div>
-  </div>
-
-  <div class="mb-5 row">
-    <% if other_type? %>
-      <%= form.label :subtype, 'Other', class: 'col-sm-2 col-form-label' %>
-      <div class="col-sm-10">
-        <%= form.text_field :subtype, class: 'form-control', required: true, multiple: true %>
-        <div class="invalid-feedback">You must provide a subtype for works of type 'Other'</div>
-      </div>
-    <% else %>
-      <% subtypes.each do |subtype| %>
-        <div class="col-sm-4">
-          <div class="form-check">
-            <%= form.check_box :subtype, { multiple: true, class: 'form-check-input' }, subtype, nil %>
-            <%= form.label "subtype_#{sanitized_value(subtype)}", subtype, class: 'form-check-label' %>
-          </div>
-        </div>
-      <% end %>
-    <% end %>
-  </div>
+  <%= render Works::SubtypesComponent.new(form: form) %>
 
   <fieldset class="mb-5">
     <legend class='h5'>Citation for this deposit (optional)</legend>

--- a/app/components/works/description_component.rb
+++ b/app/components/works/description_component.rb
@@ -9,22 +9,5 @@ module Works
     end
 
     attr_reader :form
-
-    def subtypes
-      WorkType.subtypes_for(work_type)
-    end
-
-    def work_type
-      form.object.work_type
-    end
-
-    def other_type?
-      work_type == 'other'
-    end
-
-    def sanitized_value(value)
-      # This is how the rails check_box tag with multiple values creates its labels:
-      ActionView::Helpers::Tags::Base.new(nil, nil, nil).send(:sanitized_value, value)
-    end
   end
 end

--- a/app/components/works/subtypes_component.html.erb
+++ b/app/components/works/subtypes_component.html.erb
@@ -1,0 +1,39 @@
+<div class="mb-3 row">
+  <div class="col-sm-12 h5">
+    Work types <%= '(optional)' if !other_type? %>
+  </div>
+</div>
+
+<div class="mb-5 row work-types">
+  <% if other_type? %>
+    <%= form.label :subtype, 'Other', class: 'col-sm-2 col-form-label' %>
+    <div class="col-sm-10">
+      <%= form.text_field :subtype, class: 'form-control', required: true, multiple: true %>
+      <div class="invalid-feedback">You must provide a subtype for works of type 'Other'</div>
+    </div>
+  <% else %>
+    <% subtypes.each do |subtype| %>
+      <div class="col-sm-4">
+        <div class="form-check">
+          <%= form.check_box :subtype, { multiple: true, class: 'form-check-input' }, subtype, nil %>
+          <%= form.label "subtype_#{sanitized_value(subtype)}", subtype, class: 'form-check-label' %>
+        </div>
+      </div>
+    <% end %>
+
+    <a href="#" class="mt-4 more-options collapsed" data-action="edit-deposit#toggleMoreTypes" data-edit-deposit-target="moreTypesLink">
+      See more options
+    </a>
+
+    <div class="row" data-edit-deposit-target="moreTypes" hidden>
+      <% more_types.each do |more_type| %>
+        <div class="col-sm-4">
+          <div class="form-check">
+            <%= form.check_box :subtype, { multiple: true, class: 'form-check-input' }, more_type, nil %>
+            <%= form.label "subtype_#{sanitized_value(more_type)}", more_type, class: 'form-check-label' %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/components/works/subtypes_component.rb
+++ b/app/components/works/subtypes_component.rb
@@ -1,0 +1,34 @@
+# typed: false
+# frozen_string_literal: true
+
+module Works
+  # Allows the user to specify work subtypes
+  class SubtypesComponent < ApplicationComponent
+    def initialize(form:)
+      @form = form
+    end
+
+    attr_reader :form
+
+    def work_type
+      form.object.work_type
+    end
+
+    def other_type?
+      work_type == 'other'
+    end
+
+    def subtypes
+      WorkType.subtypes_for(work_type)
+    end
+
+    def more_types
+      WorkType.more_types - subtypes
+    end
+
+    def sanitized_value(value)
+      # This is how the rails check_box tag with multiple values creates its labels:
+      ActionView::Helpers::Tags::Base.new(nil, nil, nil).send(:sanitized_value, value)
+    end
+  end
+end

--- a/app/components/works/work_type_modal_component.html.erb
+++ b/app/components/works/work_type_modal_component.html.erb
@@ -3,7 +3,7 @@
   document.moreTypes = <%= WorkType.more_types.to_json.html_safe %>
 </script>
 
-<div class="modal fade" id="workTypeModal" tabindex="-1" aria-labelledby="content-type-prompt" aria-hidden="true">
+<div class="modal fade work-types" id="workTypeModal" tabindex="-1" aria-labelledby="content-type-prompt" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg">
     <div class="modal-content">
       <div class="modal-header">

--- a/app/javascript/controllers/edit_deposit_controller.js
+++ b/app/javascript/controllers/edit_deposit_controller.js
@@ -3,8 +3,11 @@ import { Controller } from "stimulus";
 export default class extends Controller {
   static targets = ["title", "titleField",
                     "file", "fileField",
-                    "keywordsField", "contributorsField",
-                    "embargo-dateField", "terms", "termsField"];
+                    "keywordsField",
+                    "contributorsField",
+                    "embargo-dateField",
+                    "terms", "termsField",
+                    "moreTypesLink", "moreTypes"];
 
   connect() {
     // TODO see what of the things are already valid
@@ -28,5 +31,25 @@ export default class extends Controller {
       isComplete = document.querySelector('#work_agree_to_terms').checked
     }
     step.classList.toggle('active', isComplete)
+  }
+
+  toggleMoreTypes(event) {
+    event.preventDefault()
+
+    this.moreTypesTarget.hidden ?
+      this.showMoreTypes() :
+      this.hideMoreTypes()
+  }
+
+  showMoreTypes() {
+    this.moreTypesTarget.hidden = false
+    this.moreTypesLinkTarget.innerHTML = 'See fewer options'
+    this.moreTypesLinkTarget.classList.toggle('collapsed', false)
+  }
+
+  hideMoreTypes() {
+    this.moreTypesTarget.hidden = true
+    this.moreTypesLinkTarget.innerHTML = 'See more options'
+    this.moreTypesLinkTarget.classList.toggle('collapsed', true)
   }
 }

--- a/app/javascript/stylesheets/dashboard.scss
+++ b/app/javascript/stylesheets/dashboard.scss
@@ -55,7 +55,7 @@ ul.collections {
   list-style-type: none;
 }
 
-#workTypeModal {
+.work-types {
   a {
     text-decoration: none;
 

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -131,8 +131,7 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
         expect(page).to have_link(Collection.last.name)
         expect(page).to have_content(user.email)
         expect(page).to have_content('sound')
-        # expect(page).to have_content('Oral history, Podcast, Poetry reading')
-        expect(page).to have_content('Oral history, Podcast') # TODO: replace with prior line as part of #972
+        expect(page).to have_content('Oral history, Podcast, Poetry reading')
         expect(page).to have_content('Best Publisher')
         expect(page).to have_content('2020-03-06/2020-10-30')
         expect(page).to have_content 'User provided abstract'


### PR DESCRIPTION
Fixes #972

## Why was this change made?

To allow "more" types to be edited.

### "Other" work type

The link does not appear and the work types header is not marked as optional:

![other_work_type_not_optional](https://user-images.githubusercontent.com/131982/107590138-4b858f80-6bbc-11eb-926e-366177eea14f.png)

### Non-"Other" work type, collapsed

The link appears, the "more" types are collapsed, and the header is marked as optional:

![optional_collapsed](https://user-images.githubusercontent.com/131982/107590053-1ed17800-6bbc-11eb-85bd-05496eaa9630.png)

### Non-"Other" work type, expanded

The link appears, the "more" types are expanded, and the header is marked as optional:

![work_type_expanded](https://user-images.githubusercontent.com/131982/107590179-62c47d00-6bbc-11eb-8c32-a2bfb3d4f26f.png)

## How was this change tested?

CI and local browser


## Which documentation and/or configurations were updated?

None
