### PR TITLE
Calculate the progress component on the backend

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -8,10 +8,7 @@
   </p>
   <div class="dropzone dropzone-default<%= ' is-invalid' if error? %>">
     <%= form.file_field :files, multiple: true, direct_upload: true,
-                        data: { dropzone_target: 'input',
-                                edit_deposit_target: 'fileField',
-                                'progress-step': 'file',
-                                action: "change->edit-deposit#check" } %>
+                        data: { dropzone_target: 'input' } %>
     <div class="dz-message needsclick text-secondary">
       <p>Drop files here</p>
     </div>

--- a/app/components/works/agreement_component.html.erb
+++ b/app/components/works/agreement_component.html.erb
@@ -2,10 +2,7 @@
   <header>Terms of Deposit</header>
   <div class="row">
     <div class="form-check col-auto">
-      <%= form.check_box :agree_to_terms, required: true, class: 'form-check-input',
-          data: { action: "change->edit-deposit#check",
-                          'progress-step': 'terms', edit_deposit_target: 'termsField' }
-       %>
+      <%= form.check_box :agree_to_terms, required: true, class: 'form-check-input' %>
       <%= form.label :agree_to_terms,
        "I agree to the #{link_to 'SDR Terms of Deposit', '#termsOfDepositModal', data: { bs_toggle: 'modal', bs_target: '#termsOfDepositModal'}}".html_safe,
        class: 'form-check-label' %>

--- a/app/components/works/deposit_progress_component.html.erb
+++ b/app/components/works/deposit_progress_component.html.erb
@@ -1,14 +1,6 @@
 <div class="row">
   <div class="col-lg-7">
-    <ul class="depositProgress">
-      <li data-edit-deposit-target="file">File</li>
-      <li data-edit-deposit-target="title">Title</li>
-      <li data-edit-deposit-target="author">Author</li>
-      <li data-edit-deposit-target="description">Description</li>
-      <li data-edit-deposit-target="release">Release</li>
-      <li data-edit-deposit-target="license">License</li>
-      <li data-edit-deposit-target="terms">Terms</li>
-    </ul>
+    <turbo-frame id="progress" data-edit-deposit-target="frame"></turbo-frame>
   </div>
 
   <div class="col-lg-5">

--- a/app/components/works/form_component.html.erb
+++ b/app/components/works/form_component.html.erb
@@ -2,6 +2,7 @@
 <%= form_with model: work_form, url: url,
     data: {
       controller: 'edit-deposit auto-citation',
+      edit_deposit_endpoint_value: work_form.persisted? ? work_validate_path(work_form.model.id) : collection_validate_path(work_form.collection_id),
       auto_citation_purl: purl
     },
     html: { class: "needs-validation work-editor", novalidate: true, multipart: true } do |f| %>

--- a/app/components/works/title_component.html.erb
+++ b/app/components/works/title_component.html.erb
@@ -4,10 +4,8 @@
      <%= form.label :title, 'Title of deposit', class: 'col-sm-2 col-form-label' %>
      <div class="col-sm-9">
        <%= form.text_field :title, class: "form-control", required: true,
-                           data: { action: "change->auto-citation#updateDisplay change->edit-deposit#check",
-                                   'progress-step': 'title',
-                                   auto_citation_target: 'titleField',
-                                   edit_deposit_target: 'titleField' } %>
+                           data: { action: "change->auto-citation#updateDisplay",
+                                   auto_citation_target: 'titleField' } %>
        <div class="invalid-feedback">You must provide a title</div>
      </div>
    </div>

--- a/app/controllers/validates_controller.rb
+++ b/app/controllers/validates_controller.rb
@@ -1,0 +1,26 @@
+# typed: false
+# frozen_string_literal: true
+
+# Renders the progress component given the form values
+class ValidatesController < ApplicationController
+  def show
+    work = if params[:work_id]
+             Work.find(params[:work_id])
+           else
+             Work.new(collection_id: params[:collection_id])
+           end
+
+    form = WorkForm.new(work)
+    form.validate(params[:work])
+    form.sync
+    render partial: 'validate', locals: { work: work }
+  end
+
+  # Prevent long URLs (in the ValidatesController) from getting serialized into
+  # the cookie causing a CookieOverflow
+  # See https://github.com/heartcombo/devise/pull/3347
+  # overrides Devise::Controllers::StoreLocation
+  def store_location_for(resource_or_scope, location)
+    # NOP
+  end
+end

