### PR TITLE
use a default name for users if none is found

### DIFF
--- a/app/mailers/collections_mailer.rb
+++ b/app/mailers/collections_mailer.rb
@@ -4,14 +4,14 @@
 # Sends email notifications about collections
 class CollectionsMailer < ApplicationMailer
   def invitation_to_deposit_email
-    @user = params[:user]
+    @user = UserPresenter.new(user: params[:user])
     @collection_version = params[:collection_version]
     @collection = @collection_version.collection
     mail(to: @user.email, subject: "Invitation to deposit to the #{@collection_version.name} collection in the SDR")
   end
 
   def deposit_access_removed_email
-    @user = params[:user]
+    @user = UserPresenter.new(user: params[:user])
     @collection_version = params[:collection_version]
     @collection = @collection_version.collection
     mail(to: @user.email, subject: "Your Depositor permissions for the #{@collection_version.name} " \
@@ -19,14 +19,14 @@ class CollectionsMailer < ApplicationMailer
   end
 
   def manage_access_granted_email
-    @user = params[:user]
+    @user = UserPresenter.new(user: params[:user])
     @collection_version = params[:collection_version]
     mail(to: @user.email, subject: "You are invited to participate as a Manager in the #{@collection_version.name} " \
       'collection in the SDR')
   end
 
   def manage_access_removed_email
-    @user = params[:user]
+    @user = UserPresenter.new(user: params[:user])
     @collection_version = params[:collection_version]
     @collection = @collection_version.collection
     mail(to: @user.email, subject: "Your permissions have changed for the #{@collection_version.name} " \
@@ -34,14 +34,14 @@ class CollectionsMailer < ApplicationMailer
   end
 
   def review_access_granted_email
-    @user = params[:user]
+    @user = UserPresenter.new(user: params[:user])
     @collection_version = params[:collection_version]
     mail(to: @user.email, subject: "You are invited to participate as a Reviewer in the #{@collection_version.name} " \
       'collection in the SDR')
   end
 
   def review_access_removed_email
-    @user = params[:user]
+    @user = UserPresenter.new(user: params[:user])
     @collection_version = params[:collection_version]
     @collection = @collection_version.collection
     mail(to: @user.email, subject: "Your permissions have changed for the #{@collection_version.name} " \
@@ -49,7 +49,7 @@ class CollectionsMailer < ApplicationMailer
   end
 
   def collection_activity
-    @user = params[:user]
+    @user = UserPresenter.new(user: params[:user])
     @collection_version = params[:collection_version]
     @depositor = params[:depositor]
 
@@ -57,7 +57,7 @@ class CollectionsMailer < ApplicationMailer
   end
 
   def participants_changed_email
-    @user = params[:user]
+    @user = UserPresenter.new(user: params[:user])
     @collection_version = params[:collection_version]
     mail(to: @user.email, subject: "Participant changes for the #{@collection_version.name} collection in the SDR")
   end

--- a/app/mailers/reviewers_mailer.rb
+++ b/app/mailers/reviewers_mailer.rb
@@ -4,7 +4,7 @@
 # Sends emails to people who review deposits
 class ReviewersMailer < ApplicationMailer
   def submitted_email
-    @user = params[:user]
+    @user = UserPresenter.new(user: params[:user])
     @work_version = params[:work_version]
     @work = @work_version.work
     mail(to: @user.email, subject: "New deposit activity in the #{@work.collection_name} collection")

--- a/app/mailers/works_mailer.rb
+++ b/app/mailers/works_mailer.rb
@@ -4,14 +4,14 @@
 # Sends email notifications about works
 class WorksMailer < ApplicationMailer
   def approved_email
-    @user = params[:user]
+    @user = UserPresenter.new(user: params[:user])
     @work_version = params[:work_version]
     @work = @work_version.work
     mail(to: @user.email, subject: 'Your deposit has been reviewed and approved')
   end
 
   def deposited_email
-    @user = params[:user]
+    @user = UserPresenter.new(user: params[:user])
     @work_version = params[:work_version]
     @work = @work_version.work
     mail(to: @user.email, subject: "Your deposit, #{@work_version.title}, is published in the SDR")
@@ -19,7 +19,7 @@ class WorksMailer < ApplicationMailer
 
   def first_draft_reminder_email
     @work = params[:work_version].work
-    @user = @work.depositor
+    @user = UserPresenter.new(user: @work.depositor)
     subject = "Reminder: Deposit to the #{@work.collection_name} collection in the SDR is in progress"
 
     mail(to: @user.email, subject: subject)
@@ -27,7 +27,7 @@ class WorksMailer < ApplicationMailer
 
   def new_version_reminder_email
     @work = params[:work_version].work
-    @user = @work.depositor
+    @user = UserPresenter.new(user: @work.depositor)
 
     subject = "Reminder: New version of a deposit to the #{@work.collection_name} collection in the SDR is in progress"
 
@@ -35,21 +35,21 @@ class WorksMailer < ApplicationMailer
   end
 
   def new_version_deposited_email
-    @user = params[:user]
+    @user = UserPresenter.new(user: params[:user])
     @work_version = params[:work_version]
     @work = @work_version.work
     mail(to: @user.email, subject: "A new version of #{@work_version.title} has been deposited in the SDR")
   end
 
   def reject_email
-    @user = params[:user]
+    @user = UserPresenter.new(user: params[:user])
     @work_version = params[:work_version]
     @work = @work_version.work
     mail(to: @user.email, subject: 'Your deposit has been reviewed and returned')
   end
 
   def submitted_email
-    @user = params[:user]
+    @user = UserPresenter.new(user: params[:user])
     @work_version = params[:work_version]
     @work = @work_version.work
     mail(to: @user.email, subject: 'Your deposit is submitted and waiting for approval')

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -1,0 +1,20 @@
+# typed: true
+# frozen_string_literal: true
+
+# A class for the user model presentation
+class UserPresenter
+  extend T::Sig
+
+  def initialize(user:)
+    @model = user
+  end
+
+  attr_reader :model
+
+  sig { returns(String) }
+  def name
+    model.name || 'New SDR User' # return either the name in the database or a default if none exists (i.e. new users)
+  end
+
+  delegate :email, to: :model
+end

--- a/spec/mailers/collections_mailer_spec.rb
+++ b/spec/mailers/collections_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
   let(:collection_name) { collection_version.name }
   let(:collection) { build_stubbed(:collection) }
 
-  describe '#invitation_to_deposit_email' do
+  describe '#invitation_to_deposit_email for new user with no name' do
     let(:user) { collection.depositors.first }
     let(:mail) { described_class.with(user: user, collection_version: collection_version).invitation_to_deposit_email }
     let(:collection) { build_stubbed(:collection, :with_depositors) }
@@ -20,6 +20,26 @@ RSpec.describe CollectionsMailer, type: :mailer do
     end
 
     it 'renders the body' do
+      expect(mail.body.encoded).to match('Dear New SDR User,')
+      expect(mail.body.encoded).to match("You have been invited to deposit to the #{collection_name} collection")
+    end
+  end
+
+  describe '#invitation_to_deposit_email for user with a name' do
+    let(:user) { collection.depositors.first }
+    let(:mail) { described_class.with(user: user, collection_version: collection_version).invitation_to_deposit_email }
+    let(:collection) { build_stubbed(:collection, :with_depositors) }
+
+    before { user.update(name: 'Smart Person') }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq "Invitation to deposit to the #{collection_name} collection in the SDR"
+      expect(mail.to).to eq [user.email]
+      expect(mail.from).to eq ['no-reply@sdr.stanford.edu']
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to match('Dear Smart Person,')
       expect(mail.body.encoded).to match("You have been invited to deposit to the #{collection_name} collection")
     end
   end


### PR DESCRIPTION
## Why was this change made?

Fixes #1220 - show a default name for users (this will work in both emails and anywhere else user names are used, which would otherwise result in blank showing)

## How was this change tested?

Added a new test

## Which documentation and/or configurations were updated?



