### PR TITLE
Apply bootstrap classes to approximate checks

### DIFF
--- a/app/components/works/dates_component.html.erb
+++ b/app/components/works/dates_component.html.erb
@@ -31,7 +31,7 @@
         <%= select_day created_day, { prefix: 'work', field_name: 'created(3i)', prompt: 'day'}, data: { date_validation_target: 'day', action: 'date-validation#change' }, id: 'work_created_day', class: "form-control" %>
       </div>
        <div>
-       <%= check_box_tag 'work[created(approx0)]', true, created_approximate? %>
+       <%= check_box_tag 'work[created(approx0)]', true, created_approximate?, class: 'form-check-input' %>
        <%= form.label 'created(approx0)', 'Approximate' %>
       </div>
     </div>
@@ -71,7 +71,7 @@
               class: "form-control" %>
         </div>
         <div>
-         <%= check_box_tag 'work[created_range(approx0)]', true, created_range_start_approximate? %>
+         <%= check_box_tag 'work[created_range(approx0)]', true, created_range_start_approximate?, class: 'form-check-input' %>
          <label for='work_created_range_start_approx'>Approximate</label>
         </div>
       </div>
@@ -104,7 +104,7 @@
               id: 'work_created_range_end_day', class: "form-control" %>
         </div>
         <div>
-         <%= check_box_tag 'work[created_range(approx3)]', true, created_range_end_approximate? %>
+         <%= check_box_tag 'work[created_range(approx3)]', true, created_range_end_approximate?, class: 'form-check-input' %>
          <label for='work_created_range_end_approx'>Approximate</label>
         </div>
       </div>


### PR DESCRIPTION
## Why was this change made?



## How was this change tested?
Before
<img width="998" alt="Screen Shot 2021-02-12 at 1 26 03 PM" src="https://user-images.githubusercontent.com/92044/107813466-11d89400-6d36-11eb-829e-3cfb3b4210da.png">


After
<img width="990" alt="Screen Shot 2021-02-12 at 1 26 30 PM" src="https://user-images.githubusercontent.com/92044/107813453-0c7b4980-6d36-11eb-98a3-034148259dfa.png">


## Which documentation and/or configurations were updated?



