### PR TITLE
Restore manager approvals

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -19,9 +19,7 @@ class DashboardsController < ApplicationController
     DashboardPresenter.new(
       just_signed_in: current_user.just_signed_in,
       collections: authorized_scope(Collection.all, as: :deposit),
-      approvals: WorkVersion.with_state(:pending_approval)
-                     .joins(work: { collection: :reviewed_by })
-                     .where('reviewers.user_id' => current_user),
+      approvals: WorkVersion.awaiting_review_by(current_user),
       in_progress: WorkVersion.with_state(:first_draft, :version_draft, :rejected)
                      .joins(:work)
                      .where('works.depositor' => current_user),


### PR DESCRIPTION
This was caused by a bad merge in https://github.com/sul-dlss/happy-heron/commit/fe6847a2ae5bd77cd252bc850821dfd313c86215

## Why was this change made?
Fixes #1118


## How was this change tested?



## Which documentation and/or configurations were updated?



