### PR TITLE
Update email text for invitation to deposit

### DIFF
--- a/app/views/collections_mailer/invitation_to_deposit_email.html.erb
+++ b/app/views/collections_mailer/invitation_to_deposit_email.html.erb
@@ -3,6 +3,12 @@
 <p>You have been invited to deposit to the <%= @collection.name %> collection in the Stanford Digital Repository.
   Start your deposit at <%= link_to collection_url(@collection), collection_url(@collection, anchor: 'deposits') %>.</p>
 
+<p>SDR deposits can be discovered in the Stanford library catalog and can be accessed by others at a persistent link (PURL). <a href="https://purl.stanford.edu/wd068fv8349">Example of a PURL.</a>
+
+<p>In some cases a deposit requires review and approval before the PURL is available. <a href="https://library.stanford.edu/research/stanford-digital-repository/faqs/sdr-submission-workflows">Read about the approval process.</a>
+
+<p>Before you complete your deposit, you will need to accept the <%= link_to Settings.terms_url, "Terms of Deposit" %>.
+
 <p>If you have any questions, contact the SDR team at: <%= link_to contact_form_url, contact_form_url %></p>
 
 <p>The Stanford Digital Repository Team</p>


### PR DESCRIPTION
## Why was this change made?

Fixes #1053 - update email text for deposit notification email

Note: Hold until #1052 is merged, since it uses a setting for showing the terms of deposit in Box

## How was this change tested?



## Which documentation and/or configurations were updated?



