### PR TITLE
Replace collection release date selector with release options

### DIFF
--- a/app/components/collections/form_component.html.erb
+++ b/app/components/collections/form_component.html.erb
@@ -62,20 +62,10 @@
         <%= form.label 'release_option_delay', class: "form-check-label" do %>
           Delay release until
         <% end %>
-        <div class="year">
-          <label for="collection_release_date_year" class="visually-hidden">Embargo year</label>
-          <%= select_year release_date_year, { prefix: 'collection', field_name: 'release_date(1i)', start_year: Time.zone.today.year, end_year: 3.years.from_now.year }, id: 'collection_release_date_year', class: "form-control" %>
-        </div>
-
-        <div class="month">
-          <label for="collection_release_date_month" class="visually-hidden">Embargo month</label>
-          <%= select_month release_date_month, { prefix: 'collection', field_name: 'release_date(2i)', prompt: 'month'}, id: 'collection_release_date_month', class: "form-control" %>
-        </div>
-
-        <div class="day">
-          <label for="collection_release_date_day" class="visually-hidden">Embargo day</label>
-          <%= select_day release_date_day, { prefix: 'collection', field_name: 'release_date(3i)', prompt: 'day'}, id: 'collection_release_date_day', class: "form-control" %>
-        </div>
+        <%= form.select :default_release_duration,
+          options_for_select(embargo_release_duration_options, selected: release_duration),
+                              {},
+                              class: 'form-select' %>
       </div>
 
       <div class="form-check" data-complex-radio-target="selection">

--- a/app/components/collections/form_component.html.erb
+++ b/app/components/collections/form_component.html.erb
@@ -62,7 +62,7 @@
         <%= form.label 'release_option_delay', class: "form-check-label" do %>
           Delay release until
         <% end %>
-        <%= form.select :default_release_duration,
+        <%= form.select :release_duration,
           options_for_select(embargo_release_duration_options, selected: release_duration),
                               {},
                               class: 'form-select' %>

--- a/app/components/collections/form_component.rb
+++ b/app/components/collections/form_component.rb
@@ -20,25 +20,5 @@ module Collections
     def draft_collections_path(collection)
       collections_path(collection)
     end
-
-    def release_date_year
-      release_date&.year || Time.zone.today.year
-    end
-
-    def release_date_month
-      release_date&.month
-    end
-
-    def release_date_day
-      release_date&.day
-    end
-
-    sig { returns(T.nilable(Date)) }
-    def release_date
-      case collection_form.release_date
-      when Date
-        T.cast(collection_form.release_date, Date)
-      end
-    end
   end
 end

--- a/app/components/collections/release_component.html.erb
+++ b/app/components/collections/release_component.html.erb
@@ -5,7 +5,7 @@
   <tbody>
     <tr>
       <th>Release</th>
-      <td><%= release_option %></td>
+      <td><%= release_option %> <%= "(#{release_duration})" unless release_option == 'immediate' %></td>
     </tr>
     <tr>
       <th>Visibility</th>

--- a/app/components/collections/release_component.rb
+++ b/app/components/collections/release_component.rb
@@ -12,6 +12,6 @@ module Collections
     sig { returns(Collection) }
     attr_reader :collection
 
-    delegate :release_option, :access, to: :collection
+    delegate :release_option, :release_duration, :access, to: :collection
   end
 end

--- a/app/components/works/embargo_component.rb
+++ b/app/components/works/embargo_component.rb
@@ -26,7 +26,7 @@ module Works
     def availability_from_collection
       return 'immediately upon deposit' if collection.release_option == 'immediate'
 
-      "starting on #{collection.embargo_release_date.to_formatted_s(:long)}"
+      "starting on #{collection.release_date.to_formatted_s(:long)}"
     end
 
     def access_from_collection

--- a/app/components/works/embargo_component.rb
+++ b/app/components/works/embargo_component.rb
@@ -26,7 +26,7 @@ module Works
     def availability_from_collection
       return 'immediately upon deposit' if collection.release_option == 'immediate'
 
-      "starting on #{collection.release_date.to_formatted_s(:long)}"
+      "starting on #{collection.embargo_release_date.to_formatted_s(:long)}"
     end
 
     def access_from_collection

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -103,7 +103,6 @@ class CollectionsController < ObjectsController
                                        :email_when_participants_changed,
                                        :email_depositors_status_changed,
                                        :release_option, :release_duration,
