### PR TITLE
Adds Details for Collection Release

### DIFF
--- a/app/components/collections/release_component.html.erb
+++ b/app/components/collections/release_component.html.erb
@@ -5,7 +5,7 @@
   <tbody>
     <tr>
       <th>Release</th>
-      <td><%= release_option %> <%= "(#{release_duration})" unless release_option == 'immediate' %></td>
+      <td><%= release_info %> </td>
     </tr>
     <tr>
       <th>Visibility</th>

--- a/app/components/collections/release_component.rb
+++ b/app/components/collections/release_component.rb
@@ -12,6 +12,18 @@ module Collections
     sig { returns(Collection) }
     attr_reader :collection
 
-    delegate :release_option, :release_duration, :access, to: :collection
+    delegate :access, to: :collection
+
+    sig { returns(T.nilable(String)) }
+    def release_info
+      case collection.release_option
+      when 'immediate'
+        'Immediately'
+      when 'delay'
+        "#{collection.release_duration} from date of deposit"
+      when 'depositor-selects'
+        "depositor selects release date at no more than #{collection.release_duration} from date of deposit"
+      end
+    end
   end
 end

--- a/spec/components/collections/release_component_spec.rb
+++ b/spec/components/collections/release_component_spec.rb
@@ -7,13 +7,31 @@ RSpec.describe Collections::ReleaseComponent, type: :component do
   let(:rendered) { render_inline(described_class.new(collection: collection)) }
 
   context 'when displaying a collection' do
-    let(:release_option) { collection.release_option }
     let(:access) { collection.access }
     let(:collection) { build_stubbed(:collection) }
 
     it 'renders the release component' do
-      expect(rendered.css('table').to_html).to include(release_option)
+      expect(rendered.css('table').to_html).to include('Immediately')
       expect(rendered.css('table').to_html).to include(access)
+    end
+  end
+
+  context 'when displaying a collection with depositor selects the release' do
+    let(:collection) { build_stubbed(:collection, release_option: 'depositor-selects', release_duration: '3 years') }
+    let(:rendered) { render_inline(described_class.new(collection: collection)) }
+    let(:message) { 'depositor selects release date at no more than 3 years from date of deposit' }
+
+    it 'renders the release component with more detail regarding the release' do
+      expect(rendered.css('table').to_html).to include(message)
+    end
+  end
+
+  context 'when displaying a collection with a delayed release' do
+    let(:collection) { build_stubbed(:collection, release_option: 'delay', release_duration: '2 years') }
+    let(:rendered) { render_inline(described_class.new(collection: collection)) }
+
+    it 'renders the release component with a delayed option' do
+      expect(rendered.css('table').to_html).to include('2 years from date of deposit')
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?
Fixes #769 

Depending on the collection manager's choices for Release, the following messages are displayed.

Immediately:
![Screen Shot 2021-02-18 at 10 53 59 AM](https://user-images.githubusercontent.com/71847/108399848-cd3a7600-71d7-11eb-8a6b-5420c051ba97.png)


With a specific delayed time period:
![Screen Shot 2021-02-18 at 10 53 44 AM](https://user-images.githubusercontent.com/71847/108399764-b5fb8880-71d7-11eb-85b4-d684fe0f97e6.png)

When depositor selects a date:
![Screen Shot 2021-02-18 at 10 54 12 AM](https://user-images.githubusercontent.com/71847/108399915-e2170980-71d7-11eb-958c-724616f438c4.png)


## How was this change tested?
New component tests.


## Which documentation and/or configurations were updated?
n/a


