### PR TITLE
Fix typo in authors component

### DIFF
--- a/app/components/works/authors_component.html.erb
+++ b/app/components/works/authors_component.html.erb
@@ -1,4 +1,4 @@
-<section data-controller="nested-form" data-nested-form-select-value=".inner-container">
+<section data-controller="nested-form" data-nested-form-selector-value=".inner-container">
   <header>
     Authors to include in citation
     <%= render PopoverComponent.new key: 'work.author' %>


### PR DESCRIPTION


## Why was this change made?
This restores the ability to remove authors

Fixes #1091


## How was this change tested?



## Which documentation and/or configurations were updated?