-                                       'release_date(1i)', 'release_date(2i)', 'release_date(3i)',
                                        related_links_attributes: %i[_destroy id link_title url],
                                        contact_emails_attributes: %i[_destroy id email])
   end

--- a/app/forms/draft_collection_form.rb
+++ b/app/forms/draft_collection_form.rb
@@ -22,7 +22,6 @@ class DraftCollectionForm < Reform::Form
 
   property :release_option, default: 'immediate'
   property :release_duration
-  property :release_date, embargo_date: true, assign_if: ->(params) { params['release_option'] == 'delay' }
 
   property :license_option
   property :required_license
@@ -51,7 +50,6 @@ class DraftCollectionForm < Reform::Form
     property :_destroy, virtual: true
   end
 
-  validates :release_date, embargo_date: true
   validates :release_option, presence: true, inclusion: { in: %w[immediate delay depositor-selects] }
   validates :release_duration, inclusion: { in: EMBARGO_RELEASE_DURATION_OPTIONS.values }, allow_blank: true
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -26,6 +26,13 @@ class Collection < ApplicationRecord
     %w[first_draft depositing].exclude?(state)
   end
 
+  sig { returns(T.nilable(Date)) }
+  def embargo_release_date
+    return Time.zone.today + 6.months if release_duration == '6 months'
+
+    Time.zone.today + release_duration.gsub(/[^\d]/, '').to_i.years
+  end
+
   # The collection has allowed the user to specify availablity on the member works
   sig { returns(T::Boolean) }
   def user_can_set_availability?

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -27,7 +27,8 @@ class Collection < ApplicationRecord
   end
 
   sig { returns(T.nilable(Date)) }
-  def embargo_release_date
+  def release_date
+    return nil if release_duration.nil?
     return Time.zone.today + 6.months if release_duration == '6 months'
 
     Time.zone.today + release_duration.gsub(/[^\d]/, '').to_i.years

