### PR TITLE
Allow works to have a small number of legacy licenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,6 +61,9 @@ RSpec/ScatteredSetup:
 
 #### Turning on New Rules
 
+Gemspec/DateAssignment: # (new in 1.10)
+  Enabled: true
+
 Layout/BeginEndAlignment: # (new in 0.91)
   Enabled: true
 Layout/EmptyLinesAroundAttributeAccessor: # (new in 0.83)
@@ -245,6 +248,8 @@ Style/ExponentialNotation: # (new in 0.82)
 Style/GlobalStdStream: # (new in 0.89)
   Enabled: true
 Style/HashAsLastArrayItem: # (new in 0.88)
+  Enabled: true
+Style/HashConversion: # (new in 1.10)
   Enabled: true
 Style/HashEachMethods: # (new in 0.80)
   Enabled: true

--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -62,7 +62,7 @@ module Works
 
     sig { returns(String) }
     def license
-      License::ID_LABEL_HASH[work.license]
+      License.label_for(work.license)
     end
 
     sig { returns(String) }

--- a/app/components/works/license_component.html.erb
+++ b/app/components/works/license_component.html.erb
@@ -5,7 +5,7 @@
       <%= form.label :license, class: 'col-sm-2 col-form-label' %>
       <div class="col-sm-5">
         <%= form.select :license,
-                        grouped_options_for_select(License.grouped_options, license),
+                        grouped_options_for_select(License.grouped_options(license), license),
                         {}, class: "form-select" %>
       </div>
       <div class="col-sm-5">

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -18,7 +18,7 @@ class Work < ApplicationRecord
   has_many :events, as: :eventable, dependent: :destroy
 
   validates :state, presence: true
-  validates :license, presence: true, inclusion: { in: License.license_list }
+  validates :license, inclusion: { in: License.license_list(include_displayable: true) }, allow_nil: true
   validates :subtype, work_subtype: true
   validates :work_type, presence: true, work_type: true
 

--- a/spec/models/license_spec.rb
+++ b/spec/models/license_spec.rb
@@ -5,91 +5,154 @@ require 'rails_helper'
 
 RSpec.describe License do
   describe '.license_list' do
-    subject(:license_list) { described_class.license_list }
+    context 'without args' do
+      subject(:license_list) { described_class.license_list }
 
-    it 'returns array of valid license strings' do
-      expect(license_list).to eq [
-        'CC0-1.0',
-        'CC-BY-4.0',
-        'CC-BY-SA-4.0',
-        'CC-BY-ND-4.0',
-        'CC-BY-NC-4.0',
-        'CC-BY-NC-SA-4.0',
-        'CC-BY-NC-ND-4.0',
-        'PDDL-1.0',
-        'ODC-By-1.0',
-        'ODbL-1.0',
-        'CC-PDDC',
-        'AGPL-3.0-only',
-        'Apache-2.0',
-        'BSD-2-Clause',
-        'BSD-3-Clause',
-        'CDDL-1.1',
-        'EPL-2.0',
-        'GPL-3.0-only',
-        'ISC',
-        'LGPL-3.0-only',
-        'MIT',
-        'MPL-2.0',
-        'none'
-      ]
+      it 'returns array of valid license strings' do
+        expect(license_list).to eq [
+          'CC0-1.0',
+          'CC-BY-4.0',
+          'CC-BY-SA-4.0',
+          'CC-BY-ND-4.0',
+          'CC-BY-NC-4.0',
+          'CC-BY-NC-SA-4.0',
+          'CC-BY-NC-ND-4.0',
+          'PDDL-1.0',
+          'ODC-By-1.0',
+          'ODbL-1.0',
+          'CC-PDDC',
+          'AGPL-3.0-only',
+          'Apache-2.0',
+          'BSD-2-Clause',
+          'BSD-3-Clause',
+          'CDDL-1.1',
+          'EPL-2.0',
+          'GPL-3.0-only',
+          'ISC',
+          'LGPL-3.0-only',
+          'MIT',
+          'MPL-2.0',
+          'none'
+        ]
+      end
+    end
+
+    context 'with include_displayable arg' do
+      subject(:license_list) { described_class.license_list(include_displayable: true) }
+
+      it 'returns array of valid license strings' do
+        expect(license_list).to eq [
+          'CC0-1.0',
+          'CC-BY-4.0',
+          'CC-BY-SA-4.0',
+          'CC-BY-ND-4.0',
+          'CC-BY-NC-4.0',
+          'CC-BY-NC-SA-4.0',
+          'CC-BY-NC-ND-4.0',
+          'PDDL-1.0',
+          'ODC-By-1.0',
+          'ODbL-1.0',
+          'CC-PDDC',
+          'AGPL-3.0-only',
+          'Apache-2.0',
+          'BSD-2-Clause',
+          'BSD-3-Clause',
+          'CDDL-1.1',
+          'EPL-2.0',
+          'GPL-3.0-only',
+          'ISC',
+          'LGPL-3.0-only',
+          'MIT',
+          'MPL-2.0',
+          'none',
+          'CC-BY-3.0',
+          'CC-BY-SA-3.0',
+          'CC-BY-ND-3.0',
+          'CC-BY-NC-3.0',
+          'CC-BY-NC-SA-3.0',
+          'CC-BY-NC-ND-3.0'
+        ]
+      end
     end
   end
 
   describe '.grouped_options' do
