### PR TITLE
Update from apt before trying to fetch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
             - happy-heron-bundle-
       - run:
           name: Install psql
-          command: sudo apt install -y postgresql-client || true
+          command: sudo apt update && sudo apt install -y postgresql-client
       - run:
           name: Wait for database
           command: dockerize -wait tcp://localhost:5432 -timeout 1m


### PR DESCRIPTION

## Why was this change made?

Because if the cache is out of date you get:
Failed to fetch http://deb.debian.org/debian/pool/main/p/postgresql-11/postgresql-client-11_11.9-0+deb10u1_amd64.deb  404  Not Found


## How was this change tested?



## Which documentation and/or configurations were updated?