--- a/db/migrate/20210216220559_remove_release_date_from_collection.rb
+++ b/db/migrate/20210216220559_remove_release_date_from_collection.rb
@@ -1,0 +1,5 @@
+class RemoveReleaseDateFromCollection < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :collections, :release_date, :date
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -212,7 +212,6 @@ CREATE TABLE public.collections (
     description character varying,
     release_option character varying,
     release_duration character varying,
-    release_date date,
     access character varying,
     required_license character varying,
     default_license character varying,
@@ -1129,6 +1128,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210127133325'),
 ('20210201155622'),
 ('20210202044303'),
-('20210208201246');
+('20210208201246'),
+('20210216220559');
 
 

--- a/spec/components/works/embargo_component_spec.rb
+++ b/spec/components/works/embargo_component_spec.rb
@@ -36,10 +36,11 @@ RSpec.describe Works::EmbargoComponent do
   end
 
   context 'when the collection is configured for a specific date' do
-    let(:collection) { build(:collection, release_option: 'delay', release_date: Date.parse('2030-09-07')) }
+    let(:collection) { build(:collection, release_option: 'delay', release_duration: '1 year') }
+    let(:release_date) { (Time.zone.today + 1.year).to_formatted_s(:long) }
 
     it 'renders the component' do
-      expect(rendered.to_html).to include 'starting on September 07, 2030.'
+      expect(rendered.to_html).to include "starting on #{release_date}"
     end
   end
 end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
     name { 'MyString' }
     description { 'MyString' }
     release_option { 'immediate' }
-    release_date { '2020-10-09' }
     access { 'world' }
     license_option { 'depositor-selects' }
     email_when_participants_changed { false }

--- a/spec/features/single_radio_selection_spec.rb
+++ b/spec/features/single_radio_selection_spec.rb
@@ -21,9 +21,11 @@ RSpec.describe 'Selecting a radio button causes other radio button inputs to be 
         expect(find('#collection_release_option_delay')).not_to be_checked
         expect(find('#collection_release_option_depositor-selects')).to be_checked
 
-        expect(find('#collection_release_duration')).not_to be_disabled
+        delayed_release = all('#collection_release_duration').first
+        expect(delayed_release).to be_disabled
 
-        expect(find('#collection_default_release_duration')).to be_disabled
+        depositor_selects = all('#collection_release_duration').last
+        expect(depositor_selects).not_to be_disabled
 
         # Disable "depositor-selects" select when "delay" selected
         choose('Delay release until')
@@ -32,9 +34,10 @@ RSpec.describe 'Selecting a radio button causes other radio button inputs to be 
         expect(find('#collection_release_option_delay')).to be_checked
         expect(find('#collection_release_option_depositor-selects')).not_to be_checked
 
-        expect(find('#collection_release_duration')).to be_disabled
+        # expect(find('#collection_release_duration')).to be_disabled
+        expect(depositor_selects).to be_disabled
 
-        expect(find('#collection_default_release_duration')).not_to be_disabled
+        expect(delayed_release).not_to be_disabled
 
         # Disable "depositor-selects" and "delay" selects when "immediately" selected
         choose('Immediately')
@@ -43,9 +46,9 @@ RSpec.describe 'Selecting a radio button causes other radio button inputs to be 
         expect(find('#collection_release_option_delay')).not_to be_checked
         expect(find('#collection_release_option_depositor-selects')).not_to be_checked
 
-        expect(find('#collection_release_duration')).to be_disabled
+        expect(depositor_selects).to be_disabled
 
-        expect(find('#collection_default_release_duration')).to be_disabled
+        expect(delayed_release).to be_disabled
       end
     end
 

--- a/spec/features/single_radio_selection_spec.rb
+++ b/spec/features/single_radio_selection_spec.rb
@@ -17,37 +17,31 @@ RSpec.describe 'Selecting a radio button causes other radio button inputs to be 
       before { visit edit_collection_path(collection) }
 
       it 'shows only one release option as checked and disables child select elements of other options' do
+        # We need duplicate select lists with the same CSS selector
+        delayed_release = all('#collection_release_duration').first
+        depositor_selects = all('#collection_release_duration').last
+
         expect(find('#collection_release_option_immediate')).not_to be_checked
         expect(find('#collection_release_option_delay')).not_to be_checked
         expect(find('#collection_release_option_depositor-selects')).to be_checked
-
-        delayed_release = all('#collection_release_duration').first
         expect(delayed_release).to be_disabled
-
-        depositor_selects = all('#collection_release_duration').last
         expect(depositor_selects).not_to be_disabled
 
         # Disable "depositor-selects" select when "delay" selected
         choose('Delay release until')
-
         expect(find('#collection_release_option_immediate')).not_to be_checked
         expect(find('#collection_release_option_delay')).to be_checked
         expect(find('#collection_release_option_depositor-selects')).not_to be_checked
-
-        # expect(find('#collection_release_duration')).to be_disabled
+        expect(delayed_release).not_to be_disabled
         expect(depositor_selects).to be_disabled
 
-        expect(delayed_release).not_to be_disabled
-
+        # When depositor_selects was clicked, it should have disabled the delay selection
         # Disable "depositor-selects" and "delay" selects when "immediately" selected
         choose('Immediately')
-
         expect(find('#collection_release_option_immediate')).to be_checked
         expect(find('#collection_release_option_delay')).not_to be_checked
         expect(find('#collection_release_option_depositor-selects')).not_to be_checked
-
         expect(depositor_selects).to be_disabled
-
         expect(delayed_release).to be_disabled
       end
     end

--- a/spec/features/single_radio_selection_spec.rb
+++ b/spec/features/single_radio_selection_spec.rb
@@ -23,9 +23,7 @@ RSpec.describe 'Selecting a radio button causes other radio button inputs to be 
 
         expect(find('#collection_release_duration')).not_to be_disabled
 
-        expect(find('#collection_release_date_year')).to be_disabled
-        expect(find('#collection_release_date_month')).to be_disabled
-        expect(find('#collection_release_date_day')).to be_disabled
+        expect(find('#collection_default_release_duration')).to be_disabled
 
         # Disable "depositor-selects" select when "delay" selected
         choose('Delay release until')
@@ -36,9 +34,7 @@ RSpec.describe 'Selecting a radio button causes other radio button inputs to be 
 
         expect(find('#collection_release_duration')).to be_disabled
 
-        expect(find('#collection_release_date_year')).not_to be_disabled
-        expect(find('#collection_release_date_month')).not_to be_disabled
-        expect(find('#collection_release_date_day')).not_to be_disabled
+        expect(find('#collection_default_release_duration')).not_to be_disabled
 
         # Disable "depositor-selects" and "delay" selects when "immediately" selected
         choose('Immediately')
@@ -49,9 +45,7 @@ RSpec.describe 'Selecting a radio button causes other radio button inputs to be 
 
         expect(find('#collection_release_duration')).to be_disabled
 
-        expect(find('#collection_release_date_year')).to be_disabled
-        expect(find('#collection_release_date_month')).to be_disabled
-        expect(find('#collection_release_date_day')).to be_disabled
+        expect(find('#collection_default_release_duration')).to be_disabled
       end
     end
 

--- a/spec/requests/create_collection_spec.rb
+++ b/spec/requests/create_collection_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe 'Create a collection' do
             { '_destroy' => 'false', email: 'contact_email@example.com' }
           }
         end
