### PR TITLE
Validate should not cause records to persist

### DIFF
--- a/app/controllers/validates_controller.rb
+++ b/app/controllers/validates_controller.rb
@@ -12,7 +12,9 @@ class ValidatesController < ApplicationController
 
     form = WorkForm.new(work)
     form.validate(params[:work])
-    form.sync
+    # If you call sync on a persisted model, ActiveRecord will overwrite has_many assocations.
+    # If you don't call sync on a new record, it won't show any of the validations.
+    form.sync unless work.persisted?
     render partial: 'validate', locals: { work: work }
   end
 

--- a/spec/requests/validate_request_spec.rb
+++ b/spec/requests/validate_request_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe 'Validates', type: :request do
     let(:work) { create(:work) }
 
     it 'is successful' do
-      get "/works/#{work.id}/validate?work[citation]=foo"
+      get "/works/#{work.id}/validate?work[citation]=foo&work[keywords_attributes][0][label]=key"
       expect(response).to be_successful
+      expect(work.keywords).to be_empty
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Running the validation endpoint was causing dupliate has_many associations to be persisted.

## How was this change tested?



## Which documentation and/or configurations were updated?



