### PR TITLE
Convert the depositors field to a text area

### DIFF
--- a/app/components/collections/form_component.html.erb
+++ b/app/components/collections/form_component.html.erb
@@ -131,7 +131,7 @@
         <%= render PopoverComponent.new key: 'collection.depositors' %>
       </div>
       <div class="col-sm-10 col-xl-8">
-        <%= form.text_field :depositor_sunets, class: "form-control" %>
+        <%= form.text_area :depositor_sunets, class: "form-control" %>
       </div>
     </div>
 


### PR DESCRIPTION


## Why was this change made?
Fixes #1166




## How was this change tested?

<img width="1124" alt="Screen Shot 2021-02-23 at 1 01 13 PM" src="https://user-images.githubusercontent.com/92044/108894107-7ff34580-75d7-11eb-9750-7e07997f2f0b.png">


## Which documentation and/or configurations were updated?



