### PR TITLE
Remove calls to non-existant controller

### DIFF
--- a/app/components/collections/create/form_component.html.erb
+++ b/app/components/collections/create/form_component.html.erb
@@ -1,6 +1,5 @@
 <header>All fields are required, unless otherwise noted.</header>
 <%= form_with model: collection_form,
-    data: { controller: 'edit-collection', },
     html: { class: 'needs-validation collection-editor', novalidate: true, multipart: true } do |form| %>
 
   <% if collection_form.errors.any? %>

--- a/app/components/collections/create/settings_component.html.erb
+++ b/app/components/collections/create/settings_component.html.erb
@@ -112,7 +112,7 @@
 
     <!-- TODO: only display sunet entry field if reviewer workflow is enabled -->
     <p>Enter SUNet IDs of participants. Separate each one with a comma and a space. (e.g. janelath, lelandst)</p>
-    <div class="mb-3 row" data-edit-collection-target="reviewerSunetsField">
+    <div class="mb-3 row">
       <div class="col-sm-2">
         <%= form.label :reviewer_sunets, 'Additional Reviewers', class: 'col-form-label' %>
         <%= render PopoverComponent.new key: 'collection.reviewers' %>

--- a/app/components/collections/update/details_form_component.html.erb
+++ b/app/components/collections/update/details_form_component.html.erb
@@ -1,6 +1,5 @@
 <header>All fields are required, unless otherwise noted.</header>
 <%= form_with model: collection_form,
-    data: { controller: 'edit-collection', },
     html: { class: 'needs-validation collection-editor', novalidate: true, multipart: true } do |form| %>
 
   <% if collection_form.errors.any? %>

--- a/app/components/collections/update/settings_form_component.html.erb
+++ b/app/components/collections/update/settings_form_component.html.erb
@@ -1,6 +1,5 @@
 <header>All fields are required, unless otherwise noted.</header>
 <%= form_with model: collection_form,
-    data: { controller: 'edit-collection', },
     html: { class: 'needs-validation collection-editor', novalidate: true, multipart: true } do |form| %>
 
   <% if collection_form.errors.any? %>


### PR DESCRIPTION


## Why was this change made?
This is leftovers from when we switched to local forms and didn't do error handling in Stimulus. Fixes #1232


## How was this change tested?



## Which documentation and/or configurations were updated?



