### PR TITLE
Update Devise.email_regex to allow for more than one subdomain

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -184,7 +184,7 @@ Devise.setup do |config|
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /[a-z0-9._%+-]+@[a-z0-9-]+\.[a-z]{2,63}/
+  config.email_regexp = /[a-z0-9._%+-]+@[a-z0-9-]+\.([a-z]{2,63})+/
   # NOTE: this regex was modified to enforce stricter validation of email addresses (of a pattern XXX@XX.XX)
   #    and is used in all locations where an email address is validated (not just for devise).  Nov 2020
 


### PR DESCRIPTION
## Why was this change made?

Fixes #1145 by allowing for additional domains (i.e. `stanford.edu` as well as `lists.stanford.edu`) as valid email addresses.

## How was this change tested?

N/A

## Which documentation and/or configurations were updated?

N/A