-    subject(:grouped_options) { described_class.grouped_options }
+    subject(:grouped_options) { described_class.grouped_options(license) }
 
-    it 'makes groups with headings' do
-      expect(grouped_options).to eq [
-        [
-          'Creative Commons',
+    context 'without a license' do
+      let(:license) { nil }
+
+      it 'makes groups with headings' do
+        expect(grouped_options).to eq [
           [
-            ['CC0-1.0', 'CC0-1.0'],
-            ['CC-BY-4.0 Attribution International', 'CC-BY-4.0'],
-            ['CC-BY-SA-4.0 Attribution-Share Alike International', 'CC-BY-SA-4.0'],
-            ['CC-BY-ND-4.0 Attribution-No Derivatives International', 'CC-BY-ND-4.0'],
-            ['CC-BY-NC-4.0 Attribution-NonCommercial International', 'CC-BY-NC-4.0'],
-            ['CC-BY-NC-SA-4.0 Attribution-NonCommercial-Share Alike International', 'CC-BY-NC-SA-4.0'],
-            ['CC-BY-NC-ND-4.0 Attribution-NonCommercial-No Derivatives', 'CC-BY-NC-ND-4.0']
-          ]
-        ],
-        [
-          'CC-PDDC Public Domain Dedication and Certification',
+            'Creative Commons',
+            [
+              ['CC0-1.0', 'CC0-1.0'],
+              ['CC-BY-4.0 Attribution International', 'CC-BY-4.0'],
+              ['CC-BY-SA-4.0 Attribution-Share Alike International', 'CC-BY-SA-4.0'],
+              ['CC-BY-ND-4.0 Attribution-No Derivatives International', 'CC-BY-ND-4.0'],
+              ['CC-BY-NC-4.0 Attribution-NonCommercial International', 'CC-BY-NC-4.0'],
+              ['CC-BY-NC-SA-4.0 Attribution-NonCommercial-Share Alike International', 'CC-BY-NC-SA-4.0'],
+              ['CC-BY-NC-ND-4.0 Attribution-NonCommercial-No Derivatives', 'CC-BY-NC-ND-4.0']
+            ]
+          ],
           [
-            ['CC-PDDC Public Domain Dedication and Certification', 'CC-PDDC']
-          ]
-        ],
-        [
-          'Open Data Commons (ODC) licenses',
+            'CC-PDDC Public Domain Dedication and Certification',
+            [
+              ['CC-PDDC Public Domain Dedication and Certification', 'CC-PDDC']
+            ]
+          ],
           [
-            ['PDDL-1.0 Public Domain Dedication and License', 'PDDL-1.0'],
-            ['ODC-By-1.0 Attribution License', 'ODC-By-1.0'],
-            ['ODbL-1.0 Open Database License', 'ODbL-1.0']
-          ]
-        ],
-        [
-          'Software Licenses',
+            'Open Data Commons (ODC) licenses',
+            [
+              ['PDDL-1.0 Public Domain Dedication and License', 'PDDL-1.0'],
+              ['ODC-By-1.0 Attribution License', 'ODC-By-1.0'],
+              ['ODbL-1.0 Open Database License', 'ODbL-1.0']
+            ]
+          ],
           [
-            ['AGPL-3.0-only GNU Affero General Public License', 'AGPL-3.0-only'],
-            ['Apache-2.0', 'Apache-2.0'],
-            ['BSD-2-Clause "Simplified" License', 'BSD-2-Clause'],
-            ['BSD-3-Clause "New" or "Revised" License', 'BSD-3-Clause'],
-            ['CDDL-1.1 Common Development and Distribution License', 'CDDL-1.1'],
-            ['EPL-2.0 Eclipse Public License', 'EPL-2.0'],
-            ['GPL-3.0-only GNU General Public License', 'GPL-3.0-only'],
-            ['ISC License', 'ISC'],
-            ['LGPL-3.0-only Lesser GNU Public License', 'LGPL-3.0-only'],
-            ['MIT License', 'MIT'],
-            ['MPL-2.0 Mozilla Public License', 'MPL-2.0']
-          ]
-        ],
-        [
-          'No License',
+            'Software Licenses',
+            [
+              ['AGPL-3.0-only GNU Affero General Public License', 'AGPL-3.0-only'],
+              ['Apache-2.0', 'Apache-2.0'],
+              ['BSD-2-Clause "Simplified" License', 'BSD-2-Clause'],
+              ['BSD-3-Clause "New" or "Revised" License', 'BSD-3-Clause'],
+              ['CDDL-1.1 Common Development and Distribution License', 'CDDL-1.1'],
+              ['EPL-2.0 Eclipse Public License', 'EPL-2.0'],
+              ['GPL-3.0-only GNU General Public License', 'GPL-3.0-only'],
+              ['ISC License', 'ISC'],
+              ['LGPL-3.0-only Lesser GNU Public License', 'LGPL-3.0-only'],
+              ['MIT License', 'MIT'],
+              ['MPL-2.0 Mozilla Public License', 'MPL-2.0']
+            ]
+          ],
           [
-            ['No License', 'none']
+            'No License',
+            [
+              ['No License', 'none']
+            ]
           ]
         ]
