### PR TITLE
Popup the continue work modal the first time they visit the dashboard…

### DIFF
--- a/app/components/dashboard/continue_work_modal_component.rb
+++ b/app/components/dashboard/continue_work_modal_component.rb
@@ -16,6 +16,10 @@ module Dashboard
       @presenter.in_progress.first
     end
 
-    delegate :title, :work, to: :work_version
+    delegate :work, to: :work_version
+
+    def title
+      @title ||= Works::DetailComponent.new(work_version: work_version).title
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
   # Smartly redirect user back to URL they requested before authenticating
   # From: https://github.com/heartcombo/devise/wiki/How-To:-Redirect-back-to-current-page-after-sign-in,-sign-out,-sign-up,-update
   before_action :store_user_location!, if: :storable_location?
+  before_action :copy_just_signed_in_to_session
 
   rescue_from ActionPolicy::Unauthorized, with: :deny_access
 
@@ -22,6 +23,11 @@ class ApplicationController < ActionController::Base
   helper_method :user_with_groups
 
   private
+
+  # If User#just_signed_in is set, copy that into the session
+  def copy_just_signed_in_to_session
+    session[:just_signed_in] = current_user.just_signed_in if current_user&.just_signed_in
+  end
 
   sig { returns(T::Array[String]) }
   # This looks first in the session for groups, and then to the headers.

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -17,7 +17,7 @@ class DashboardsController < ApplicationController
 
   def build_presenter
     DashboardPresenter.new(
-      just_signed_in: current_user.just_signed_in,
+      just_signed_in: session.delete(:just_signed_in),
       collections: authorized_scope(Collection.all, as: :deposit),
       approvals: WorkVersion.awaiting_review_by(current_user),
       in_progress: WorkVersion.with_state(:first_draft, :version_draft, :rejected)


### PR DESCRIPTION
… after logging in



## Why was this change made?
Previously it wasn't working because User#just_signed_in was only true on the root path, thus the modal was never opening

fixes #1023 (again, 😞 )


## How was this change tested?
Tested on qa.


## Which documentation and/or configurations were updated?



