### PR TITLE
Update homepage header text

### DIFF
--- a/app/javascript/stylesheets/frontpage.scss
+++ b/app/javascript/stylesheets/frontpage.scss
@@ -7,6 +7,19 @@
 
   h1, h2 {
     font-weight: 700;
+
+    .stanford {
+      font-weight: normal;
+      font-family: Palatino, ‘Palatino Linotype’, ‘Hoefler Text’, Times, ‘Times New Roman’, serif;
+      padding-right: 1rem;
+      border-right: 1px solid #f2f1eb;
+    }
+
+    .digital-repo {
+      font-weight: 500;
+      padding-left: 1rem;
+      text-transform: uppercase;
+    }
   }
 
   .btn-xl {

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -3,7 +3,7 @@
   <div class="container flex-wrap flex-md-nowrap">
     <div class="row">
       <div class="col-md-12">
-        <h1 class="me-auto">Digital Repository</h1>
+        <h1 class="me-auto"><span class="stanford">Stanford</span><span class="digital-repo">Digital repository</span></h1>
       </div>
     </div
     <p class="fs-4">Long term preservation of scholarly works at Stanford</p>


### PR DESCRIPTION
## Why was this change made?

Fixes #1155 

<img width="1413" alt="Screen Shot 2021-02-19 at 2 20 21 PM" src="https://user-images.githubusercontent.com/2294288/108567829-d0a82d00-72bd-11eb-8485-a14f058e9d13.png">


## How was this change tested?

N/A

## Which documentation and/or configurations were updated?

N/A


