### PR TITLE
Remove CC-PDDC from the license lists

### DIFF
--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -18,7 +18,6 @@ class License
     'PDDL-1.0' => 'PDDL-1.0 Public Domain Dedication and License',
     'ODC-By-1.0' => 'ODC-By-1.0 Attribution License',
     'ODbL-1.0' => 'ODbL-1.0 Open Database License',
-    'CC-PDDC' => 'CC-PDDC Public Domain Dedication and Certification',
     'AGPL-3.0-only' => 'AGPL-3.0-only GNU Affero General Public License',
     'Apache-2.0' => 'Apache-2.0',
     'BSD-2-Clause' => 'BSD-2-Clause "Simplified" License',
@@ -87,10 +86,6 @@ class License
         'CC-BY-NC-SA-4.0',
         'CC-BY-NC-ND-4.0'
       ]
-    },
-    {
-      label: 'CC-PDDC Public Domain Dedication and Certification',
-      options: ['CC-PDDC']
     },
     {
       label: 'Open Data Commons (ODC) licenses',

--- a/spec/models/license_spec.rb
+++ b/spec/models/license_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe License do
           'PDDL-1.0',
           'ODC-By-1.0',
           'ODbL-1.0',
-          'CC-PDDC',
           'AGPL-3.0-only',
           'Apache-2.0',
           'BSD-2-Clause',
@@ -52,7 +51,6 @@ RSpec.describe License do
           'PDDL-1.0',
           'ODC-By-1.0',
           'ODbL-1.0',
-          'CC-PDDC',
           'AGPL-3.0-only',
           'Apache-2.0',
           'BSD-2-Clause',
@@ -94,12 +92,6 @@ RSpec.describe License do
               ['CC-BY-NC-4.0 Attribution-NonCommercial International', 'CC-BY-NC-4.0'],
               ['CC-BY-NC-SA-4.0 Attribution-NonCommercial-Share Alike International', 'CC-BY-NC-SA-4.0'],
               ['CC-BY-NC-ND-4.0 Attribution-NonCommercial-No Derivatives', 'CC-BY-NC-ND-4.0']
-            ]
-          ],
-          [
-            'CC-PDDC Public Domain Dedication and Certification',
-            [
-              ['CC-PDDC Public Domain Dedication and Certification', 'CC-PDDC']
             ]
           ],
           [


### PR DESCRIPTION


## Why was this change made?
Because it is deprecated and CC-0 should be used instead. Fixes #1100


## How was this change tested?



## Which documentation and/or configurations were updated?