-      ]
+      end
+
+      it 'does not include the unsupported 3.0 grouping' do
+        expect(grouped_options.last).not_to include('Creative Commons 3.0 (Unsupported)')
+      end
+    end
+
+    context 'with an unsupported license' do
+      let(:legacy_option) { grouped_options.last }
+      let(:license) { 'CC-BY-NC-3.0' }
+
+      it 'includes the unsupported 3.0 grouping' do
+        expect(legacy_option).to include('Creative Commons 3.0 (Unsupported)')
+      end
+
+      it 'includes the specified license marked as disabled' do
+        expect(legacy_option.last).to include(
+          ['CC Attribution Non Commercial 3.0 (Unsupported)', license, { disabled: true }]
+        )
+      end
     end
   end
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -120,8 +120,16 @@ RSpec.describe Work do
   end
 
   describe 'license validation' do
-    context 'with an empty license' do
+    context 'with a nil license' do
       let(:work) { build(:work, license: nil) }
+
+      it 'validates' do
+        expect(work).to be_valid
+      end
+    end
+
+    context 'with a blank license' do
+      let(:work) { build(:work, license: '') }
 
       it 'does not validate' do
         expect(work).not_to be_valid
@@ -136,8 +144,16 @@ RSpec.describe Work do
       end
     end
 
-    context 'with a valid license' do
+    context 'with a valid selectable license' do
       let(:work) { build(:work, license: License.license_list.first) }
+
+      it 'validates' do
+        expect(work).to be_valid
+      end
+    end
+
+    context 'with a valid displayable license' do
+      let(:work) { build(:work, license: License.license_list(include_displayable: true).last) }
 
       it 'validates' do
         expect(work).to be_valid


### PR DESCRIPTION
Fixes #1047

## Why was this change made?

This change is intended to help migrate Hydrus 1 data into Hydrus 2, and to display migrated works with their current (CC 3.0) licenses. It allows a small set of displayable licenses to show both in the work show page and on the work form. Before a new version of such a work may be deposited again, a new H2 license must be selected.

Includes:

* Remove license validation from work model
  * We are already validating licenses in the work form so this is not necessary and is counter to our approach to validation where we favor form validation over modal validation. This also allows us to migrate *any* license from Hydrus 1.0.

### Screenshot: Show legacy license in show page

![license_show](https://user-images.githubusercontent.com/131982/107831443-ee681600-6d42-11eb-869d-03acdb0627aa.png)


### Screenshot: Display legacy license in form

![selected_license](https://user-images.githubusercontent.com/131982/107831251-7b5e9f80-6d42-11eb-9ebe-7bb814ebbea9.png)

### Screencast: Show dropdown behavior in form

![Peek 2021-02-12 14-58](https://user-images.githubusercontent.com/131982/107831420-e27c5400-6d42-11eb-8d02-d1fdff10e5a2.gif)

## How was this change tested?

CI, local browser

## Which documentation and/or configurations were updated?

None

