### PR TITLE
Add missing style to move the caption back to the top of the table

### DIFF
--- a/app/components/collections/participants_component.html.erb
+++ b/app/components/collections/participants_component.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-sm mb-5">
+<table class="table table-sm mb-5 caption-header">
   <caption>Collection participants
     <%= render Collections::EditLinkComponent.new(collection: collection, anchor: 'participants', label: 'Edit collection participants') %>
   </caption>


### PR DESCRIPTION
## Why was this change made?

Fixes #1082

## How was this change tested?



## Which documentation and/or configurations were updated?



