### PR TITLE
fix Cocina deposit creation for PURL reservation

### DIFF
--- a/app/models/work_type.rb
+++ b/app/models/work_type.rb
@@ -92,7 +92,8 @@ class WorkType
 
   sig { returns(WorkType) }
   def self.purl_reservation_type
-    new(id: 'purl_reservation', label: 'PURL reservation', icon: '', subtypes: [], cocina_type: 'n/a')
+    new(id: 'purl_reservation', label: 'PURL reservation', icon: '', subtypes: [],
+        cocina_type: Cocina::Models::Vocab.object)
   end
 
   sig { params(id: T.nilable(String)).returns(WorkType) }

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -125,6 +125,6 @@ FactoryBot.define do
     abstract { '' }
     citation { nil }
     license { 'none' }
-    state { 'purl_reserved' }
+    state { 'reserving_purl' }
   end
 end

--- a/spec/jobs/deposit_job_spec.rb
+++ b/spec/jobs/deposit_job_spec.rb
@@ -51,8 +51,7 @@ RSpec.describe DepositJob do
         build(:work_version, :reserving_purl, work: work)
       end
 
-      # TODO: failing because purl reservation placeholder type is not valid cocina type
-      xit 'calls CreateResource.run with false for the accession param' do
+      it 'calls CreateResource.run with false for the accession param' do
         described_class.perform_now(work_version)
         expect(SdrClient::Deposit::CreateResource).to have_received(:run).with(a_hash_including(accession: false))
       end


### PR DESCRIPTION
- `WorkType.purl_reservation_type.cocina_type` becomes a valid cocina type (`Cocina::Models::Vocab.object` instead of `'n/a'`)
- fix `reserving_purl` trait for `work_version` FactoryBot fixture to have the `reserving_purl` state (instead of copypasta `purl_reserved` state)
- unskip `deposit_job_spec.rb` test now that the above two changes allow it to pass

## Why was this change made?

This is part of the fix for #1191 (generate valid a valid Cocina model so that initial SDR resource gets created and a PURL is reserved).

The other part of fix for #1191 will be preventing editing/type selection for the work until the PURL is reserved.  That will prevent having to add a bunch of state transitions (as tried in #1202).  The simpler approach of preventing editing in the initial purl reservation states has the upside of keeping the state machine simpler (at the expense of briefly disallowing editing, though PURL reservation should finish quickly).

## How was this change tested?

unit tests, tested PURL reservation using this branch on stage.

## Which documentation and/or configurations were updated?

n/a