### PR TITLE
slightly stricter updatability checks

### DIFF
--- a/app/policies/work_version_policy.rb
+++ b/app/policies/work_version_policy.rb
@@ -28,7 +28,7 @@ class WorkVersionPolicy < ApplicationPolicy
   end
 
   # Can edit a work iff:
-  #   The work is in a state where it can be updated (e.g. not depositing)
+  #   The work is in a state where it can be updated (e.g. not depositing, not an in-progress purl reservation)
   #   AND if any one of the following is true:
   #     1. The user is an administrator
   #     2. The user is the depositor of the work and it is not currently pending approval (review workflow)
@@ -36,11 +36,13 @@ class WorkVersionPolicy < ApplicationPolicy
   #     4. The user is a reviewer of the collection the work is in
   sig { returns(T::Boolean) }
   def update?
+    return false unless record.updatable?
+
     return true if administrator? ||
                    collection.managed_by.include?(user) ||
                    collection.reviewed_by.include?(user)
 
-    depositor? && record.updatable? && !record.pending_approval?
+    depositor? && !record.pending_approval?
   end
   # Can show a work iff any one of the following is true:
   #   1. The user is an administrator

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -119,6 +119,15 @@ FactoryBot.define do
     state { 'purl_reserved' }
   end
 
+  trait :purl_requested do
+    work_type { WorkType.purl_reservation_type.id }
+    subtype { [] }
+    abstract { '' }
+    citation { nil }
+    license { 'none' }
+    state { 'purl_requested' }
+  end
+
   trait :reserving_purl do
     work_type { WorkType.purl_reservation_type.id }
     subtype { [] }

--- a/spec/policies/work_version_policy_spec.rb
+++ b/spec/policies/work_version_policy_spec.rb
@@ -63,6 +63,24 @@ RSpec.describe WorkVersionPolicy do
       let(:record) { build_stubbed :work_version, :depositing, work: work }
     end
 
+    failed 'when user is an admin and status is depositing' do
+      let(:groups) { [Settings.authorization_workgroup_names.administrators] }
+      let(:work) { build_stubbed :work, collection: collection }
+      let(:record) { build_stubbed :work_version, :depositing, work: work }
+    end
+
+    failed 'when user is an admin and status is purl_requested' do
+      let(:groups) { [Settings.authorization_workgroup_names.administrators] }
+      let(:work) { build_stubbed :work, collection: collection }
+      let(:record) { build_stubbed :work_version, :purl_requested, work: work }
+    end
+
+    failed 'when user is an admin and status is reserving_purl' do
+      let(:groups) { [Settings.authorization_workgroup_names.administrators] }
+      let(:work) { build_stubbed :work, collection: collection }
+      let(:record) { build_stubbed :work_version, :reserving_purl, work: work }
+    end
+
     succeed 'when user is an admin and status is not pending_approval' do
       let(:groups) { [Settings.authorization_workgroup_names.administrators] }
     end

--- a/spec/policies/work_version_policy_spec.rb
+++ b/spec/policies/work_version_policy_spec.rb
@@ -63,31 +63,29 @@ RSpec.describe WorkVersionPolicy do
       let(:record) { build_stubbed :work_version, :depositing, work: work }
     end
 
-    failed 'when user is an admin and status is depositing' do
+    context 'when user is an admin' do
       let(:groups) { [Settings.authorization_workgroup_names.administrators] }
-      let(:work) { build_stubbed :work, collection: collection }
-      let(:record) { build_stubbed :work_version, :depositing, work: work }
-    end
 
-    failed 'when user is an admin and status is purl_requested' do
-      let(:groups) { [Settings.authorization_workgroup_names.administrators] }
-      let(:work) { build_stubbed :work, collection: collection }
-      let(:record) { build_stubbed :work_version, :purl_requested, work: work }
-    end
+      failed 'when status is depositing' do
+        let(:work) { build_stubbed :work, collection: collection }
+        let(:record) { build_stubbed :work_version, :depositing, work: work }
+      end
 
-    failed 'when user is an admin and status is reserving_purl' do
-      let(:groups) { [Settings.authorization_workgroup_names.administrators] }
-      let(:work) { build_stubbed :work, collection: collection }
-      let(:record) { build_stubbed :work_version, :reserving_purl, work: work }
-    end
+      failed 'when status is purl_requested' do
+        let(:work) { build_stubbed :work, collection: collection }
+        let(:record) { build_stubbed :work_version, :purl_requested, work: work }
+      end
 
-    succeed 'when user is an admin and status is not pending_approval' do
-      let(:groups) { [Settings.authorization_workgroup_names.administrators] }
-    end
+      failed 'when status is reserving_purl' do
+        let(:work) { build_stubbed :work, collection: collection }
+        let(:record) { build_stubbed :work_version, :reserving_purl, work: work }
+      end
 
-    succeed 'when user is an admin and status is pending_approval' do
-      let(:groups) { [Settings.authorization_workgroup_names.administrators] }
-      let(:record) { build_stubbed :work_version, :pending_approval, work: work }
+      succeed 'when status is not pending_approval'
+
+      succeed 'when status is pending_approval' do
+        let(:record) { build_stubbed :work_version, :pending_approval, work: work }
+      end
     end
 
     succeed 'when user is a collection manager and status is not pending_approval' do


### PR DESCRIPTION
## Why was this change made?

closes #1191 (should prevent the state transition error i ran into)
closes #1200

* ~~`WorkVersion#updatable?` -- can't update something in the initial stages of PURL reservation, because the `update_metadata!` from `purl_reserved` brings the work version to draft.  If picking type and the first two PURL reservation states (`purl_requested`, `reserving_purl`) could happen in any order, it'd make the possible [states and transitions balloon](https://github.com/sul-dlss/happy-heron/pull/1202#issuecomment-786371113), to little benefit (since in most cases PURL reservation should happen quickly, and should block type selection and metadata update for only a few seconds).  See also https://github.com/sul-dlss/happy-heron/pull/1202 and https://github.com/sul-dlss/happy-heron/issues/1191~~ (as @jcoyne observed, this change was unnecessary, because the state defs already enforced it)
* consistency for `WorkVersionPolicy#update?` -- can't update something if it's not in an updatable state (even for admins/managers/reviewers -- no one's allowed to make illegal state transitions). `Collections::EditLinkComponent` and `Works::EditLinkComponent` already decline to render if the work or collection isn't updatable.
* `work_version_policy_spec.rb` -- a bit of additional testing, a bit of `context` grouping

## How was this change tested?

unit tests, local dev instance (notice no edit link for `Reserving PURL`, but still get an edit link for the one that's reserved):
<img width="1414" alt="Screen Shot 2021-03-02 at 4 45 18 PM" src="https://user-images.githubusercontent.com/7741604/109734962-bcdeaf80-7b76-11eb-97ea-68679f358813.png">


## Which documentation and/or configurations were updated?

n/a

