### PR TITLE
Introduce subtype requirements for mixed material-type works

### DIFF
--- a/app/components/works/subtypes_component.html.erb
+++ b/app/components/works/subtypes_component.html.erb
@@ -14,7 +14,10 @@
   <% else %>
     <% if music_type? %>
       <h6>Select at least one term below:</h6>
+    <% elsif mixed_material_type? %>
+      <h6>Select at least two terms below:</h6>
     <% end %>
+
     <% subtypes.each do |subtype| %>
       <div class="col-sm-4">
         <div class="form-check">

--- a/app/components/works/subtypes_component.rb
+++ b/app/components/works/subtypes_component.rb
@@ -22,8 +22,12 @@ module Works
       work_type == 'music'
     end
 
+    def mixed_material_type?
+      work_type == 'mixed material'
+    end
+
     def optional?
-      !work_type.in?(%w[other music])
+      !work_type.in?(['mixed material', 'music', 'other'])
     end
 
     def subtypes

--- a/app/components/works/work_type_modal_component.html.erb
+++ b/app/components/works/work_type_modal_component.html.erb
@@ -40,6 +40,10 @@
             <h6>Select at least one term below:</h6>
           </template>
 
+          <template data-work-type-target="mixedMaterialTemplateSubheader">
+            <h6>Select at least two terms below:</h6>
+          </template>
+
           <template data-work-type-target="otherTemplateHeader">
             <h5>Specify "Other" type</h5>
           </template>

--- a/app/javascript/controllers/work_type_controller.js
+++ b/app/javascript/controllers/work_type_controller.js
@@ -4,7 +4,7 @@ export default class extends Controller {
   static targets = [
     "form", "template", "otherTemplate", "subtype", "area", "templateHeader",
     "otherTemplateHeader", "moreTypesLink", "moreTypes", "continueButton",
-    "musicTemplateSubheader"
+    "musicTemplateSubheader", "mixedMaterialTemplateSubheader"
   ]
 
   // Sets the form in the popup to use the action in the data-destination attribute
@@ -52,7 +52,14 @@ export default class extends Controller {
     this.subtypeTarget.innerHTML = this.subtypesFor(type).join('')
     this.moreTypesTarget.innerHTML = this.moreTypesFor(type).join('')
     this.areaTarget.innerHTML = this.templateHeaderTarget.innerHTML
-    if (type == 'music') this.areaTarget.innerHTML += this.musicTemplateSubheaderTarget.innerHTML
+    switch(type) {
+      case 'music':
+        this.areaTarget.innerHTML += this.musicTemplateSubheaderTarget.innerHTML
+        break
+      case 'mixed material':
+        this.areaTarget.innerHTML += this.mixedMaterialTemplateSubheaderTarget.innerHTML
+        break
+    }
   }
 
   displayOtherSubtypeOptions() {

--- a/app/models/work_type.rb
+++ b/app/models/work_type.rb
@@ -7,6 +7,9 @@ class WorkType
 
   class InvalidType < StandardError; end
 
+  MINIMUM_REQUIRED_MUSIC_SUBTYPES = 1
+  MINIMUM_REQUIRED_MIXED_MATERIAL_SUBTYPES = 2
+
   DATA_TYPES = [
     '3D model', 'Database', 'Documentation', 'Geospatial data', 'Image',
     'Tabular data', 'Text corpus'

--- a/spec/components/works/subtypes_component_spec.rb
+++ b/spec/components/works/subtypes_component_spec.rb
@@ -26,8 +26,21 @@ RSpec.describe Works::SubtypesComponent do
       expect(rendered.to_html).not_to include('optional')
     end
 
-    it 'renders a header about selecting one term' do
+    it 'renders a header about selecting one or more terms' do
       expect(rendered.to_html).to include('Select at least one term below')
+    end
+  end
+
+  context 'when work type is "mixed material"' do
+    let(:work) { build_stubbed(:work, work_type: 'mixed material', subtype: %w[Data Sound]) }
+
+    it 'does not label subtypes as optional' do
+      expect(rendered.to_html).to include('Work types')
+      expect(rendered.to_html).not_to include('optional')
+    end
+
+    it 'renders a header about selecting two or more terms' do
+      expect(rendered.to_html).to include('Select at least two terms below')
     end
   end
 

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -100,6 +100,25 @@ RSpec.describe 'Create a new work' do
         end
       end
 
+      context 'with a valid work_type and not enough valid required subtypes' do
+        it 'redirects to dashboard with an informative flash message' do
+          get "/collections/#{collection.id}/works/new?work_type=mixed+material&subtype%5B%5D=Data"
+          expect(response).to redirect_to(dashboard_path)
+          follow_redirect!
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include 'Invalid subtype value for work_type &#39;mixed material&#39;: Data'
+        end
+      end
+
+      context 'with a valid work_type and enough valid required subtypes' do
+        it 'renders the form' do
+          get "/collections/#{collection.id}/works/new?work_type=mixed+material&subtype%5B%5D=Data&subtype%5B%5D=Text"
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include 'Data'
+          expect(response.body).to include 'Text'
+        end
+      end
+
       context 'with a work_type that is missing a required user-supplied subtype' do
         it 'redirects to dashboard with an informative flash message' do
           get "/collections/#{collection.id}/works/new?work_type=other"


### PR DESCRIPTION
Fixes #609

## Why was this change made?

This commit adds the desired behavior to the existing mixed material work type, which is unique in that it requires two or more primary subtypes to be selected.

Includes:

* Make work type stimulus controller able to render a subheader for mixed material-type works
* Change subtype validator so it can enforce mixed material-type works' unique constraint (see above)

### Screenshot: Work form 

![form](https://user-images.githubusercontent.com/131982/107718223-4bec5c00-6c8a-11eb-98e1-b2ffe7b86934.png)

### Screenshot: Work type modal

![modal](https://user-images.githubusercontent.com/131982/107718224-4c84f280-6c8a-11eb-8af3-99ffed2f7c23.png)

## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None

