### PR TITLE
Add new work type for Music-type works

### DIFF
--- a/app/components/works/subtypes_component.html.erb
+++ b/app/components/works/subtypes_component.html.erb
@@ -1,6 +1,6 @@
 <div class="mb-3 row">
   <div class="col-sm-12 h5">
-    Work types <%= '(optional)' if !other_type? %>
+    Work types <%= '(optional)' if optional? %>
   </div>
 </div>
 
@@ -12,6 +12,9 @@
       <div class="invalid-feedback">You must provide a subtype for works of type 'Other'</div>
     </div>
   <% else %>
+    <% if music_type? %>
+      <h6>Select at least one term below:</h6>
+    <% end %>
     <% subtypes.each do |subtype| %>
       <div class="col-sm-4">
         <div class="form-check">

--- a/app/components/works/subtypes_component.rb
+++ b/app/components/works/subtypes_component.rb
@@ -18,6 +18,14 @@ module Works
       work_type == 'other'
     end
 
+    def music_type?
+      work_type == 'music'
+    end
+
+    def optional?
+      !work_type.in?(%w[other music])
+    end
+
     def subtypes
       WorkType.subtypes_for(work_type)
     end

--- a/app/components/works/work_type_modal_component.html.erb
+++ b/app/components/works/work_type_modal_component.html.erb
@@ -36,6 +36,10 @@
             </div>
           </template>
 
+          <template data-work-type-target="musicTemplateSubheader">
+            <h6>Select at least one term below:</h6>
+          </template>
+
           <template data-work-type-target="otherTemplateHeader">
             <h5>Specify "Other" type</h5>
           </template>

--- a/app/javascript/controllers/work_type_controller.js
+++ b/app/javascript/controllers/work_type_controller.js
@@ -3,7 +3,8 @@ import { Controller } from "stimulus"
 export default class extends Controller {
   static targets = [
     "form", "template", "otherTemplate", "subtype", "area", "templateHeader",
-    "otherTemplateHeader", "moreTypesLink", "moreTypes", "continueButton"
+    "otherTemplateHeader", "moreTypesLink", "moreTypes", "continueButton",
+    "musicTemplateSubheader"
   ]
 
   // Sets the form in the popup to use the action in the data-destination attribute
@@ -51,6 +52,7 @@ export default class extends Controller {
     this.subtypeTarget.innerHTML = this.subtypesFor(type).join('')
     this.moreTypesTarget.innerHTML = this.moreTypesFor(type).join('')
     this.areaTarget.innerHTML = this.templateHeaderTarget.innerHTML
+    if (type == 'music') this.areaTarget.innerHTML += this.musicTemplateSubheaderTarget.innerHTML
   }
 
   displayOtherSubtypeOptions() {

--- a/app/javascript/stylesheets/dashboard.scss
+++ b/app/javascript/stylesheets/dashboard.scss
@@ -27,46 +27,10 @@
     }
   }
 
-  input[type="radio"].toggle + label {
-    font-size: smaller;
-    line-height: 1;
-    padding: 0.375rem 0.375rem;
-  }
-
-  .work-type-box {
-    @extend .col-md-3;
-    @extend .mb-5;
-
-    height: 2rem;
-  }
-
-  .work-type-button-text {
-    display: inline-block;
-    max-width: 60%;
-    padding-left: 1rem;
-    vertical-align: middle;
-  }
-
   margin-top: 1rem;
   max-width: 1140px;
 }
 
 ul.collections {
   list-style-type: none;
-}
-
-.work-types {
-  a {
-    text-decoration: none;
-
-    &:after {
-      content: '\f078';
-      font-family: Fontawesome;
-      padding-left: 0.5rem;
-    }
-
-    &.collapsed:after {
-      content: '\f054';
-    }
-  }
 }

--- a/app/javascript/stylesheets/main.scss
+++ b/app/javascript/stylesheets/main.scss
@@ -12,6 +12,7 @@
 @import 'collectionEditor';
 @import 'work';
 @import 'workEditor';
