### PR TITLE
Vary work embargo component availability text based on collection

### DIFF
--- a/app/components/works/embargo_component.html.erb
+++ b/app/components/works/embargo_component.html.erb
@@ -7,8 +7,8 @@
 
   <% if user_can_set_availability? %>
     <p>Select when the files in your deposit will be downloadable from the PURL page.
-      If you select "Immediately", your files will be available shortly after you click
-      "Deposit" at the bottom of this page. Or you may specify a specific date in the future.</p>
+      If you select "Immediately", your files will be available shortly after <%= when_available_statement %>.
+      Or you may specify a specific date in the future.</p>
 
     <%= render Works::AvailableDateComponent.new(form: form) %>
     <% if user_can_set_access? %>

--- a/app/components/works/embargo_component.rb
+++ b/app/components/works/embargo_component.rb
@@ -32,5 +32,11 @@ module Works
     def access_from_collection
       collection.access
     end
+
+    def when_available_statement
+      return 'your deposit is approved' if collection.review_enabled?
+
+      'you click "Deposit" at the bottom of this page'
+    end
   end
 end

--- a/spec/components/works/embargo_component_spec.rb
+++ b/spec/components/works/embargo_component_spec.rb
@@ -35,6 +35,28 @@ RSpec.describe Works::EmbargoComponent do
     end
   end
 
+  context 'when the collection allows depositor to select release timing' do
+    let(:collection) do
+      build(:collection, :depositor_selects_access, release_option: 'depositor-selects', review_enabled: review_enabled)
+    end
+
+    context 'when collection does not require review' do
+      let(:review_enabled) { false }
+
+      it 'renders the component' do
+        expect(rendered.to_html).to include 'you click "Deposit" at the bottom of this page'
+      end
+    end
+
+    context 'when collection requires review' do
+      let(:review_enabled) { true }
+
+      it 'renders the component' do
+        expect(rendered.to_html).to include 'your deposit is approved'
+      end
+    end
+  end
+
   context 'when the collection is configured for a specific date' do
     let(:collection) { build(:collection, release_option: 'delay', release_duration: '1 year') }
     let(:release_date) { (Time.zone.today + 1.year).to_formatted_s(:long) }


### PR DESCRIPTION
Fixes #336

## Why was this change made?

This commit makes sure not to suggest that files are available shortly after the depositor clicks the deposit button when the collection requires review workflow, in which case the deposit button is the "submit for review" button and requires human intervention before the deposit is approved.


## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None

