### PR TITLE
Add a button to open the citation modal

### DIFF
--- a/app/components/citation_component.rb
+++ b/app/components/citation_component.rb
@@ -1,0 +1,26 @@
+# typed: false
+# frozen_string_literal: true
+
+# A button that opens a modal containing the citation for a deposit
+class CitationComponent < ApplicationComponent
+  def initialize(work_version:)
+    @work_version = work_version
+  end
+
+  def call
+    tag.button data: {
+      controller: 'show-citation',
+      action: 'show-citation#setContent',
+      show_citation_citation_value: work_version.citation,
+      show_citation_header_value: work_version.title,
+      show_citation_target_value: '#citationModal',
+      bs_toggle: 'modal',
+      bs_target: '#citationModal'
+    }, class: 'btn' do
+      # It's a SafeBuffer, not a String
+      tag.span(class: 'fas fa-quote-left') + ' Cite' # rubocop:disable Style/StringConcatenation
+    end
+  end
+
+  attr_reader :work_version
+end

--- a/app/components/citation_modal_component.html.erb
+++ b/app/components/citation_modal_component.html.erb
@@ -1,0 +1,16 @@
+<div class="modal fade" id="citationModal" tabindex="-1" aria-labelledby="citationModalHeader" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="citationModalHeader"></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+
+      <div class="modal-body">
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-link" data-bs-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/citation_modal_component.rb
+++ b/app/components/citation_modal_component.rb
@@ -1,0 +1,5 @@
+# typed: false
+# frozen_string_literal: true
+
+class CitationModalComponent < ApplicationComponent
+end

--- a/app/components/collections/header_component.html.erb
+++ b/app/components/collections/header_component.html.erb
@@ -16,6 +16,7 @@
             class: "btn btn-primary" %>
 
       <%= render Works::WorkTypeModalComponent.new %>
+      <%= render CitationModalComponent.new %>
     </span>
   <% end %>
 </header>

--- a/app/components/collections/work_row_component.html.erb
+++ b/app/components/collections/work_row_component.html.erb
@@ -14,5 +14,5 @@
   <td><%= attached_files.count %></td>
   <td><%= size %></td>
   <td><%= link_to work.purl, work.purl if work.purl %></td>
-  <td><span class="fas fa-quote-left"></span> Cite</td>
+  <td><%= render CitationComponent.new(work_version: work_version) %></td>
 </tr>

--- a/app/components/dashboard/collection_component.html.erb
+++ b/app/components/dashboard/collection_component.html.erb
@@ -24,10 +24,9 @@
           <td><%= render Works::StateDisplayComponent.new(work_version: work.head) %></td>
           <td><%= I18n.l(work.updated_at.to_date, format: :abbr_month) %></td>
           <td><%= link_to work.purl, work.purl if work.purl %></td>
-          <td><span class="fas fa-quote-left"></span> Cite</td>
+          <td><%= render CitationComponent.new(work_version: work.head) %></td>
         </tr>
       <% end %>
-
     </tbody>
   </table>
 

--- a/app/javascript/controllers/show_citation_controller.js
+++ b/app/javascript/controllers/show_citation_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static values = {
+    citation: String,
+    header: String,
+    target: String,
+  }
+
+  setContent() {
+    const modal = document.querySelector(this.targetValue)
+    modal.querySelector('h5').textContent = `${this.headerValue} citation`
+    modal.querySelector('.modal-body').textContent = this.citationValue
+  }
+}

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -25,6 +25,7 @@
       </ul>
 
       <%= render Works::WorkTypeModalComponent.new %>
+      <%= render CitationModalComponent.new %>
     </section>
 
     <%= render Dashboard::AllCollectionsComponent.new(stats: @presenter.work_stats) %>

--- a/spec/components/citation_component_spec.rb
+++ b/spec/components/citation_component_spec.rb
@@ -1,0 +1,15 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CitationComponent, type: :component do
+  let(:rendered) { render_inline(described_class.new(work_version: work_version)) }
+  let(:work_version) { build(:work_version) }
+
+  it 'renders the component' do
+    button = rendered.css('button').first
+    expect(button['data-bs-target']).to eq '#citationModal'
+    expect(button['data-controller']).to eq 'show-citation'
+  end
+end

--- a/spec/components/citation_modal_component_spec.rb
+++ b/spec/components/citation_modal_component_spec.rb
@@ -1,0 +1,13 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CitationModalComponent, type: :component do
+  let(:rendered) { render_inline(described_class.new) }
+
+  it 'renders the component' do
+    expect(rendered.css('#citationModal h5')).to be_present
+    expect(rendered.css('#citationModal .modal-body')).to be_present
+  end
+end

--- a/spec/components/collections/works_component_spec.rb
+++ b/spec/components/collections/works_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Collections::WorksComponent, type: :component do
     end
 
     it 'renders the works detail table component' do
-      expect(rendered.css('table').to_html).to include('Test title').exactly(6).times
+      expect(rendered.css('table').to_html).to include('Test title').exactly(8).times
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?
Fixes #468



## How was this change tested?

<img width="938" alt="Screen Shot 2021-02-17 at 11 27 06 AM" src="https://user-images.githubusercontent.com/92044/108242897-14126800-7113-11eb-98cc-0da3787070fd.png">


## Which documentation and/or configurations were updated?