+@import 'workTypes';
 @import 'depositProgress';
 @import "dropzone";
 @import "keywords";

--- a/app/javascript/stylesheets/workTypes.scss
+++ b/app/javascript/stylesheets/workTypes.scss
@@ -1,0 +1,41 @@
+.work-types {
+  a {
+    text-decoration: none;
+
+    &:after {
+      content: '\f078';
+      font-family: Fontawesome;
+      padding-left: 0.5rem;
+    }
+
+    &.collapsed:after {
+      content: '\f054';
+    }
+  }
+
+  h6 {
+    color: $stanford-digital-red;
+    font-weight: bold;
+  }
+
+  input[type="radio"].toggle + label {
+    font-size: smaller;
+    line-height: 1;
+    padding: 0.375rem 0.375rem;
+  }
+}
+
+.work-type-box {
+  @extend .col-md-3;
+  @extend .mb-5;
+  @extend .mx-4;
+
+  height: 2rem;
+}
+
+.work-type-button-text {
+  display: inline-block;
+  max-width: 60%;
+  padding-left: 1rem;
+  vertical-align: middle;
+}

--- a/app/models/work_type.rb
+++ b/app/models/work_type.rb
@@ -29,6 +29,19 @@ class WorkType
 
   IMAGE_TYPES = ['CAD', 'Map', 'Photograph', 'Poster', 'Presentation slides'].freeze
 
