### PR TITLE
bottom margin belongs on button, not entire row

### DIFF
--- a/app/components/dashboard/in_progress_collection_row_component.html.erb
+++ b/app/components/dashboard/in_progress_collection_row_component.html.erb
@@ -1,9 +1,9 @@
-<div class="mb-2" class="row">
+<div class="row">
   <div class="col-4">
     <%= show_collection_link %>
   </div>
   <div class="col-3">
-    <%= link_to 'Complete draft', edit_collection_path(collection), class: "btn btn-primary" %>
+    <%= link_to 'Complete draft', edit_collection_path(collection), class: "mb-2 btn btn-primary" %>
   </div>
   <div class="col-5">
     <%= helpers.turbo_frame_tag dom_id(collection, :delete), src: delete_button_collection_path(collection) if collection.first_draft?%>


### PR DESCRIPTION
## Why was this change made?

Fix styling of collections in new progress panel for collection managers.

Before:

![Screen Shot 2021-02-11 at 10 12 23 AM](https://user-images.githubusercontent.com/47137/107679698-b92fcb00-6c51-11eb-8c0b-503c79362c3a.png)

After:

![Screen Shot 2021-02-11 at 10 12 12 AM](https://user-images.githubusercontent.com/47137/107679709-bf25ac00-6c51-11eb-8e75-442aec243249.png)


## How was this change tested?

Localhost browser


## Which documentation and/or configurations were updated?



