### PR TITLE
Don't raise errors when running feature specs

### DIFF
--- a/spec/support/feature_errors.rb
+++ b/spec/support/feature_errors.rb
@@ -1,0 +1,29 @@
+# typed: false
+# frozen_string_literal: true
+
+# Allow the feature tests to respond like production (e.g. respond with a 404 rather than an exception)
+# See https://github.com/eliotsykes/rspec-rails-examples#testing-production-errors
+
+module ErrorResponses
+  # See: https://github.com/rails/rails/pull/11289#issuecomment-118612393
+  def respond_without_detailed_exceptions
+    env_config = Rails.application.env_config
+    original_show_exceptions = env_config['action_dispatch.show_exceptions']
+    original_show_detailed_exceptions = env_config['action_dispatch.show_detailed_exceptions']
+    env_config['action_dispatch.show_exceptions'] = true
+    env_config['action_dispatch.show_detailed_exceptions'] = false
+    yield
+  ensure
+    env_config['action_dispatch.show_exceptions'] = original_show_exceptions
+    env_config['action_dispatch.show_detailed_exceptions'] = original_show_detailed_exceptions
+  end
+end
+
+RSpec.configure do |config|
+  config.include ErrorResponses, type: :feature
+  config.around :each, type: :feature do |example|
+    respond_without_detailed_exceptions do
+      example.run
+    end
+  end
+end


### PR DESCRIPTION


## Why was this change made?

Instead respond with production like responses (e.g. 404 rather than ActiveRecord::RecordNotFound).

This fixes the build because the delete test can delete a record before the delete_button endpoint is called, which leads it to raise a RecordNotFound.  This is handled as expected if it returns a 404 instead.

This code was also used in the hydra_etd project

## How was this change tested?



## Which documentation and/or configurations were updated?