--- a/app/javascript/controllers/edit_deposit_controller.js
+++ b/app/javascript/controllers/edit_deposit_controller.js
@@ -1,36 +1,29 @@
 import { Controller } from "stimulus";
 
 export default class extends Controller {
-  static targets = ["title", "titleField",
-                    "file", "fileField",
-                    "keywordsField",
-                    "contributorsField",
-                    "embargo-dateField",
-                    "terms", "termsField",
-                    "moreTypesLink", "moreTypes"];
+  static targets = ["moreTypesLink",
+                    "moreTypes",
+                    "frame"]
+  static values = { endpoint: String }
 
   connect() {
-    // TODO see what of the things are already valid
-    this.checkField(this.fileFieldTarget)
-    this.checkField(this.titleFieldTarget)
-    this.checkField(this.termsFieldTarget)
+    this.check()
+    this.element.addEventListener('change', () => this.check())
   }
 
   check(e) {
-    this.checkField(e.target)
-  }
+    const form = this.element
+    const data = new FormData(form)
 
-  checkField(field) {
-    const stepName = field.getAttribute("data-progress-step")
-    const step = this.targets.find(stepName)
-    let isComplete = field.value !== ''
-    if (stepName === 'file') {
-      isComplete = document.querySelectorAll('.dz-preview').length > 0
+    // Discard any template records
+    for(const key of data.keys()) {
+      if (key.match(/TEMPLATE_RECORD/)) {
+        data.delete(key)
+      }
     }
-    if (stepName === 'terms') {
-      isComplete = document.querySelector('#work_agree_to_terms').checked
-    }
-    step.classList.toggle('active', isComplete)
+
+    const queryString = new URLSearchParams(data).toString();
+    this.frameTarget.src = `${this.endpointValue}?${queryString}`
   }
 
   toggleMoreTypes(event) {

--- a/app/views/validates/_validate.html.erb
+++ b/app/views/validates/_validate.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag 'progress' do %>
+  <%= render Dashboard::DepositProgressComponent.new(work: work) %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
       get :delete_button
     end
 
+    resource :validate, only: :show
+
     resources :works, shallow: true do
       member do
         get :delete_button
@@ -29,6 +31,7 @@ Rails.application.routes.draw do
       end
 
       resource :review, only: :create
+      resource :validate, only: :show
     end
   end
 

--- a/spec/components/works/deposit_progress_component_spec.rb
+++ b/spec/components/works/deposit_progress_component_spec.rb
@@ -6,6 +6,6 @@ require 'rails_helper'
 RSpec.describe Works::DepositProgressComponent do
   it 'renders the component' do
     expect(render_inline(described_class.new).to_html)
-      .to include('File')
+      .to include('turbo-frame id="progress"')
   end
 end

--- a/spec/components/works/form_component_spec.rb
+++ b/spec/components/works/form_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Works::FormComponent do
 
   it 'renders the component' do
     expect(rendered.to_html)
-      .to include('Deposit', 'Save as draft', 'File', 'Add your files',
+      .to include('Deposit', 'Save as draft', 'Add your files',
                   'Title of deposit and contact information',
                   'List authors and contributors',
                   'Enter dates related to your deposit',

--- a/spec/requests/validate_request_spec.rb
+++ b/spec/requests/validate_request_spec.rb
@@ -1,0 +1,24 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Validates', type: :request do
+  context 'when the work is new' do
+    let(:collection) { create(:collection) }
+
+    it 'is successful' do
+      get "/collections/#{collection.id}/validate?work[citation]=foo"
+      expect(response).to be_successful
+    end
+  end
+
+  context 'when the work is persisted' do
+    let(:work) { create(:work) }
+
+    it 'is successful' do
+      get "/works/#{work.id}/validate?work[citation]=foo"
+      expect(response).to be_successful
+    end
+  end
+end


### PR DESCRIPTION

## Why was this change made?
Fixes #935 
This makes the progress component on the edit form fully functional and identical to the behavior on the dashboard

## How was this change tested?



## Which documentation and/or configurations were updated?



