### PR TITLE
Only show items waiting for approvals in the approvals table

### DIFF
--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -22,8 +22,7 @@ class WorkVersion < ApplicationRecord
       .joins(:work)
       .left_outer_joins(work: { collection: :reviewed_by })
       .left_outer_joins(work: { collection: :managed_by })
-      .where('reviewers.user_id' => user)
-      .or(where('managers.user_id' => user))
+      .where('reviewers.user_id = %s OR managers.user_id = %s', user.id, user.id)
   }
 
   enum access: {

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -37,21 +37,27 @@ RSpec.describe WorkVersion do
   describe '.awaiting_review_by' do
     subject { described_class.awaiting_review_by(user) }
 
-    let(:work) { create(:work, collection: collection) }
-    let(:work_version) { create(:work_version, :pending_approval, work: work) }
+    let(:work1) { create(:work, collection: collection) }
+    let!(:work_version1) { create(:work_version, :pending_approval, work: work1) }
+    let(:work2) { create(:work, collection: collection) }
+
+    before do
+      # We should not see this draft work in the query results
+      create(:work_version, :first_draft, work: work2)
+    end
 
     context 'when the user is a reviewer' do
       let(:collection) { create(:collection, :with_reviewers) }
       let(:user) { collection.reviewed_by.first }
 
-      it { is_expected.to include(work_version) }
+      it { is_expected.to eq [work_version1] }
     end
 
     context 'when the user is a manager' do
       let(:collection) { create(:collection, :with_managers) }
       let(:user) { collection.managed_by.first }
 
-      it { is_expected.to include(work_version) }
+      it { is_expected.to eq [work_version1] }
     end
 
     context 'when the user is an unrelated user' do


### PR DESCRIPTION


## Why was this change made?
This fixes a misplaced parenthesis in the generated SQL.
Fixes #1140


## How was this change tested?



## Which documentation and/or configurations were updated?