+  MUSIC_TYPES = [
+    'Data',
+    'Image',
+    'MIDI',
+    'Musical transcription',
+    'Notated music',
+    'Piano roll',
+    'Software/Code',
+    'Sound',
+    'Text',
+    'Video'
+  ].freeze
+
   # These types appear below the fold and may be expanded
   MORE_TYPES = [
     '3D model', 'Animation', 'Article', 'Book', 'Book chapter', 'Broadcast', 'CAD',
@@ -76,8 +89,9 @@ class WorkType
     all.find { |work| work.id == id } || raise(InvalidType, "Unknown worktype #{id}")
   end
 
-  # id is a value acceptable for MODS typeOfResource
+  # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/MethodLength
+  # id is a value acceptable for MODS typeOfResource
   sig { returns(T::Array[WorkType]) }
   def self.all
     [
@@ -93,6 +107,8 @@ class WorkType
           cocina_type: Cocina::Models::Vocab.media),
       new(id: 'video', label: 'Video', icon: 'film', subtypes: VIDEO_TYPES,
           cocina_type: Cocina::Models::Vocab.media),
+      new(id: 'music', label: 'Music', icon: 'music', subtypes: MUSIC_TYPES,
+          cocina_type: Cocina::Models::Vocab.object),
       new(id: 'mixed material', label: 'Mixed Materials', icon: 'play', subtypes: MIXED_TYPES,
           cocina_type: Cocina::Models::Vocab.object),
       new(id: 'other', label: 'Other', icon: 'archive', subtypes: [],
@@ -100,6 +116,7 @@ class WorkType
     ]
   end
   # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
 
   sig { returns(T::Array[String]) }
   def self.type_list

--- a/app/validators/work_subtype_validator.rb
+++ b/app/validators/work_subtype_validator.rb
@@ -9,12 +9,19 @@ class WorkSubtypeValidator < ActiveModel::EachValidator
     record.errors.add attribute, "is not a valid subtype for work type #{record.work_type}"
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   # Public class method so that it can be called from a controller. We want to
   # validate these on the incoming works/new request before there is a model
   # instance to validate.
   def self.valid?(work_type, value)
-    # A subtype is required for the "other" work type
+    # A subtype is required for the "other" work type and the value must merely be present
     return Array(value).first.present? if work_type == 'other'
+
+    # A subtype is required for the "music" work type and at least one must come from a defined list
+    if work_type == 'music'
+      return value.present? &&
+             value.any? { |subtype| subtype.in?(WorkType.subtypes_for(work_type)) }
+    end
 
     return true if value.nil?
 
@@ -22,4 +29,5 @@ class WorkSubtypeValidator < ActiveModel::EachValidator
   rescue WorkType::InvalidType
     false
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/config/mappings/types_to_genres.yml
+++ b/config/mappings/types_to_genres.yml
@@ -215,6 +215,76 @@ Video:
         uri: http://id.loc.gov/authorities/genreForms/gf2011026276
         source:
           code: lcgft
+Music:
+  type:
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  subtypes:
+    Data:
+      - type: genre
+        value: dataset
+      - type: genre
+        value: Data sets
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+    Image:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    MIDI:
+      - type: genre
+        value: MIDI (information technology)
+        uri: http://vocab.getty.edu/aat/300266746
+        source:
+          code: aat
+    Musical transcription:
+      - type: genre
+        value: transcriptions (documents)
+        uri: http://vocab.getty.edu/aat/300404333
+        source:
+          code: aat
+    Notated music:
+      - type: genre
+        value: Notated music
+        uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+        source:
+          code: lcgft
+    Piano roll:
+      - type: genre
+        value: music rolls
+        uri: http://vocab.getty.edu/aat/300429369
+        source:
+          code: aat
+    Software/Code:
+      - type: genre
+        value: software
+        uri: http://vocab.getty.edu/aat/300028566
+        source:
+          code: aat
+    Sound:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Text:
+      - type: genre
+        value: texts (documents)
+        uri: http://vocab.getty.edu/aat/300263751
+        source:
+          code: aat
+    Video:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
 Mixed Materials:
   subtypes:
     Data:

--- a/config/mappings/types_to_resource_types.yml
+++ b/config/mappings/types_to_resource_types.yml
@@ -204,6 +204,63 @@ Video:
         value: moving image
         source:
           value: MODS resource types
+Music:
+  type:
+    type: resource type
+    value: music
+    source:
+      value: MODS resource types
+  subtypes:
+    Data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Image:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    MIDI:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Musical transcription:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+    Notated music:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+    Piano roll:
+      - type: resource type
+        value: sound recording-musical
+        source:
+          value: MODS resource types
+    Software/Code:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Sound:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Text:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Video:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
 Mixed Materials:
   type:
     type: resource type

--- a/spec/components/works/subtypes_component_spec.rb
+++ b/spec/components/works/subtypes_component_spec.rb
@@ -1,0 +1,39 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Works::SubtypesComponent do
+  let(:form) { ActionView::Helpers::FormBuilder.new('work', work_form, controller.view_context, {}) }
+  let(:work) { build_stubbed(:work) }
+  let(:work_form) { WorkForm.new(work) }
+  let(:rendered) { render_inline(described_class.new(form: form)) }
+
+  context 'when work type is "other"' do
+    let(:work) { build_stubbed(:work, work_type: 'other', subtype: ['femur']) }
+
+    it 'does not label subtypes as optional' do
+      expect(rendered.to_html).to include('Work types')
+      expect(rendered.to_html).not_to include('optional')
+    end
+  end
+
+  context 'when work type is "music"' do
+    let(:work) { build_stubbed(:work, work_type: 'music', subtype: ['Data']) }
+
+    it 'does not label subtypes as optional' do
+      expect(rendered.to_html).to include('Work types')
+      expect(rendered.to_html).not_to include('optional')
+    end
+
+    it 'renders a header about selecting one term' do
+      expect(rendered.to_html).to include('Select at least one term below')
+    end
+  end
+
+  context 'when work type is anything else' do
+    it 'labels subtypes as optional' do
+      expect(rendered.to_html).to include('Work types (optional)')
+    end
+  end
+end

--- a/spec/features/edit_draft_work_spec.rb
+++ b/spec/features/edit_draft_work_spec.rb
@@ -87,10 +87,11 @@ RSpec.describe 'Edit a draft work', js: true do
     expect(page).to have_current_path(edit_work_path(work))
   end
 
-  context 'when successful deposit of non-"other" type work' do
+  context 'when successful deposit of "music" type work' do
     let(:work) do
       create(:valid_work, title: 'My Preprint/Data',
                           depositor: depositor,
+                          work_type: 'music',
                           subtype: %w[Data Preprint])
     end
 
@@ -102,17 +103,18 @@ RSpec.describe 'Edit a draft work', js: true do
       end
 
       expect(page).to have_content work.title
-      expect(page).to have_content('Work types (optional)')
-      expect(find('#work_subtype_data', visible: :all)).not_to be_visible
-      expect(find('#work_subtype_preprint')).to be_visible
-      expect(find('#work_subtype_preprint')).to be_checked
-      click_link 'See more options'
+      expect(page).to have_content('Work types')
+      expect(page).to have_content('Select at least one term below')
+      expect(find('#work_subtype_preprint', visible: :all)).not_to be_visible
       expect(find('#work_subtype_data')).to be_visible
       expect(find('#work_subtype_data')).to be_checked
-      uncheck 'Data'
-      check 'Database'
+      click_link 'See more options'
+      expect(find('#work_subtype_preprint')).to be_visible
+      expect(find('#work_subtype_preprint')).to be_checked
+      uncheck 'Preprint'
+      check 'Technical report'
       click_link 'See fewer options'
-      expect(find('#work_subtype_data', visible: :all)).not_to be_visible
+      expect(find('#work_subtype_preprint', visible: :all)).not_to be_visible
 
       # TODO: we should be able to remove this once accepting is persisted.
       # See https://github.com/sul-dlss/happy-heron/issues/243
@@ -121,7 +123,7 @@ RSpec.describe 'Edit a draft work', js: true do
       click_button 'Deposit'
 
       expect(page).to have_content('My Preprint/Data')
-      expect(page).to have_content('Preprint, Database')
+      expect(page).to have_content('Data, Technical report')
     end
   end
 end

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -80,6 +80,26 @@ RSpec.describe 'Create a new work' do
         end
       end
 
+      context 'with a valid work_type and a missing required subtype' do
+        it 'redirects to dashboard with an informative flash message' do
+          get "/collections/#{collection.id}/works/new?work_type=music"
+          expect(response).to redirect_to(dashboard_path)
+          follow_redirect!
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include 'Invalid subtype value for work_type &#39;music&#39;: missing'
+        end
+      end
+
+      context 'with a valid work_type and an invalid required subtype' do
+        it 'redirects to dashboard with an informative flash message' do
+          get "/collections/#{collection.id}/works/new?work_type=music&subtype%5B%5D=Preprint"
+          expect(response).to redirect_to(dashboard_path)
+          follow_redirect!
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include 'Invalid subtype value for work_type &#39;music&#39;: Preprint'
+        end
+      end
+
       context 'with a work_type that is missing a required user-supplied subtype' do
         it 'redirects to dashboard with an informative flash message' do
           get "/collections/#{collection.id}/works/new?work_type=other"


### PR DESCRIPTION
Fixes #715

## Why was this change made?

This commit adds a new music work type, which is unique in that it requires one or more primary subtypes to be selected.

Includes:

* Extract work type-related styles into a dedicated file to fix a bug with the display of the work type modal when clicked from collection show page
* Pad work type boxes in modal to render three per row instead of four
* Make work type stimulus controller able to render a subheader for music-type works
* Change subtype validator so it can enforce music-type works' unique constraint (see above)
* Add genre and resource type mappings for music-type works

### Screenshot: Music modal

![music_modal](https://user-images.githubusercontent.com/131982/107707699-23a73200-6c77-11eb-8347-e83e98a4c2a3.png)

### Screenshot: Music work form

![music_work_form](https://user-images.githubusercontent.com/131982/107707727-2efa5d80-6c77-11eb-98cd-1a02ab5f678f.png)


## How was this change tested?

CI + local

## Which documentation and/or configurations were updated?

None