-        let(:next_year) { (Time.zone.today + 1.year).year.to_s }
+        let(:next_year) { Time.zone.today + 1.year }
 
         let(:no_contact_emails) do
           { '0' => { '_destroy' => 'false', email: '' } }
@@ -129,9 +129,6 @@ RSpec.describe 'Create a collection' do
             license_option: 'required',
             required_license: 'CC0-1.0',
             'release_option' => 'delay',
-            'release_date(1i)' => next_year,
-            'release_date(2i)' => '7',
-            'release_date(3i)' => '14',
             'release_duration' => '1 year',
             contact_emails_attributes: contact_emails,
             related_links_attributes: related_links
@@ -154,7 +151,7 @@ RSpec.describe 'Create a collection' do
           expect(collection.related_links.size).to eq 2
           expect(collection.related_links).to all(be_kind_of(RelatedLink))
           expect(collection.release_option).to eq 'delay'
-          expect(collection.release_date).to eq Date.parse("#{next_year}-7-14")
+          expect(collection.release_date).to eq next_year
         end
 
         it 'sends emails to depositors when a new collection is created and deposited' do

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -515,9 +515,9 @@ RSpec.describe 'Create a new work' do
       context 'with a collection with delay release but a embargo is provided' do
         let(:collection) do
           create(:collection, :deposited, :with_contact_emails, depositors: [user], release_option: 'delay',
-                                                                release_date: release_date)
+                                                                release_duration: '1 year')
         end
-        let(:release_date) { Date.parse('2029-03-07') }
+        let(:release_date) { Time.zone.today + 1.year }
         let(:work_params) do
           {
             title: 'Test title',
@@ -531,9 +531,6 @@ RSpec.describe 'Create a new work' do
             },
             license: 'CC0-1.0',
             release: 'embargo',
-            'embargo(1i)': '2030',
-            'embargo(2i)': '09',
-            'embargo(3i)': '01',
             agree_to_terms: '1'
           }
         end


### PR DESCRIPTION
## Why was this change made?

Fixes #966 

On the new collection entry:

<img width="703" alt="Screen Shot 2021-02-16 at 3 09 30 PM" src="https://user-images.githubusercontent.com/2294288/108133856-1cfb2f00-706a-11eb-8e3e-60bfe85ebe2e.png">

On the collection show page:

<img width="1144" alt="Screen Shot 2021-02-16 at 3 12 59 PM" src="https://user-images.githubusercontent.com/2294288/108133901-2a181e00-706a-11eb-8b0f-11c0a3ffce87.png">

On the work entry page when release is set to `delay`:

<img width="1309" alt="Screen Shot 2021-02-16 at 3 13 51 PM" src="https://user-images.githubusercontent.com/2294288/108133970-474cec80-706a-11eb-905d-1b60c308eeb5.png">

On the work show page:

<img width="1080" alt="Screen Shot 2021-02-16 at 3 14 05 PM" src="https://user-images.githubusercontent.com/2294288/108133979-4caa3700-706a-11eb-910b-d96a1634f0b2.png">

## How was this change tested?

Unit tests updated and manually verified.

## Which documentation and/or configurations were updated?



