### PR TITLE
Update resource type and genre mappings

### DIFF
--- a/app/components/collections/update/settings_form_component.html.erb
+++ b/app/components/collections/update/settings_form_component.html.erb
@@ -22,11 +22,7 @@
 
   <div class="row">
     <div class="col text-end">
-<<<<<<< HEAD
       <%= link_to 'Cancel', dashboard_path, class: 'btn btn-link' %>
-=======
-      <%= link_to 'Cancel', dashboard_path %>
->>>>>>> f031a34f (Prevent navigating away from changed forms)
       <%= form.submit 'Save', class: 'btn btn-primary', data: { action: 'unsaved-changes#allowFormSubmission' } %>
     </div>
   </div>

--- a/app/components/collections/update/settings_form_component.html.erb
+++ b/app/components/collections/update/settings_form_component.html.erb
@@ -22,7 +22,11 @@
 
   <div class="row">
     <div class="col text-end">
+<<<<<<< HEAD
       <%= link_to 'Cancel', dashboard_path, class: 'btn btn-link' %>
+=======
+      <%= link_to 'Cancel', dashboard_path %>
+>>>>>>> f031a34f (Prevent navigating away from changed forms)
       <%= form.submit 'Save', class: 'btn btn-primary', data: { action: 'unsaved-changes#allowFormSubmission' } %>
     </div>
   </div>

--- a/app/services/types_generator.rb
+++ b/app/services/types_generator.rb
@@ -79,7 +79,7 @@ class TypesGenerator
     return [] if work_type == 'Other'
 
     # add the top level resource type mapping (i.e. top level work type with no subtype)
-    resource_types = [types_to_resource_types.dig(work_type, 'type')]
+    resource_types = Array(types_to_resource_types.dig(work_type, 'type'))
 
     # uniq and compact the list of resource types, since multiple subtypes can map
     # to the same resource type but we only need them mapped once

--- a/app/services/types_generator.rb
+++ b/app/services/types_generator.rb
@@ -64,7 +64,7 @@ class TypesGenerator
     # add the top level genre mapping (i.e. top level work type with no subtype)
     type_genres = types_to_genres.dig(work_type, 'type') || []
 
-    all_genres = type_genres + subtype_genres
+    all_genres = (type_genres + subtype_genres).uniq
     all_genres.map { |genre| Cocina::Models::DescriptiveValue.new(genre) }
   end
 

--- a/app/services/types_generator.rb
+++ b/app/services/types_generator.rb
@@ -64,6 +64,9 @@ class TypesGenerator
     # add the top level genre mapping (i.e. top level work type with no subtype)
     type_genres = types_to_genres.dig(work_type, 'type') || []
 
+    # NOTE: we should not add duplicate genres if the same one is coming from both the top level mapping and then the
+    # sub-type. We will try and avoid duplicating in the `types_to_genres.yml` mappings, but this `.uniq` ensures it.
+    # see https://github.com/sul-dlss/happy-heron/issues/1254#issuecomment-790935330
     all_genres = (type_genres + subtype_genres).uniq
     all_genres.map { |genre| Cocina::Models::DescriptiveValue.new(genre) }
   end

--- a/config/mappings/types_to_genres.yml
+++ b/config/mappings/types_to_genres.yml
@@ -1,5014 +1,5057 @@
 Data:
-  3D model:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Animation:
-    - type: genre
-      value: animations (visual works)
-      uri: http://vocab.getty.edu/aat/300411663
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Article:
-    - type: genre
-      value: articles
-      uri: http://vocab.getty.edu/aat/300048715
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Book:
-    - type: genre
-      value: books
-      uri: http://vocab.getty.edu/aat/300028051
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Book chapter:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Broadcast:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  CAD:
-    - type: genre
-      value: computer-aided designs (visual works)
-      uri: http://vocab.getty.edu/aat/300418056
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Code:
-    - type: genre
-      value: programs (computer)
-      uri: http://vocab.getty.edu/aat/300312188
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Conference session:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Correspondence:
-    - type: genre
-      value: correspondence
-      uri: http://vocab.getty.edu/aat/300026877
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Course/instructional materials:
-    - type: genre
-      value: Instructional and educational works
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Data:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Database:
-    - type: genre
-      value: Databases
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Documentary:
-    - type: genre
-      value: documentaries (documents)
-      uri: http://vocab.getty.edu/aat/300249172
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Documentation:
-    - type: genre
-      value: Data dictionaries
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026080
-      source:
-         code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Dramatic performance:
-    - type: genre
-      value: Drama
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Essay:
-    - type: genre
-      value: Essays
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Ethnography:
-    - type: genre
-      value: Ethnographies
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Event:
-    - type: genre
-      value: events (activities)
-      uri: http://vocab.getty.edu/aat/300069084
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Experimental audio/video:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Field recording:
-    - type: genre
-      value: Field recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Game:
-    - type: genre
-      value: computer game
-      uri: http://vocab.getty.edu/aat/300422211
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Geospatial data:
-    - type: genre
-      value: Geographic information systems
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Government document:
-    - type: genre
-      value: government records
-      uri: http://vocab.getty.edu/aat/300027777
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Image:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Interview:
-    - type: genre
-      value: Interviews
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Journal/periodical issue:
-    - type: genre
-      value: Periodicals
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Manuscript:
-    - type: genre
-      value: manuscripts (documents)
-      uri: http://vocab.getty.edu/aat/300028569
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Map:
-    - type: genre
-      value: Maps
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  MIDI:
-    - type: genre
-      value: MIDI (information technology)
-      uri: http://vocab.getty.edu/aat/300266746
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Musical transcription:
-    - type: genre
-      value: transcriptions (documents)
-      uri: http://vocab.getty.edu/aat/300404333
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Notated music:
-    - type: genre
-      value: Notated music
-      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Narrative film:
-    - type: genre
-      value: Fiction films
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Oral history:
-    - type: genre
-      value: Oral histories
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Other spoken word:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Performance:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Photograph:
-    - type: genre
-      value: Photographs
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Piano roll:
-    - type: genre
-      value: music rolls
-      uri: http://vocab.getty.edu/aat/300429369
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Podcast:
-    - type: genre
-      value: Podcasts
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Poetry reading:
-    - type: genre
-      value: Poetry
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Policy brief:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Poster:
-    - type: genre
-      value: Posters
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Preprint:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Presentation recording:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Presentation slides:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Questionnaire:
-    - type: genre
-      value: Questionnaires
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Remote sensing imagery:
-    - type: genre
-      value: Remote-sensing images
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Report:
-    - type: genre
-      value: reports
-      uri: http://vocab.getty.edu/aat/300027267
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Software:
-    - type: genre
-      value: software
-      uri: http://vocab.getty.edu/aat/300028566
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Sound recording:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Speaker notes:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Speech:
-    - type: genre
-      value: Speeches
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Statistical model:
-    - type: genre
-      value: mathematical models
-      uri: http://vocab.getty.edu/aat/300065075
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Story:
-    - type: genre
-      value: Fiction
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Syllabus:
-    - type: genre
-      value: Outlines and syllabi
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Tabular data:
-    - type: genre
-      value: Tables (data)
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Technical report:
-    - type: genre
-      value: Technical reports
-      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Text corpus:
-    - type: genre
-      value: Text corpora
-      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Text:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Thesis:
-    - type: genre
-      value: Academic theses
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Transcript:
-    - type: genre
-      value: transcripts
-      uri: http://vocab.getty.edu/aat/300027388
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Unedited recording:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Video art:
-    - type: genre
-      value: Video art
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Video recording:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  White paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Working paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
+  type:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  subtypes:
+    3D model:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Animation:
+      - type: genre
+        value: animations (visual works)
+        uri: http://vocab.getty.edu/aat/300411663
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Article:
+      - type: genre
+        value: articles
+        uri: http://vocab.getty.edu/aat/300048715
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Book:
+      - type: genre
+        value: books
+        uri: http://vocab.getty.edu/aat/300028051
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Book chapter:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Broadcast:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    CAD:
+      - type: genre
+        value: computer-aided designs (visual works)
+        uri: http://vocab.getty.edu/aat/300418056
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Code:
+      - type: genre
+        value: programs (computer)
+        uri: http://vocab.getty.edu/aat/300312188
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Conference session:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Correspondence:
+      - type: genre
+        value: correspondence
+        uri: http://vocab.getty.edu/aat/300026877
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Course/instructional materials:
+      - type: genre
+        value: Instructional and educational works
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Data:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Database:
+      - type: genre
+        value: Databases
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Documentary:
+      - type: genre
+        value: documentaries (documents)
+        uri: http://vocab.getty.edu/aat/300249172
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Documentation:
+      - type: genre
+        value: Data dictionaries
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026080
+        source:
+           code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Dramatic performance:
+      - type: genre
+        value: Drama
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Essay:
+      - type: genre
+        value: Essays
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Ethnography:
+      - type: genre
+        value: Ethnographies
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Event:
+      - type: genre
+        value: events (activities)
+        uri: http://vocab.getty.edu/aat/300069084
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Experimental audio/video:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Field recording:
+      - type: genre
+        value: Field recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Game:
+      - type: genre
+        value: computer game
+        uri: http://vocab.getty.edu/aat/300422211
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Geospatial data:
+      - type: genre
+        value: Geographic information systems
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Government document:
+      - type: genre
+        value: government records
+        uri: http://vocab.getty.edu/aat/300027777
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Image:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Interview:
+      - type: genre
+        value: Interviews
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Journal/periodical issue:
+      - type: genre
+        value: Periodicals
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Manuscript:
+      - type: genre
+        value: manuscripts (documents)
+        uri: http://vocab.getty.edu/aat/300028569
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Map:
+      - type: genre
+        value: Maps
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    MIDI:
+      - type: genre
+        value: MIDI (information technology)
+        uri: http://vocab.getty.edu/aat/300266746
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Musical transcription:
+      - type: genre
+        value: transcriptions (documents)
+        uri: http://vocab.getty.edu/aat/300404333
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Notated music:
+      - type: genre
+        value: Notated music
+        uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Narrative film:
+      - type: genre
+        value: Fiction films
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Oral history:
+      - type: genre
+        value: Oral histories
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Other spoken word:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Performance:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Photograph:
+      - type: genre
+        value: Photographs
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Piano roll:
+      - type: genre
+        value: music rolls
+        uri: http://vocab.getty.edu/aat/300429369
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Podcast:
+      - type: genre
+        value: Podcasts
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Poetry reading:
+      - type: genre
+        value: Poetry
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Policy brief:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Poster:
+      - type: genre
+        value: Posters
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Preprint:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Presentation recording:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Presentation slides:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Questionnaire:
+      - type: genre
+        value: Questionnaires
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Remote sensing imagery:
+      - type: genre
+        value: Remote-sensing images
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Report:
+      - type: genre
+        value: reports
+        uri: http://vocab.getty.edu/aat/300027267
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Software:
+      - type: genre
+        value: software
+        uri: http://vocab.getty.edu/aat/300028566
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Sound recording:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Speaker notes:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Speech:
+      - type: genre
+        value: Speeches
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Statistical model:
+      - type: genre
+        value: mathematical models
+        uri: http://vocab.getty.edu/aat/300065075
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Story:
+      - type: genre
+        value: Fiction
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Syllabus:
+      - type: genre
+        value: Outlines and syllabi
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Tabular data:
+      - type: genre
+        value: Tables (data)
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Technical report:
+      - type: genre
+        value: Technical reports
+        uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Text corpus:
+      - type: genre
+        value: Text corpora
+        uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Text:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Thesis:
+      - type: genre
+        value: Academic theses
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Transcript:
+      - type: genre
+        value: transcripts
+        uri: http://vocab.getty.edu/aat/300027388
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Unedited recording:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Video art:
+      - type: genre
+        value: Video art
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Video recording:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    White paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Working paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
 Image:
-  3D model:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Animation:
-    - type: genre
-      value: animations (visual works)
-      uri: http://vocab.getty.edu/aat/300411663
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Article:
-    - type: genre
-      value: articles
-      uri: http://vocab.getty.edu/aat/300048715
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Book:
-    - type: genre
-      value: books
-      uri: http://vocab.getty.edu/aat/300028051
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Book chapter:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Broadcast:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  CAD:
-    - type: genre
-      value: computer-aided designs (visual works)
-      uri: http://vocab.getty.edu/aat/300418056
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Code:
-    - type: genre
-      value: programs (computer)
-      uri: http://vocab.getty.edu/aat/300312188
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Conference session:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Correspondence:
-    - type: genre
-      value: correspondence
-      uri: http://vocab.getty.edu/aat/300026877
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Course/instructional materials:
-    - type: genre
-      value: Instructional and educational works
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Data:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Database:
-    - type: genre
-      value: Databases
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Documentary:
-    - type: genre
-      value: documentaries (documents)
-      uri: http://vocab.getty.edu/aat/300249172
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Documentation:
-    - type: genre
-      value: technical manuals
-      uri: http://vocab.getty.edu/aat/300026413
-      source:
-         code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Dramatic performance:
-    - type: genre
-      value: Drama
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Essay:
-    - type: genre
-      value: Essays
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Ethnography:
-    - type: genre
-      value: Ethnographies
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Event:
-    - type: genre
-      value: events (activities)
-      uri: http://vocab.getty.edu/aat/300069084
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Experimental audio/video:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Field recording:
-    - type: genre
-      value: Field recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Game:
-    - type: genre
-      value: computer game
-      uri: http://vocab.getty.edu/aat/300422211
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Geospatial data:
-    - type: genre
-      value: Geographic information systems
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Government document:
-    - type: genre
-      value: government records
-      uri: http://vocab.getty.edu/aat/300027777
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Image:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Interview:
-    - type: genre
-      value: Interviews
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Journal/periodical issue:
-    - type: genre
-      value: Periodicals
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Manuscript:
-    - type: genre
-      value: manuscripts (documents)
-      uri: http://vocab.getty.edu/aat/300028569
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Map:
-    - type: genre
-      value: Maps
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  MIDI:
-    - type: genre
-      value: MIDI (information technology)
-      uri: http://vocab.getty.edu/aat/300266746
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Musical transcription:
-    - type: genre
-      value: transcriptions (documents)
-      uri: http://vocab.getty.edu/aat/300404333
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Notated music:
-    - type: genre
-      value: Notated music
-      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Narrative film:
-    - type: genre
-      value: Fiction films
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Oral history:
-    - type: genre
-      value: Oral histories
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Other spoken word:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Performance:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Photograph:
-    - type: genre
-      value: Photographs
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Piano roll:
-    - type: genre
-      value: music rolls
-      uri: http://vocab.getty.edu/aat/300429369
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Podcast:
-    - type: genre
-      value: Podcasts
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Poetry reading:
-    - type: genre
-      value: Poetry
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Policy brief:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Poster:
-    - type: genre
-      value: Posters
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Preprint:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Presentation recording:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Presentation slides:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Questionnaire:
-    - type: genre
-      value: Questionnaires
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Remote sensing imagery:
-    - type: genre
-      value: Remote-sensing images
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Report:
-    - type: genre
-      value: reports
-      uri: http://vocab.getty.edu/aat/300027267
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Software:
-    - type: genre
-      value: software
-      uri: http://vocab.getty.edu/aat/300028566
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Sound recording:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Speaker notes:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Speech:
-    - type: genre
-      value: Speeches
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Statistical model:
-    - type: genre
-      value: mathematical models
-      uri: http://vocab.getty.edu/aat/300065075
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Story:
-    - type: genre
-      value: Fiction
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Syllabus:
-    - type: genre
-      value: Outlines and syllabi
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Tabular data:
-    - type: genre
-      value: Tables (data)
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Technical report:
-    - type: genre
-      value: Technical reports
-      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Text corpus:
-    - type: genre
-      value: Text corpora
-      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Text:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Thesis:
-    - type: genre
-      value: Academic theses
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Transcript:
-    - type: genre
-      value: transcripts
-      uri: http://vocab.getty.edu/aat/300027388
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Unedited recording:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Video art:
-    - type: genre
-      value: Video art
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
-      source:
-        code: lcgft
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Video recording:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  White paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Working paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
+  type:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  subtypes:
+    3D model:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Animation:
+      - type: genre
+        value: animations (visual works)
+        uri: http://vocab.getty.edu/aat/300411663
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Article:
+      - type: genre
+        value: articles
+        uri: http://vocab.getty.edu/aat/300048715
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Book:
+      - type: genre
+        value: books
+        uri: http://vocab.getty.edu/aat/300028051
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Book chapter:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Broadcast:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    CAD:
+      - type: genre
+        value: computer-aided designs (visual works)
+        uri: http://vocab.getty.edu/aat/300418056
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Code:
+      - type: genre
+        value: programs (computer)
+        uri: http://vocab.getty.edu/aat/300312188
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Conference session:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Correspondence:
+      - type: genre
+        value: correspondence
+        uri: http://vocab.getty.edu/aat/300026877
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Course/instructional materials:
+      - type: genre
+        value: Instructional and educational works
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Data:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Database:
+      - type: genre
+        value: Databases
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Documentary:
+      - type: genre
+        value: documentaries (documents)
+        uri: http://vocab.getty.edu/aat/300249172
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Documentation:
+      - type: genre
+        value: technical manuals
+        uri: http://vocab.getty.edu/aat/300026413
+        source:
+           code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Dramatic performance:
+      - type: genre
+        value: Drama
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Essay:
+      - type: genre
+        value: Essays
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Ethnography:
+      - type: genre
+        value: Ethnographies
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Event:
+      - type: genre
+        value: events (activities)
+        uri: http://vocab.getty.edu/aat/300069084
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Experimental audio/video:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Field recording:
+      - type: genre
+        value: Field recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Game:
+      - type: genre
+        value: computer game
+        uri: http://vocab.getty.edu/aat/300422211
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Geospatial data:
+      - type: genre
+        value: Geographic information systems
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Government document:
+      - type: genre
+        value: government records
+        uri: http://vocab.getty.edu/aat/300027777
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Image:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Interview:
+      - type: genre
+        value: Interviews
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Journal/periodical issue:
+      - type: genre
+        value: Periodicals
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Manuscript:
+      - type: genre
+        value: manuscripts (documents)
+        uri: http://vocab.getty.edu/aat/300028569
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Map:
+      - type: genre
+        value: Maps
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    MIDI:
+      - type: genre
+        value: MIDI (information technology)
+        uri: http://vocab.getty.edu/aat/300266746
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Musical transcription:
+      - type: genre
+        value: transcriptions (documents)
+        uri: http://vocab.getty.edu/aat/300404333
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Notated music:
+      - type: genre
+        value: Notated music
+        uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Narrative film:
+      - type: genre
+        value: Fiction films
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Oral history:
+      - type: genre
+        value: Oral histories
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Other spoken word:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Performance:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Photograph:
+      - type: genre
+        value: Photographs
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Piano roll:
+      - type: genre
+        value: music rolls
+        uri: http://vocab.getty.edu/aat/300429369
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Podcast:
+      - type: genre
+        value: Podcasts
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Poetry reading:
+      - type: genre
+        value: Poetry
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Policy brief:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Poster:
+      - type: genre
+        value: Posters
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Preprint:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Presentation recording:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Presentation slides:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Questionnaire:
+      - type: genre
+        value: Questionnaires
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Remote sensing imagery:
+      - type: genre
+        value: Remote-sensing images
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Report:
+      - type: genre
+        value: reports
+        uri: http://vocab.getty.edu/aat/300027267
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Software:
+      - type: genre
+        value: software
+        uri: http://vocab.getty.edu/aat/300028566
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Sound recording:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Speaker notes:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Speech:
+      - type: genre
+        value: Speeches
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Statistical model:
+      - type: genre
+        value: mathematical models
+        uri: http://vocab.getty.edu/aat/300065075
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Story:
+      - type: genre
+        value: Fiction
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Syllabus:
+      - type: genre
+        value: Outlines and syllabi
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Tabular data:
+      - type: genre
+        value: Tables (data)
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Technical report:
+      - type: genre
+        value: Technical reports
+        uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Text corpus:
+      - type: genre
+        value: Text corpora
+        uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Text:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Thesis:
+      - type: genre
+        value: Academic theses
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Transcript:
+      - type: genre
+        value: transcripts
+        uri: http://vocab.getty.edu/aat/300027388
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Unedited recording:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Video art:
+      - type: genre
+        value: Video art
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+        source:
+          code: lcgft
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Video recording:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    White paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Working paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
 Mixed Materials:
-  Animation:
-    - type: genre
-      value: animations (visual works)
-      uri: http://vocab.getty.edu/aat/300411663
-      source:
-        code: aat
-  Article:
-    - type: genre
-      value: articles
-      uri: http://vocab.getty.edu/aat/300048715
-      source:
-        code: aat
-  Book:
-    - type: genre
-      value: books
-      uri: http://vocab.getty.edu/aat/300028051
-      source:
-        code: aat
-  CAD:
-    - type: genre
-      value: computer-aided designs (visual works)
-      uri: http://vocab.getty.edu/aat/300418056
-      source:
-        code: aat
-  Code:
-    - type: genre
-      value: programs (computer)
-      uri: http://vocab.getty.edu/aat/300312188
-      source:
-        code: aat
-  Correspondence:
-    - type: genre
-      value: correspondence
-      uri: http://vocab.getty.edu/aat/300026877
-      source:
-        code: aat
-  Course/instructional materials:
-    - type: genre
-      value: Instructional and educational works
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-      source:
-        code: lcgft
-  Data:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Database:
-    - type: genre
-      value: Databases
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Documentary:
-    - type: genre
-      value: documentaries (documents)
-      uri: http://vocab.getty.edu/aat/300249172
-      source:
-        code: aat
-  Dramatic performance:
-    - type: genre
-      value: Drama
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
-      source:
-        code: lcgft
-  Essay:
-    - type: genre
-      value: Essays
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
-      source:
-        code: lcgft
-  Ethnography:
-    - type: genre
-      value: Ethnographies
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
-      source:
-        code: lcgft
-  Event:
-    - type: genre
-      value: events (activities)
-      uri: http://vocab.getty.edu/aat/300069084
-      source:
-        code: aat
-  Field recording:
-    - type: genre
-      value: Field recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
-      source:
-        code: lcgft
-  Game:
-    - type: genre
-      value: computer game
-      uri: http://vocab.getty.edu/aat/300422211
-      source:
-        code: aat
-  Geospatial data:
-    - type: genre
-      value: Geographic information systems
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Government document:
-    - type: genre
-      value: government records
-      uri: http://vocab.getty.edu/aat/300027777
-      source:
-        code: aat
-  Image:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Interview:
-    - type: genre
-      value: Interviews
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
-      source:
-        code: lcgft
-  Journal/periodical issue:
-    - type: genre
-      value: Periodicals
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
-      source:
-        code: lcgft
-  Manuscript:
-    - type: genre
-      value: manuscripts (documents)
-      uri: http://vocab.getty.edu/aat/300028569
-      source:
-        code: aat
-  Map:
-    - type: genre
-      value: Maps
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
-      source:
-        code: lcgft
-  MIDI:
-    - type: genre
-      value: MIDI (information technology)
-      uri: http://vocab.getty.edu/aat/300266746
-      source:
-        code: aat
-  Musical transcription:
-    - type: genre
-      value: transcriptions (documents)
-      uri: http://vocab.getty.edu/aat/300404333
-      source:
-        code: aat
-  Notated music:
-    - type: genre
-      value: Notated music
-      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
-      source:
-        code: lcgft
-  Narrative film:
-    - type: genre
-      value: Fiction films
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
-      source:
-        code: lcgft
-  Oral history:
-    - type: genre
-      value: Oral histories
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
-      source:
-        code: lcgft
-  Photograph:
-    - type: genre
-      value: Photographs
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
-      source:
-        code: lcgft
-  Piano roll:
-    - type: genre
-      value: music rolls
-      uri: http://vocab.getty.edu/aat/300429369
-      source:
-        code: aat
-  Podcast:
-    - type: genre
-      value: Podcasts
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
-      source:
-        code: lcgft
-  Poetry reading:
-    - type: genre
-      value: Poetry
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
-      source:
-        code: lcgft
-  Poster:
-    - type: genre
-      value: Posters
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
-      source:
-        code: lcgft
-  Preprint:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-  Questionnaire:
-    - type: genre
-      value: Questionnaires
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
-      source:
-        code: lcgft
-  Remote sensing imagery:
-    - type: genre
-      value: Remote-sensing images
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Report:
-    - type: genre
-      value: reports
-      uri: http://vocab.getty.edu/aat/300027267
-      source:
-        code: aat
-  Software:
-    - type: genre
-      value: software
-      uri: http://vocab.getty.edu/aat/300028566
-      source:
-        code: aat
-  Sound recording:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Speech:
-    - type: genre
-      value: Speeches
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
-      source:
-        code: lcgft
-  Statistical model:
-    - type: genre
-      value: mathematical models
-      uri: http://vocab.getty.edu/aat/300065075
-      source:
-        code: aat
-  Story:
-    - type: genre
-      value: Fiction
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
-      source:
-        code: lcgft
-  Syllabus:
-    - type: genre
-      value: Outlines and syllabi
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
-      source:
-        code: lcgft
-  Tabular data:
-    - type: genre
-      value: Tables (data)
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Technical report:
-    - type: genre
-      value: Technical reports
-      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
-      source:
-        code: lcgft
-  Text corpus:
-    - type: genre
-      value: Text corpora
-      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Thesis:
-    - type: genre
-      value: Academic theses
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
-      source:
-        code: lcgft
-  Transcript:
-    - type: genre
-      value: transcripts
-      uri: http://vocab.getty.edu/aat/300027388
-      source:
-        code: aat
-  Video art:
-    - type: genre
-      value: Video art
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
-      source:
-        code: lcgft
-  Video recording:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  White paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-  Working paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
+  subtypes:
+    Animation:
+      - type: genre
+        value: animations (visual works)
+        uri: http://vocab.getty.edu/aat/300411663
+        source:
+          code: aat
+    Article:
+      - type: genre
+        value: articles
+        uri: http://vocab.getty.edu/aat/300048715
+        source:
+          code: aat
+    Book:
+      - type: genre
+        value: books
+        uri: http://vocab.getty.edu/aat/300028051
+        source:
+          code: aat
+    CAD:
+      - type: genre
+        value: computer-aided designs (visual works)
+        uri: http://vocab.getty.edu/aat/300418056
+        source:
+          code: aat
+    Code:
+      - type: genre
+        value: programs (computer)
+        uri: http://vocab.getty.edu/aat/300312188
+        source:
+          code: aat
+    Correspondence:
+      - type: genre
+        value: correspondence
+        uri: http://vocab.getty.edu/aat/300026877
+        source:
+          code: aat
+    Course/instructional materials:
+      - type: genre
+        value: Instructional and educational works
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+        source:
+          code: lcgft
+    Data:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Database:
+      - type: genre
+        value: Databases
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Documentary:
+      - type: genre
+        value: documentaries (documents)
+        uri: http://vocab.getty.edu/aat/300249172
+        source:
+          code: aat
+    Dramatic performance:
+      - type: genre
+        value: Drama
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+        source:
+          code: lcgft
+    Essay:
+      - type: genre
+        value: Essays
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+        source:
+          code: lcgft
+    Ethnography:
+      - type: genre
+        value: Ethnographies
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+        source:
+          code: lcgft
+    Event:
+      - type: genre
+        value: events (activities)
+        uri: http://vocab.getty.edu/aat/300069084
+        source:
+          code: aat
+    Field recording:
+      - type: genre
+        value: Field recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+        source:
+          code: lcgft
+    Game:
+      - type: genre
+        value: computer game
+        uri: http://vocab.getty.edu/aat/300422211
+        source:
+          code: aat
+    Geospatial data:
+      - type: genre
+        value: Geographic information systems
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Government document:
+      - type: genre
+        value: government records
+        uri: http://vocab.getty.edu/aat/300027777
+        source:
+          code: aat
+    Image:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Interview:
+      - type: genre
+        value: Interviews
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+        source:
+          code: lcgft
+    Journal/periodical issue:
+      - type: genre
+        value: Periodicals
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+        source:
+          code: lcgft
+    Manuscript:
+      - type: genre
+        value: manuscripts (documents)
+        uri: http://vocab.getty.edu/aat/300028569
+        source:
+          code: aat
+    Map:
+      - type: genre
+        value: Maps
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+        source:
+          code: lcgft
+    MIDI:
+      - type: genre
+        value: MIDI (information technology)
+        uri: http://vocab.getty.edu/aat/300266746
+        source:
+          code: aat
+    Musical transcription:
+      - type: genre
+        value: transcriptions (documents)
+        uri: http://vocab.getty.edu/aat/300404333
+        source:
+          code: aat
+    Notated music:
+      - type: genre
+        value: Notated music
+        uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+        source:
+          code: lcgft
+    Narrative film:
+      - type: genre
+        value: Fiction films
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+        source:
+          code: lcgft
+    Oral history:
+      - type: genre
+        value: Oral histories
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+        source:
+          code: lcgft
+    Photograph:
+      - type: genre
+        value: Photographs
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+        source:
+          code: lcgft
+    Piano roll:
+      - type: genre
+        value: music rolls
+        uri: http://vocab.getty.edu/aat/300429369
+        source:
+          code: aat
+    Podcast:
+      - type: genre
+        value: Podcasts
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+        source:
+          code: lcgft
+    Poetry reading:
+      - type: genre
+        value: Poetry
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+        source:
+          code: lcgft
+    Poster:
+      - type: genre
+        value: Posters
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+        source:
+          code: lcgft
+    Preprint:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+    Questionnaire:
+      - type: genre
+        value: Questionnaires
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+        source:
+          code: lcgft
+    Remote sensing imagery:
+      - type: genre
+        value: Remote-sensing images
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Report:
+      - type: genre
+        value: reports
+        uri: http://vocab.getty.edu/aat/300027267
+        source:
+          code: aat
+    Software:
+      - type: genre
+        value: software
+        uri: http://vocab.getty.edu/aat/300028566
+        source:
+          code: aat
+    Sound recording:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Speech:
+      - type: genre
+        value: Speeches
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+        source:
+          code: lcgft
+    Statistical model:
+      - type: genre
+        value: mathematical models
+        uri: http://vocab.getty.edu/aat/300065075
+        source:
+          code: aat
+    Story:
+      - type: genre
+        value: Fiction
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+        source:
+          code: lcgft
+    Syllabus:
+      - type: genre
+        value: Outlines and syllabi
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+        source:
+          code: lcgft
+    Tabular data:
+      - type: genre
+        value: Tables (data)
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Technical report:
+      - type: genre
+        value: Technical reports
+        uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+        source:
+          code: lcgft
+    Text corpus:
+      - type: genre
+        value: Text corpora
+        uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Thesis:
+      - type: genre
+        value: Academic theses
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+        source:
+          code: lcgft
+    Transcript:
+      - type: genre
+        value: transcripts
+        uri: http://vocab.getty.edu/aat/300027388
+        source:
+          code: aat
+    Video art:
+      - type: genre
+        value: Video art
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+        source:
+          code: lcgft
+    Video recording:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    White paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+    Working paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
 Music:
-  3D model:
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Animation:
-    - type: genre
-      value: animations (visual works)
-      uri: http://vocab.getty.edu/aat/300411663
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Article:
-    - type: genre
-      value: articles
-      uri: http://vocab.getty.edu/aat/300048715
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Book:
-    - type: genre
-      value: books
-      uri: http://vocab.getty.edu/aat/300028051
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Book chapter:
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Broadcast:
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  CAD:
-    - type: genre
-      value: computer-aided designs (visual works)
-      uri: http://vocab.getty.edu/aat/300418056
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Code:
-    - type: genre
-      value: programs (computer)
-      uri: http://vocab.getty.edu/aat/300312188
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Conference session:
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Correspondence:
-    - type: genre
-      value: correspondence
-      uri: http://vocab.getty.edu/aat/300026877
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Course/instructional materials:
-    - type: genre
-      value: Instructional and educational works
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Data:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Database:
-    - type: genre
-      value: Databases
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Documentary:
-    - type: genre
-      value: documentaries (documents)
-      uri: http://vocab.getty.edu/aat/300249172
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Documentation:
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Dramatic performance:
-    - type: genre
-      value: Drama
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Essay:
-    - type: genre
-      value: Essays
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Ethnography:
-    - type: genre
-      value: Ethnographies
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Event:
-    - type: genre
-      value: events (activities)
-      uri: http://vocab.getty.edu/aat/300069084
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Experimental audio/video:
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Field recording:
-    - type: genre
-      value: Field recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Game:
-    - type: genre
-      value: computer game
-      uri: http://vocab.getty.edu/aat/300422211
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Geospatial data:
-    - type: genre
-      value: Geographic information systems
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Government document:
-    - type: genre
-      value: government records
-      uri: http://vocab.getty.edu/aat/300027777
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Image:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Interview:
-    - type: genre
-      value: Interviews
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Journal/periodical issue:
-    - type: genre
-      value: Periodicals
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Manuscript:
-    - type: genre
-      value: manuscripts (documents)
-      uri: http://vocab.getty.edu/aat/300028569
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Map:
-    - type: genre
-      value: Maps
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  MIDI:
-    - type: genre
-      value: MIDI (information technology)
-      uri: http://vocab.getty.edu/aat/300266746
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Musical transcription:
-    - type: genre
-      value: transcriptions (documents)
-      uri: http://vocab.getty.edu/aat/300404333
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Notated music:
-    - type: genre
-      value: Notated music
-      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Narrative film:
-    - type: genre
-      value: Fiction films
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Oral history:
-    - type: genre
-      value: Oral histories
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Other spoken word:
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Performance:
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Photograph:
-    - type: genre
-      value: Photographs
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Piano roll:
-    - type: genre
-      value: music rolls
-      uri: http://vocab.getty.edu/aat/300429369
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Podcast:
-    - type: genre
-      value: Podcasts
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Poetry reading:
-    - type: genre
-      value: Poetry
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Policy brief:
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Poster:
-    - type: genre
-      value: Posters
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Preprint:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Presentation recording:
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Presentation slides:
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Questionnaire:
-    - type: genre
-      value: Questionnaires
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Remote sensing imagery:
-    - type: genre
-      value: Remote-sensing images
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Report:
-    - type: genre
-      value: reports
-      uri: http://vocab.getty.edu/aat/300027267
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Software:
-    - type: genre
-      value: software
-      uri: http://vocab.getty.edu/aat/300028566
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Sound recording:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Speaker notes:
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Speech:
-    - type: genre
-      value: Speeches
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Statistical model:
-    - type: genre
-      value: mathematical models
-      uri: http://vocab.getty.edu/aat/300065075
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Story:
-    - type: genre
-      value: Fiction
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Syllabus:
-    - type: genre
-      value: Outlines and syllabi
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Tabular data:
-    - type: genre
-      value: Tables (data)
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Technical report:
-    - type: genre
-      value: Technical reports
-      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Text corpus:
-    - type: genre
-      value: Text corpora
-      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Text:
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Thesis:
-    - type: genre
-      value: Academic theses
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Transcript:
-    - type: genre
-      value: transcripts
-      uri: http://vocab.getty.edu/aat/300027388
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Unedited recording:
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Video art:
-    - type: genre
-      value: Video art
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
-      source:
-        code: lcgft
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Video recording:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  White paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
-  Working paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-    - type: genre
-      value: Music
-      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-      source:
-        code: lcgft
+  type:
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  subtypes:
+    3D model:
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Animation:
+      - type: genre
+        value: animations (visual works)
+        uri: http://vocab.getty.edu/aat/300411663
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Article:
+      - type: genre
+        value: articles
+        uri: http://vocab.getty.edu/aat/300048715
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Book:
+      - type: genre
+        value: books
+        uri: http://vocab.getty.edu/aat/300028051
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Book chapter:
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Broadcast:
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    CAD:
+      - type: genre
+        value: computer-aided designs (visual works)
+        uri: http://vocab.getty.edu/aat/300418056
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Code:
+      - type: genre
+        value: programs (computer)
+        uri: http://vocab.getty.edu/aat/300312188
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Conference session:
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Correspondence:
+      - type: genre
+        value: correspondence
+        uri: http://vocab.getty.edu/aat/300026877
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Course/instructional materials:
+      - type: genre
+        value: Instructional and educational works
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Data:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Database:
+      - type: genre
+        value: Databases
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Documentary:
+      - type: genre
+        value: documentaries (documents)
+        uri: http://vocab.getty.edu/aat/300249172
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Documentation:
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Dramatic performance:
+      - type: genre
+        value: Drama
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Essay:
+      - type: genre
+        value: Essays
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Ethnography:
+      - type: genre
+        value: Ethnographies
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Event:
+      - type: genre
+        value: events (activities)
+        uri: http://vocab.getty.edu/aat/300069084
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Experimental audio/video:
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Field recording:
+      - type: genre
+        value: Field recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Game:
+      - type: genre
+        value: computer game
+        uri: http://vocab.getty.edu/aat/300422211
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Geospatial data:
+      - type: genre
+        value: Geographic information systems
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Government document:
+      - type: genre
+        value: government records
+        uri: http://vocab.getty.edu/aat/300027777
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Image:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Interview:
+      - type: genre
+        value: Interviews
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Journal/periodical issue:
+      - type: genre
+        value: Periodicals
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Manuscript:
+      - type: genre
+        value: manuscripts (documents)
+        uri: http://vocab.getty.edu/aat/300028569
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Map:
+      - type: genre
+        value: Maps
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    MIDI:
+      - type: genre
+        value: MIDI (information technology)
+        uri: http://vocab.getty.edu/aat/300266746
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Musical transcription:
+      - type: genre
+        value: transcriptions (documents)
+        uri: http://vocab.getty.edu/aat/300404333
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Notated music:
+      - type: genre
+        value: Notated music
+        uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Narrative film:
+      - type: genre
+        value: Fiction films
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Oral history:
+      - type: genre
+        value: Oral histories
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Other spoken word:
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Performance:
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Photograph:
+      - type: genre
+        value: Photographs
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Piano roll:
+      - type: genre
+        value: music rolls
+        uri: http://vocab.getty.edu/aat/300429369
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Podcast:
+      - type: genre
+        value: Podcasts
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Poetry reading:
+      - type: genre
+        value: Poetry
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Policy brief:
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Poster:
+      - type: genre
+        value: Posters
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Preprint:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Presentation recording:
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Presentation slides:
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Questionnaire:
+      - type: genre
+        value: Questionnaires
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Remote sensing imagery:
+      - type: genre
+        value: Remote-sensing images
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Report:
+      - type: genre
+        value: reports
+        uri: http://vocab.getty.edu/aat/300027267
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Software:
+      - type: genre
+        value: software
+        uri: http://vocab.getty.edu/aat/300028566
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Sound recording:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Speaker notes:
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Speech:
+      - type: genre
+        value: Speeches
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Statistical model:
+      - type: genre
+        value: mathematical models
+        uri: http://vocab.getty.edu/aat/300065075
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Story:
+      - type: genre
+        value: Fiction
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Syllabus:
+      - type: genre
+        value: Outlines and syllabi
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Tabular data:
+      - type: genre
+        value: Tables (data)
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Technical report:
+      - type: genre
+        value: Technical reports
+        uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Text corpus:
+      - type: genre
+        value: Text corpora
+        uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Text:
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Thesis:
+      - type: genre
+        value: Academic theses
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Transcript:
+      - type: genre
+        value: transcripts
+        uri: http://vocab.getty.edu/aat/300027388
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Unedited recording:
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Video art:
+      - type: genre
+        value: Video art
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+        source:
+          code: lcgft
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Video recording:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    White paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
+    Working paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+      - type: genre
+        value: Music
+        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+        source:
+          code: lcgft
 Other:
-  Animation:
-    - type: genre
-      value: animations (visual works)
-      uri: http://vocab.getty.edu/aat/300411663
-      source:
-        code: aat
-  Article:
-    - type: genre
-      value: articles
-      uri: http://vocab.getty.edu/aat/300048715
-      source:
-        code: aat
-  Book:
-    - type: genre
-      value: books
-      uri: http://vocab.getty.edu/aat/300028051
-      source:
-        code: aat
-  CAD:
-    - type: genre
-      value: computer-aided designs (visual works)
-      uri: http://vocab.getty.edu/aat/300418056
-      source:
-        code: aat
-  Code:
-    - type: genre
-      value: programs (computer)
-      uri: http://vocab.getty.edu/aat/300312188
-      source:
-        code: aat
-  Correspondence:
-    - type: genre
-      value: correspondence
-      uri: http://vocab.getty.edu/aat/300026877
-      source:
-        code: aat
-  Course/instructional materials:
-    - type: genre
-      value: Instructional and educational works
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-      source:
-        code: lcgft
-  Data:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Database:
-    - type: genre
-      value: Databases
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Documentary:
-    - type: genre
-      value: documentaries (documents)
-      uri: http://vocab.getty.edu/aat/300249172
-      source:
-        code: aat
-  Dramatic performance:
-    - type: genre
-      value: Drama
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
-      source:
-        code: lcgft
-  Essay:
-    - type: genre
-      value: Essays
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
-      source:
-        code: lcgft
-  Ethnography:
-    - type: genre
-      value: Ethnographies
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
-      source:
-        code: lcgft
-  Event:
-    - type: genre
-      value: events (activities)
-      uri: http://vocab.getty.edu/aat/300069084
-      source:
-        code: aat
-  Field recording:
-    - type: genre
-      value: Field recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
-      source:
-        code: lcgft
-  Game:
-    - type: genre
-      value: computer game
-      uri: http://vocab.getty.edu/aat/300422211
-      source:
-        code: aat
-  Geospatial data:
-    - type: genre
-      value: Geographic information systems
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Government document:
-    - type: genre
-      value: government records
-      uri: http://vocab.getty.edu/aat/300027777
-      source:
-        code: aat
-  Image:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Interview:
-    - type: genre
-      value: Interviews
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
-      source:
-        code: lcgft
-  Journal/periodical issue:
-    - type: genre
-      value: Periodicals
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
-      source:
-        code: lcgft
-  Manuscript:
-    - type: genre
-      value: manuscripts (documents)
-      uri: http://vocab.getty.edu/aat/300028569
-      source:
-        code: aat
-  Map:
-    - type: genre
-      value: Maps
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
-      source:
-        code: lcgft
-  MIDI:
-    - type: genre
-      value: MIDI (information technology)
-      uri: http://vocab.getty.edu/aat/300266746
-      source:
-        code: aat
-  Musical transcription:
-    - type: genre
-      value: transcriptions (documents)
-      uri: http://vocab.getty.edu/aat/300404333
-      source:
-        code: aat
-  Notated music:
-    - type: genre
-      value: Notated music
-      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
-      source:
-        code: lcgft
-  Narrative film:
-    - type: genre
-      value: Fiction films
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
-      source:
-        code: lcgft
-  Oral history:
-    - type: genre
-      value: Oral histories
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
-      source:
-        code: lcgft
-  Photograph:
-    - type: genre
-      value: Photographs
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
-      source:
-        code: lcgft
-  Piano roll:
-    - type: genre
-      value: music rolls
-      uri: http://vocab.getty.edu/aat/300429369
-      source:
-        code: aat
-  Podcast:
-    - type: genre
-      value: Podcasts
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
-      source:
-        code: lcgft
-  Poetry reading:
-    - type: genre
-      value: Poetry
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
-      source:
-        code: lcgft
-  Poster:
-    - type: genre
-      value: Posters
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
-      source:
-        code: lcgft
-  Preprint:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-  Questionnaire:
-    - type: genre
-      value: Questionnaires
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
-      source:
-        code: lcgft
-  Remote sensing imagery:
-    - type: genre
-      value: Remote-sensing images
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Report:
-    - type: genre
-      value: reports
-      uri: http://vocab.getty.edu/aat/300027267
-      source:
-        code: aat
-  Software:
-    - type: genre
-      value: software
-      uri: http://vocab.getty.edu/aat/300028566
-      source:
-        code: aat
-  Sound recording:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Speech:
-    - type: genre
-      value: Speeches
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
-      source:
-        code: lcgft
-  Statistical model:
-    - type: genre
-      value: mathematical models
-      uri: http://vocab.getty.edu/aat/300065075
-      source:
-        code: aat
-  Story:
-    - type: genre
-      value: Fiction
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
-      source:
-        code: lcgft
-  Syllabus:
-    - type: genre
-      value: Outlines and syllabi
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
-      source:
-        code: lcgft
-  Tabular data:
-    - type: genre
-      value: Tables (data)
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Technical report:
-    - type: genre
-      value: Technical reports
-      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
-      source:
-        code: lcgft
-  Text corpus:
-    - type: genre
-      value: Text corpora
-      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Thesis:
-    - type: genre
-      value: Academic theses
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
-      source:
-        code: lcgft
-  Transcript:
-    - type: genre
-      value: transcripts
-      uri: http://vocab.getty.edu/aat/300027388
-      source:
-        code: aat
-  Video art:
-    - type: genre
-      value: Video art
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
-      source:
-        code: lcgft
-  Video recording:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  White paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-  Working paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
+  subtypes:
+    Animation:
+      - type: genre
+        value: animations (visual works)
+        uri: http://vocab.getty.edu/aat/300411663
+        source:
+          code: aat
+    Article:
+      - type: genre
+        value: articles
+        uri: http://vocab.getty.edu/aat/300048715
+        source:
+          code: aat
+    Book:
+      - type: genre
+        value: books
+        uri: http://vocab.getty.edu/aat/300028051
+        source:
+          code: aat
+    CAD:
+      - type: genre
+        value: computer-aided designs (visual works)
+        uri: http://vocab.getty.edu/aat/300418056
+        source:
+          code: aat
+    Code:
+      - type: genre
+        value: programs (computer)
+        uri: http://vocab.getty.edu/aat/300312188
+        source:
+          code: aat
+    Correspondence:
+      - type: genre
+        value: correspondence
+        uri: http://vocab.getty.edu/aat/300026877
+        source:
+          code: aat
+    Course/instructional materials:
+      - type: genre
+        value: Instructional and educational works
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+        source:
+          code: lcgft
+    Data:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Database:
+      - type: genre
+        value: Databases
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Documentary:
+      - type: genre
+        value: documentaries (documents)
+        uri: http://vocab.getty.edu/aat/300249172
+        source:
+          code: aat
+    Dramatic performance:
+      - type: genre
+        value: Drama
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+        source:
+          code: lcgft
+    Essay:
+      - type: genre
+        value: Essays
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+        source:
+          code: lcgft
+    Ethnography:
+      - type: genre
+        value: Ethnographies
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+        source:
+          code: lcgft
+    Event:
+      - type: genre
+        value: events (activities)
+        uri: http://vocab.getty.edu/aat/300069084
+        source:
+          code: aat
+    Field recording:
+      - type: genre
+        value: Field recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+        source:
+          code: lcgft
+    Game:
+      - type: genre
+        value: computer game
+        uri: http://vocab.getty.edu/aat/300422211
+        source:
+          code: aat
+    Geospatial data:
+      - type: genre
+        value: Geographic information systems
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Government document:
+      - type: genre
+        value: government records
+        uri: http://vocab.getty.edu/aat/300027777
+        source:
+          code: aat
+    Image:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Interview:
+      - type: genre
+        value: Interviews
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+        source:
+          code: lcgft
+    Journal/periodical issue:
+      - type: genre
+        value: Periodicals
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+        source:
+          code: lcgft
+    Manuscript:
+      - type: genre
+        value: manuscripts (documents)
+        uri: http://vocab.getty.edu/aat/300028569
+        source:
+          code: aat
+    Map:
+      - type: genre
+        value: Maps
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+        source:
+          code: lcgft
+    MIDI:
+      - type: genre
+        value: MIDI (information technology)
+        uri: http://vocab.getty.edu/aat/300266746
+        source:
+          code: aat
+    Musical transcription:
+      - type: genre
+        value: transcriptions (documents)
+        uri: http://vocab.getty.edu/aat/300404333
+        source:
+          code: aat
+    Notated music:
+      - type: genre
+        value: Notated music
+        uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+        source:
+          code: lcgft
+    Narrative film:
+      - type: genre
+        value: Fiction films
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+        source:
+          code: lcgft
+    Oral history:
+      - type: genre
+        value: Oral histories
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+        source:
+          code: lcgft
+    Photograph:
+      - type: genre
+        value: Photographs
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+        source:
+          code: lcgft
+    Piano roll:
+      - type: genre
+        value: music rolls
+        uri: http://vocab.getty.edu/aat/300429369
+        source:
+          code: aat
+    Podcast:
+      - type: genre
+        value: Podcasts
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+        source:
+          code: lcgft
+    Poetry reading:
+      - type: genre
+        value: Poetry
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+        source:
+          code: lcgft
+    Poster:
+      - type: genre
+        value: Posters
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+        source:
+          code: lcgft
+    Preprint:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+    Questionnaire:
+      - type: genre
+        value: Questionnaires
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+        source:
+          code: lcgft
+    Remote sensing imagery:
+      - type: genre
+        value: Remote-sensing images
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Report:
+      - type: genre
+        value: reports
+        uri: http://vocab.getty.edu/aat/300027267
+        source:
+          code: aat
+    Software:
+      - type: genre
+        value: software
+        uri: http://vocab.getty.edu/aat/300028566
+        source:
+          code: aat
+    Sound recording:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Speech:
+      - type: genre
+        value: Speeches
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+        source:
+          code: lcgft
+    Statistical model:
+      - type: genre
+        value: mathematical models
+        uri: http://vocab.getty.edu/aat/300065075
+        source:
+          code: aat
+    Story:
+      - type: genre
+        value: Fiction
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+        source:
+          code: lcgft
+    Syllabus:
+      - type: genre
+        value: Outlines and syllabi
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+        source:
+          code: lcgft
+    Tabular data:
+      - type: genre
+        value: Tables (data)
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Technical report:
+      - type: genre
+        value: Technical reports
+        uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+        source:
+          code: lcgft
+    Text corpus:
+      - type: genre
+        value: Text corpora
+        uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Thesis:
+      - type: genre
+        value: Academic theses
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+        source:
+          code: lcgft
+    Transcript:
+      - type: genre
+        value: transcripts
+        uri: http://vocab.getty.edu/aat/300027388
+        source:
+          code: aat
+    Video art:
+      - type: genre
+        value: Video art
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+        source:
+          code: lcgft
+    Video recording:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    White paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+    Working paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
 Software/Code:
-  Animation:
-    - type: genre
-      value: animations (visual works)
-      uri: http://vocab.getty.edu/aat/300411663
-      source:
-        code: aat
-  Article:
-    - type: genre
-      value: articles
-      uri: http://vocab.getty.edu/aat/300048715
-      source:
-        code: aat
-  Book:
-    - type: genre
-      value: books
-      uri: http://vocab.getty.edu/aat/300028051
-      source:
-        code: aat
-  CAD:
-    - type: genre
-      value: computer-aided designs (visual works)
-      uri: http://vocab.getty.edu/aat/300418056
-      source:
-        code: aat
-  Code:
-    - type: genre
-      value: programs (computer)
-      uri: http://vocab.getty.edu/aat/300312188
-      source:
-        code: aat
-  Correspondence:
-    - type: genre
-      value: correspondence
-      uri: http://vocab.getty.edu/aat/300026877
-      source:
-        code: aat
-  Course/instructional materials:
-    - type: genre
-      value: Instructional and educational works
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-      source:
-        code: lcgft
-  Data:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Database:
-    - type: genre
-      value: Databases
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Documentary:
-    - type: genre
-      value: documentaries (documents)
-      uri: http://vocab.getty.edu/aat/300249172
-      source:
-        code: aat
-  Dramatic performance:
-    - type: genre
-      value: Drama
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
-      source:
-        code: lcgft
-  Essay:
-    - type: genre
-      value: Essays
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
-      source:
-        code: lcgft
-  Ethnography:
-    - type: genre
-      value: Ethnographies
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
-      source:
-        code: lcgft
-  Event:
-    - type: genre
-      value: events (activities)
-      uri: http://vocab.getty.edu/aat/300069084
-      source:
-        code: aat
-  Field recording:
-    - type: genre
-      value: Field recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
-      source:
-        code: lcgft
-  Game:
-    - type: genre
-      value: computer game
-      uri: http://vocab.getty.edu/aat/300422211
-      source:
-        code: aat
-  Geospatial data:
-    - type: genre
-      value: Geographic information systems
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Government document:
-    - type: genre
-      value: government records
-      uri: http://vocab.getty.edu/aat/300027777
-      source:
-        code: aat
-  Image:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Interview:
-    - type: genre
-      value: Interviews
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
-      source:
-        code: lcgft
-  Journal/periodical issue:
-    - type: genre
-      value: Periodicals
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
-      source:
-        code: lcgft
-  Manuscript:
-    - type: genre
-      value: manuscripts (documents)
-      uri: http://vocab.getty.edu/aat/300028569
-      source:
-        code: aat
-  Map:
-    - type: genre
-      value: Maps
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
-      source:
-        code: lcgft
-  MIDI:
-    - type: genre
-      value: MIDI (information technology)
-      uri: http://vocab.getty.edu/aat/300266746
-      source:
-        code: aat
-  Musical transcription:
-    - type: genre
-      value: transcriptions (documents)
-      uri: http://vocab.getty.edu/aat/300404333
-      source:
-        code: aat
-  Notated music:
-    - type: genre
-      value: Notated music
-      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
-      source:
-        code: lcgft
-  Narrative film:
-    - type: genre
-      value: Fiction films
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
-      source:
-        code: lcgft
-  Oral history:
-    - type: genre
-      value: Oral histories
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
-      source:
-        code: lcgft
-  Photograph:
-    - type: genre
-      value: Photographs
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
-      source:
-        code: lcgft
-  Piano roll:
-    - type: genre
-      value: music rolls
-      uri: http://vocab.getty.edu/aat/300429369
-      source:
-        code: aat
-  Podcast:
-    - type: genre
-      value: Podcasts
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
-      source:
-        code: lcgft
-  Poetry reading:
-    - type: genre
-      value: Poetry
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
-      source:
-        code: lcgft
-  Poster:
-    - type: genre
-      value: Posters
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
-      source:
-        code: lcgft
-  Preprint:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-  Questionnaire:
-    - type: genre
-      value: Questionnaires
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
-      source:
-        code: lcgft
-  Remote sensing imagery:
-    - type: genre
-      value: Remote-sensing images
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Report:
-    - type: genre
-      value: reports
-      uri: http://vocab.getty.edu/aat/300027267
-      source:
-        code: aat
-  Software:
-    - type: genre
-      value: software
-      uri: http://vocab.getty.edu/aat/300028566
-      source:
-        code: aat
-  Sound recording:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Speech:
-    - type: genre
-      value: Speeches
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
-      source:
-        code: lcgft
-  Statistical model:
-    - type: genre
-      value: mathematical models
-      uri: http://vocab.getty.edu/aat/300065075
-      source:
-        code: aat
-  Story:
-    - type: genre
-      value: Fiction
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
-      source:
-        code: lcgft
-  Syllabus:
-    - type: genre
-      value: Outlines and syllabi
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
-      source:
-        code: lcgft
-  Tabular data:
-    - type: genre
-      value: Tables (data)
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Technical report:
-    - type: genre
-      value: Technical reports
-      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
-      source:
-        code: lcgft
-  Text corpus:
-    - type: genre
-      value: Text corpora
-      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Thesis:
-    - type: genre
-      value: Academic theses
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
-      source:
-        code: lcgft
-  Transcript:
-    - type: genre
-      value: transcripts
-      uri: http://vocab.getty.edu/aat/300027388
-      source:
-        code: aat
-  Video art:
-    - type: genre
-      value: Video art
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
-      source:
-        code: lcgft
-  Video recording:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  White paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-  Working paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
+  subtypes:
+    Animation:
+      - type: genre
+        value: animations (visual works)
+        uri: http://vocab.getty.edu/aat/300411663
+        source:
+          code: aat
+    Article:
+      - type: genre
+        value: articles
+        uri: http://vocab.getty.edu/aat/300048715
+        source:
+          code: aat
+    Book:
+      - type: genre
+        value: books
+        uri: http://vocab.getty.edu/aat/300028051
+        source:
+          code: aat
+    CAD:
+      - type: genre
+        value: computer-aided designs (visual works)
+        uri: http://vocab.getty.edu/aat/300418056
+        source:
+          code: aat
+    Code:
+      - type: genre
+        value: programs (computer)
+        uri: http://vocab.getty.edu/aat/300312188
+        source:
+          code: aat
+    Correspondence:
+      - type: genre
+        value: correspondence
+        uri: http://vocab.getty.edu/aat/300026877
+        source:
+          code: aat
+    Course/instructional materials:
+      - type: genre
+        value: Instructional and educational works
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+        source:
+          code: lcgft
+    Data:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Database:
+      - type: genre
+        value: Databases
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Documentary:
+      - type: genre
+        value: documentaries (documents)
+        uri: http://vocab.getty.edu/aat/300249172
+        source:
+          code: aat
+    Dramatic performance:
+      - type: genre
+        value: Drama
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+        source:
+          code: lcgft
+    Essay:
+      - type: genre
+        value: Essays
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+        source:
+          code: lcgft
+    Ethnography:
+      - type: genre
+        value: Ethnographies
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+        source:
+          code: lcgft
+    Event:
+      - type: genre
+        value: events (activities)
+        uri: http://vocab.getty.edu/aat/300069084
+        source:
+          code: aat
+    Field recording:
+      - type: genre
+        value: Field recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+        source:
+          code: lcgft
+    Game:
+      - type: genre
+        value: computer game
+        uri: http://vocab.getty.edu/aat/300422211
+        source:
+          code: aat
+    Geospatial data:
+      - type: genre
+        value: Geographic information systems
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Government document:
+      - type: genre
+        value: government records
+        uri: http://vocab.getty.edu/aat/300027777
+        source:
+          code: aat
+    Image:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Interview:
+      - type: genre
+        value: Interviews
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+        source:
+          code: lcgft
+    Journal/periodical issue:
+      - type: genre
+        value: Periodicals
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+        source:
+          code: lcgft
+    Manuscript:
+      - type: genre
+        value: manuscripts (documents)
+        uri: http://vocab.getty.edu/aat/300028569
+        source:
+          code: aat
+    Map:
+      - type: genre
+        value: Maps
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+        source:
+          code: lcgft
+    MIDI:
+      - type: genre
+        value: MIDI (information technology)
+        uri: http://vocab.getty.edu/aat/300266746
+        source:
+          code: aat
+    Musical transcription:
+      - type: genre
+        value: transcriptions (documents)
+        uri: http://vocab.getty.edu/aat/300404333
+        source:
+          code: aat
+    Notated music:
+      - type: genre
+        value: Notated music
+        uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+        source:
+          code: lcgft
+    Narrative film:
+      - type: genre
+        value: Fiction films
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+        source:
+          code: lcgft
+    Oral history:
+      - type: genre
+        value: Oral histories
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+        source:
+          code: lcgft
+    Photograph:
+      - type: genre
+        value: Photographs
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+        source:
+          code: lcgft
+    Piano roll:
+      - type: genre
+        value: music rolls
+        uri: http://vocab.getty.edu/aat/300429369
+        source:
+          code: aat
+    Podcast:
+      - type: genre
+        value: Podcasts
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+        source:
+          code: lcgft
+    Poetry reading:
+      - type: genre
+        value: Poetry
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+        source:
+          code: lcgft
+    Poster:
+      - type: genre
+        value: Posters
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+        source:
+          code: lcgft
+    Preprint:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+    Questionnaire:
+      - type: genre
+        value: Questionnaires
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+        source:
+          code: lcgft
+    Remote sensing imagery:
+      - type: genre
+        value: Remote-sensing images
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Report:
+      - type: genre
+        value: reports
+        uri: http://vocab.getty.edu/aat/300027267
+        source:
+          code: aat
+    Software:
+      - type: genre
+        value: software
+        uri: http://vocab.getty.edu/aat/300028566
+        source:
+          code: aat
+    Sound recording:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Speech:
+      - type: genre
+        value: Speeches
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+        source:
+          code: lcgft
+    Statistical model:
+      - type: genre
+        value: mathematical models
+        uri: http://vocab.getty.edu/aat/300065075
+        source:
+          code: aat
+    Story:
+      - type: genre
+        value: Fiction
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+        source:
+          code: lcgft
+    Syllabus:
+      - type: genre
+        value: Outlines and syllabi
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+        source:
+          code: lcgft
+    Tabular data:
+      - type: genre
+        value: Tables (data)
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Technical report:
+      - type: genre
+        value: Technical reports
+        uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+        source:
+          code: lcgft
+    Text corpus:
+      - type: genre
+        value: Text corpora
+        uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Thesis:
+      - type: genre
+        value: Academic theses
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+        source:
+          code: lcgft
+    Transcript:
+      - type: genre
+        value: transcripts
+        uri: http://vocab.getty.edu/aat/300027388
+        source:
+          code: aat
+    Video art:
+      - type: genre
+        value: Video art
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+        source:
+          code: lcgft
+    Video recording:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    White paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+    Working paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
 Sound:
-  3D model:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Animation:
-    - type: genre
-      value: animations (visual works)
-      uri: http://vocab.getty.edu/aat/300411663
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Article:
-    - type: genre
-      value: articles
-      uri: http://vocab.getty.edu/aat/300048715
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Book:
-    - type: genre
-      value: books
-      uri: http://vocab.getty.edu/aat/300028051
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Book chapter:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Broadcast:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  CAD:
-    - type: genre
-      value: computer-aided designs (visual works)
-      uri: http://vocab.getty.edu/aat/300418056
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Code:
-    - type: genre
-      value: programs (computer)
-      uri: http://vocab.getty.edu/aat/300312188
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Conference session:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Correspondence:
-    - type: genre
-      value: correspondence
-      uri: http://vocab.getty.edu/aat/300026877
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Course/instructional materials:
-    - type: genre
-      value: Instructional and educational works
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Data:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Database:
-    - type: genre
-      value: Databases
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Documentary:
-    - type: genre
-      value: documentaries (documents)
-      uri: http://vocab.getty.edu/aat/300249172
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Documentation:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Dramatic performance:
-    - type: genre
-      value: Drama
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Essay:
-    - type: genre
-      value: Essays
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Ethnography:
-    - type: genre
-      value: Ethnographies
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Event:
-    - type: genre
-      value: events (activities)
-      uri: http://vocab.getty.edu/aat/300069084
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Experimental audio/video:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Field recording:
-    - type: genre
-      value: Field recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Game:
-    - type: genre
-      value: computer game
-      uri: http://vocab.getty.edu/aat/300422211
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Geospatial data:
-    - type: genre
-      value: Geographic information systems
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Government document:
-    - type: genre
-      value: government records
-      uri: http://vocab.getty.edu/aat/300027777
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Image:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Interview:
-    - type: genre
-      value: Interviews
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Journal/periodical issue:
-    - type: genre
-      value: Periodicals
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Manuscript:
-    - type: genre
-      value: manuscripts (documents)
-      uri: http://vocab.getty.edu/aat/300028569
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Map:
-    - type: genre
-      value: Maps
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  MIDI:
-    - type: genre
-      value: MIDI (information technology)
-      uri: http://vocab.getty.edu/aat/300266746
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Musical transcription:
-    - type: genre
-      value: transcriptions (documents)
-      uri: http://vocab.getty.edu/aat/300404333
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Notated music:
-    - type: genre
-      value: Notated music
-      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Narrative film:
-    - type: genre
-      value: Fiction films
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Oral history:
-    - type: genre
-      value: Oral histories
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Other spoken word:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Performance:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Photograph:
-    - type: genre
-      value: Photographs
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Piano roll:
-    - type: genre
-      value: music rolls
-      uri: http://vocab.getty.edu/aat/300429369
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Podcast:
-    - type: genre
-      value: Podcasts
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Poetry reading:
-    - type: genre
-      value: Poetry
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Policy brief:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Poster:
-    - type: genre
-      value: Posters
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Preprint:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Presentation recording:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Presentation slides:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Questionnaire:
-    - type: genre
-      value: Questionnaires
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Remote sensing imagery:
-    - type: genre
-      value: Remote-sensing images
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Report:
-    - type: genre
-      value: reports
-      uri: http://vocab.getty.edu/aat/300027267
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Software:
-    - type: genre
-      value: software
-      uri: http://vocab.getty.edu/aat/300028566
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Sound recording:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Speaker notes:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Speech:
-    - type: genre
-      value: Speeches
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Statistical model:
-    - type: genre
-      value: mathematical models
-      uri: http://vocab.getty.edu/aat/300065075
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Story:
-    - type: genre
-      value: Fiction
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Syllabus:
-    - type: genre
-      value: Outlines and syllabi
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Tabular data:
-    - type: genre
-      value: Tables (data)
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Technical report:
-    - type: genre
-      value: Technical reports
-      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Text corpus:
-    - type: genre
-      value: Text corpora
-      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Text:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Thesis:
-    - type: genre
-      value: Academic theses
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Transcript:
-    - type: genre
-      value: transcripts
-      uri: http://vocab.getty.edu/aat/300027388
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Unedited recording:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Video art:
-    - type: genre
-      value: Video art
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
-      source:
-        code: lcgft
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Video recording:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  White paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Working paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
+  type:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  subtypes:
+    3D model:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Animation:
+      - type: genre
+        value: animations (visual works)
+        uri: http://vocab.getty.edu/aat/300411663
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Article:
+      - type: genre
+        value: articles
+        uri: http://vocab.getty.edu/aat/300048715
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Book:
+      - type: genre
+        value: books
+        uri: http://vocab.getty.edu/aat/300028051
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Book chapter:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Broadcast:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    CAD:
+      - type: genre
+        value: computer-aided designs (visual works)
+        uri: http://vocab.getty.edu/aat/300418056
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Code:
+      - type: genre
+        value: programs (computer)
+        uri: http://vocab.getty.edu/aat/300312188
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Conference session:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Correspondence:
+      - type: genre
+        value: correspondence
+        uri: http://vocab.getty.edu/aat/300026877
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Course/instructional materials:
+      - type: genre
+        value: Instructional and educational works
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Data:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Database:
+      - type: genre
+        value: Databases
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Documentary:
+      - type: genre
+        value: documentaries (documents)
+        uri: http://vocab.getty.edu/aat/300249172
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Documentation:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Dramatic performance:
+      - type: genre
+        value: Drama
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Essay:
+      - type: genre
+        value: Essays
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Ethnography:
+      - type: genre
+        value: Ethnographies
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Event:
+      - type: genre
+        value: events (activities)
+        uri: http://vocab.getty.edu/aat/300069084
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Experimental audio/video:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Field recording:
+      - type: genre
+        value: Field recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Game:
+      - type: genre
+        value: computer game
+        uri: http://vocab.getty.edu/aat/300422211
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Geospatial data:
+      - type: genre
+        value: Geographic information systems
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Government document:
+      - type: genre
+        value: government records
+        uri: http://vocab.getty.edu/aat/300027777
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Image:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Interview:
+      - type: genre
+        value: Interviews
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Journal/periodical issue:
+      - type: genre
+        value: Periodicals
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Manuscript:
+      - type: genre
+        value: manuscripts (documents)
+        uri: http://vocab.getty.edu/aat/300028569
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Map:
+      - type: genre
+        value: Maps
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    MIDI:
+      - type: genre
+        value: MIDI (information technology)
+        uri: http://vocab.getty.edu/aat/300266746
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Musical transcription:
+      - type: genre
+        value: transcriptions (documents)
+        uri: http://vocab.getty.edu/aat/300404333
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Notated music:
+      - type: genre
+        value: Notated music
+        uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Narrative film:
+      - type: genre
+        value: Fiction films
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Oral history:
+      - type: genre
+        value: Oral histories
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Other spoken word:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Performance:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Photograph:
+      - type: genre
+        value: Photographs
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Piano roll:
+      - type: genre
+        value: music rolls
+        uri: http://vocab.getty.edu/aat/300429369
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Podcast:
+      - type: genre
+        value: Podcasts
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Poetry reading:
+      - type: genre
+        value: Poetry
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Policy brief:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Poster:
+      - type: genre
+        value: Posters
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Preprint:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Presentation recording:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Presentation slides:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Questionnaire:
+      - type: genre
+        value: Questionnaires
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Remote sensing imagery:
+      - type: genre
+        value: Remote-sensing images
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Report:
+      - type: genre
+        value: reports
+        uri: http://vocab.getty.edu/aat/300027267
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Software:
+      - type: genre
+        value: software
+        uri: http://vocab.getty.edu/aat/300028566
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Sound recording:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Speaker notes:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Speech:
+      - type: genre
+        value: Speeches
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Statistical model:
+      - type: genre
+        value: mathematical models
+        uri: http://vocab.getty.edu/aat/300065075
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Story:
+      - type: genre
+        value: Fiction
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Syllabus:
+      - type: genre
+        value: Outlines and syllabi
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Tabular data:
+      - type: genre
+        value: Tables (data)
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Technical report:
+      - type: genre
+        value: Technical reports
+        uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Text corpus:
+      - type: genre
+        value: Text corpora
+        uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Text:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Thesis:
+      - type: genre
+        value: Academic theses
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Transcript:
+      - type: genre
+        value: transcripts
+        uri: http://vocab.getty.edu/aat/300027388
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Unedited recording:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Video art:
+      - type: genre
+        value: Video art
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+        source:
+          code: lcgft
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Video recording:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    White paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Working paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
 Text:
-  Animation:
-    - type: genre
-      value: animations (visual works)
-      uri: http://vocab.getty.edu/aat/300411663
-      source:
-        code: aat
-  Article:
-    - type: genre
-      value: articles
-      uri: http://vocab.getty.edu/aat/300048715
-      source:
-        code: aat
-  Book:
-    - type: genre
-      value: books
-      uri: http://vocab.getty.edu/aat/300028051
-      source:
-        code: aat
-  CAD:
-    - type: genre
-      value: computer-aided designs (visual works)
-      uri: http://vocab.getty.edu/aat/300418056
-      source:
-        code: aat
-  Code:
-    - type: genre
-      value: programs (computer)
-      uri: http://vocab.getty.edu/aat/300312188
-      source:
-        code: aat
-  Correspondence:
-    - type: genre
-      value: correspondence
-      uri: http://vocab.getty.edu/aat/300026877
-      source:
-        code: aat
-  Course/instructional materials:
-    - type: genre
-      value: Instructional and educational works
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-      source:
-        code: lcgft
-  Data:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Database:
-    - type: genre
-      value: Databases
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Documentary:
-    - type: genre
-      value: documentaries (documents)
-      uri: http://vocab.getty.edu/aat/300249172
-      source:
-        code: aat
-  Documentation:
-    - type: genre
-      value: technical manuals
-      uri: http://vocab.getty.edu/aat/300026413
-      source:
-        code: aat
-  Dramatic performance:
-    - type: genre
-      value: Drama
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
-      source:
-        code: lcgft
-  Essay:
-    - type: genre
-      value: Essays
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
-      source:
-        code: lcgft
-  Ethnography:
-    - type: genre
-      value: Ethnographies
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
-      source:
-        code: lcgft
-  Event:
-    - type: genre
-      value: events (activities)
-      uri: http://vocab.getty.edu/aat/300069084
-      source:
-        code: aat
-  Field recording:
-    - type: genre
-      value: Field recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
-      source:
-        code: lcgft
-  Game:
-    - type: genre
-      value: computer game
-      uri: http://vocab.getty.edu/aat/300422211
-      source:
-        code: aat
-  Geospatial data:
-    - type: genre
-      value: Geographic information systems
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Government document:
-    - type: genre
-      value: government records
-      uri: http://vocab.getty.edu/aat/300027777
-      source:
-        code: aat
-  Image:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: lcgft
-  Interview:
-    - type: genre
-      value: Interviews
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
-      source:
-        code: lcgft
-  Journal/periodical issue:
-    - type: genre
-      value: Periodicals
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
-      source:
-        code: lcgft
-  Manuscript:
-    - type: genre
-      value: manuscripts (documents)
-      uri: http://vocab.getty.edu/aat/300028569
-      source:
-        code: aat
-  Map:
-    - type: genre
-      value: Maps
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
-      source:
-        code: lcgft
-  MIDI:
-    - type: genre
-      value: MIDI (information technology)
-      uri: http://vocab.getty.edu/aat/300266746
-      source:
-        code: aat
-  Musical transcription:
-    - type: genre
-      value: transcriptions (documents)
-      uri: http://vocab.getty.edu/aat/300404333
-      source:
-        code: aat
-  Notated music:
-    - type: genre
-      value: Notated music
-      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
-      source:
-        code: lcgft
-  Narrative film:
-    - type: genre
-      value: Fiction films
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
-      source:
-        code: lcgft
-  Oral history:
-    - type: genre
-      value: Oral histories
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
-      source:
-        code: lcgft
-  Photograph:
-    - type: genre
-      value: Photographs
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
-      source:
-        code: lcgft
-  Piano roll:
-    - type: genre
-      value: music rolls
-      uri: http://vocab.getty.edu/aat/300429369
-      source:
-        code: aat
-  Podcast:
-    - type: genre
-      value: Podcasts
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
-      source:
-        code: lcgft
-  Poetry reading:
-    - type: genre
-      value: Poetry
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
-      source:
-        code: lcgft
-  Poster:
-    - type: genre
-      value: Posters
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
-      source:
-        code: lcgft
-  Preprint:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-  Questionnaire:
-    - type: genre
-      value: Questionnaires
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
-      source:
-        code: lcgft
-  Remote sensing imagery:
-    - type: genre
-      value: Remote-sensing images
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Report:
-    - type: genre
-      value: reports
-      uri: http://vocab.getty.edu/aat/300027267
-      source:
-        code: aat
-  Software:
-    - type: genre
-      value: software
-      uri: http://vocab.getty.edu/aat/300028566
-      source:
-        code: aat
-  Sound recording:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: lcgft
-  Speech:
-    - type: genre
-      value: Speeches
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
-      source:
-        code: lcgft
-  Statistical model:
-    - type: genre
-      value: mathematical models
-      uri: http://vocab.getty.edu/aat/300065075
-      source:
-        code: aat
-  Story:
-    - type: genre
-      value: Fiction
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
-      source:
-        code: lcgft
-  Syllabus:
-    - type: genre
-      value: Outlines and syllabi
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
-      source:
-        code: lcgft
-  Tabular data:
-    - type: genre
-      value: Tables (data)
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Technical report:
-    - type: genre
-      value: Technical reports
-      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
-      source:
-        code: lcgft
-  Text corpus:
-    - type: genre
-      value: Text corpora
-      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Thesis:
-    - type: genre
-      value: Academic theses
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
-      source:
-        code: lcgft
-  Transcript:
-    - type: genre
-      value: transcripts
-      uri: http://vocab.getty.edu/aat/300027388
-      source:
-        code: aat
-  Video art:
-    - type: genre
-      value: Video art
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
-      source:
-        code: lcgft
-  Video recording:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  White paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-  Working paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
+  subtypes:
+    Animation:
+      - type: genre
+        value: animations (visual works)
+        uri: http://vocab.getty.edu/aat/300411663
+        source:
+          code: aat
+    Article:
+      - type: genre
+        value: articles
+        uri: http://vocab.getty.edu/aat/300048715
+        source:
+          code: aat
+    Book:
+      - type: genre
+        value: books
+        uri: http://vocab.getty.edu/aat/300028051
+        source:
+          code: aat
+    CAD:
+      - type: genre
+        value: computer-aided designs (visual works)
+        uri: http://vocab.getty.edu/aat/300418056
+        source:
+          code: aat
+    Code:
+      - type: genre
+        value: programs (computer)
+        uri: http://vocab.getty.edu/aat/300312188
+        source:
+          code: aat
+    Correspondence:
+      - type: genre
+        value: correspondence
+        uri: http://vocab.getty.edu/aat/300026877
+        source:
+          code: aat
+    Course/instructional materials:
+      - type: genre
+        value: Instructional and educational works
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+        source:
+          code: lcgft
+    Data:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Database:
+      - type: genre
+        value: Databases
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Documentary:
+      - type: genre
+        value: documentaries (documents)
+        uri: http://vocab.getty.edu/aat/300249172
+        source:
+          code: aat
+    Documentation:
+      - type: genre
+        value: technical manuals
+        uri: http://vocab.getty.edu/aat/300026413
+        source:
+          code: aat
+    Dramatic performance:
+      - type: genre
+        value: Drama
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+        source:
+          code: lcgft
+    Essay:
+      - type: genre
+        value: Essays
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+        source:
+          code: lcgft
+    Ethnography:
+      - type: genre
+        value: Ethnographies
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+        source:
+          code: lcgft
+    Event:
+      - type: genre
+        value: events (activities)
+        uri: http://vocab.getty.edu/aat/300069084
+        source:
+          code: aat
+    Field recording:
+      - type: genre
+        value: Field recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+        source:
+          code: lcgft
+    Game:
+      - type: genre
+        value: computer game
+        uri: http://vocab.getty.edu/aat/300422211
+        source:
+          code: aat
+    Geospatial data:
+      - type: genre
+        value: Geographic information systems
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Government document:
+      - type: genre
+        value: government records
+        uri: http://vocab.getty.edu/aat/300027777
+        source:
+          code: aat
+    Image:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: lcgft
+    Interview:
+      - type: genre
+        value: Interviews
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+        source:
+          code: lcgft
+    Journal/periodical issue:
+      - type: genre
+        value: Periodicals
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+        source:
+          code: lcgft
+    Manuscript:
+      - type: genre
+        value: manuscripts (documents)
+        uri: http://vocab.getty.edu/aat/300028569
+        source:
+          code: aat
+    Map:
+      - type: genre
+        value: Maps
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+        source:
+          code: lcgft
+    MIDI:
+      - type: genre
+        value: MIDI (information technology)
+        uri: http://vocab.getty.edu/aat/300266746
+        source:
+          code: aat
+    Musical transcription:
+      - type: genre
+        value: transcriptions (documents)
+        uri: http://vocab.getty.edu/aat/300404333
+        source:
+          code: aat
+    Notated music:
+      - type: genre
+        value: Notated music
+        uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+        source:
+          code: lcgft
+    Narrative film:
+      - type: genre
+        value: Fiction films
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+        source:
+          code: lcgft
+    Oral history:
+      - type: genre
+        value: Oral histories
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+        source:
+          code: lcgft
+    Photograph:
+      - type: genre
+        value: Photographs
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+        source:
+          code: lcgft
+    Piano roll:
+      - type: genre
+        value: music rolls
+        uri: http://vocab.getty.edu/aat/300429369
+        source:
+          code: aat
+    Podcast:
+      - type: genre
+        value: Podcasts
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+        source:
+          code: lcgft
+    Poetry reading:
+      - type: genre
+        value: Poetry
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+        source:
+          code: lcgft
+    Poster:
+      - type: genre
+        value: Posters
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+        source:
+          code: lcgft
+    Preprint:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+    Questionnaire:
+      - type: genre
+        value: Questionnaires
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+        source:
+          code: lcgft
+    Remote sensing imagery:
+      - type: genre
+        value: Remote-sensing images
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Report:
+      - type: genre
+        value: reports
+        uri: http://vocab.getty.edu/aat/300027267
+        source:
+          code: aat
+    Software:
+      - type: genre
+        value: software
+        uri: http://vocab.getty.edu/aat/300028566
+        source:
+          code: aat
+    Sound recording:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: lcgft
+    Speech:
+      - type: genre
+        value: Speeches
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+        source:
+          code: lcgft
+    Statistical model:
+      - type: genre
+        value: mathematical models
+        uri: http://vocab.getty.edu/aat/300065075
+        source:
+          code: aat
+    Story:
+      - type: genre
+        value: Fiction
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+        source:
+          code: lcgft
+    Syllabus:
+      - type: genre
+        value: Outlines and syllabi
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+        source:
+          code: lcgft
+    Tabular data:
+      - type: genre
+        value: Tables (data)
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Technical report:
+      - type: genre
+        value: Technical reports
+        uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+        source:
+          code: lcgft
+    Text corpus:
+      - type: genre
+        value: Text corpora
+        uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Thesis:
+      - type: genre
+        value: Academic theses
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+        source:
+          code: lcgft
+    Transcript:
+      - type: genre
+        value: transcripts
+        uri: http://vocab.getty.edu/aat/300027388
+        source:
+          code: aat
+    Video art:
+      - type: genre
+        value: Video art
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+        source:
+          code: lcgft
+    Video recording:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    White paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+    Working paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
 Video:
-  3D model:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Animation:
-    - type: genre
-      value: animations (visual works)
-      uri: http://vocab.getty.edu/aat/300411663
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Article:
-    - type: genre
-      value: articles
-      uri: http://vocab.getty.edu/aat/300048715
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Book:
-    - type: genre
-      value: books
-      uri: http://vocab.getty.edu/aat/300028051
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Book chapter:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Broadcast:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  CAD:
-    - type: genre
-      value: computer-aided designs (visual works)
-      uri: http://vocab.getty.edu/aat/300418056
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Code:
-    - type: genre
-      value: programs (computer)
-      uri: http://vocab.getty.edu/aat/300312188
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Conference session:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Correspondence:
-    - type: genre
-      value: correspondence
-      uri: http://vocab.getty.edu/aat/300026877
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Course/instructional materials:
-    - type: genre
-      value: Instructional and educational works
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Data:
-    - type: genre
-      value: Data sets
-      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-      source:
-        code: lcgft
-    - type: genre
-      value: dataset
-      source:
-        code: local
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Database:
-    - type: genre
-      value: Databases
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Documentary:
-    - type: genre
-      value: documentaries (documents)
-      uri: http://vocab.getty.edu/aat/300249172
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-    - type: genre
-      value: Documentary films
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026205
-      source:
-        code: lcgft
-  Documentation:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Dramatic performance:
-    - type: genre
-      value: Drama
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Essay:
-    - type: genre
-      value: Essays
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Ethnography:
-    - type: genre
-      value: Ethnographies
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-    - type: genre
-      value: Ethnographic films
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026232
-      source:
-        code: lcgft
-  Event:
-    - type: genre
-      value: events (activities)
-      uri: http://vocab.getty.edu/aat/300069084
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Experimental audio/video:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-    - type: genre
-      value: Experimental films
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026235
-      source:
-        code: lcgft
-  Field recording:
-    - type: genre
-      value: Field recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Game:
-    - type: genre
-      value: computer game
-      uri: http://vocab.getty.edu/aat/300422211
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Geospatial data:
-    - type: genre
-      value: Geographic information systems
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Government document:
-    - type: genre
-      value: government records
-      uri: http://vocab.getty.edu/aat/300027777
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Image:
-    - type: genre
-      value: Pictures
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Interview:
-    - type: genre
-      value: Interviews
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Journal/periodical issue:
-    - type: genre
-      value: Periodicals
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Manuscript:
-    - type: genre
-      value: manuscripts (documents)
-      uri: http://vocab.getty.edu/aat/300028569
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Map:
-    - type: genre
-      value: Maps
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  MIDI:
-    - type: genre
-      value: MIDI (information technology)
-      uri: http://vocab.getty.edu/aat/300266746
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Musical transcription:
-    - type: genre
-      value: transcriptions (documents)
-      uri: http://vocab.getty.edu/aat/300404333
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Notated music:
-    - type: genre
-      value: Notated music
-      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Narrative film:
-    - type: genre
-      value: Fiction films
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Oral history:
-    - type: genre
-      value: Oral histories
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Other spoken word:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Performance:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-    - type: genre
-      value: Filmed performances
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026276
-      source:
-        code: lcgft
-  Photograph:
-    - type: genre
-      value: Photographs
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Piano roll:
-    - type: genre
-      value: music rolls
-      uri: http://vocab.getty.edu/aat/300429369
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Podcast:
-    - type: genre
-      value: Podcasts
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Poetry reading:
-    - type: genre
-      value: Poetry
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Policy brief:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Poster:
-    - type: genre
-      value: Posters
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Preprint:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Presentation recording:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Presentation slides:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Questionnaire:
-    - type: genre
-      value: Questionnaires
-      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Remote sensing imagery:
-    - type: genre
-      value: Remote-sensing images
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Report:
-    - type: genre
-      value: reports
-      uri: http://vocab.getty.edu/aat/300027267
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Software:
-    - type: genre
-      value: software
-      uri: http://vocab.getty.edu/aat/300028566
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Sound recording:
-    - type: genre
-      value: Sound recordings
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Speaker notes:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Speech:
-    - type: genre
-      value: Speeches
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Statistical model:
-    - type: genre
-      value: mathematical models
-      uri: http://vocab.getty.edu/aat/300065075
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Story:
-    - type: genre
-      value: Fiction
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Syllabus:
-    - type: genre
-      value: Outlines and syllabi
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Tabular data:
-    - type: genre
-      value: Tables (data)
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Technical report:
-    - type: genre
-      value: Technical reports
-      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Text corpus:
-    - type: genre
-      value: Text corpora
-      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-    - type: genre
-      value: dataset
-      source:
-        code: local
-  Text:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Thesis:
-    - type: genre
-      value: Academic theses
-      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Transcript:
-    - type: genre
-      value: transcripts
-      uri: http://vocab.getty.edu/aat/300027388
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Unedited recording:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-    - type: genre
-      value: Unedited footage
-      uri: http://id.loc.gov/authorities/genreForms/gf2011026712
-      source:
-        code: lcgft
-  Video art:
-    - type: genre
-      value: Video art
-      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
-      source:
-        code: lcgft
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Video recording:
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  White paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
-  Working paper:
-    - type: genre
-      value: grey literature
-      uri: http://vocab.getty.edu/aat/300256200
-      source:
-        code: aat
-    - type: genre
-      value: moving images
-      uri: http://vocab.getty.edu/aat/300263857
-      source:
-        code: aat
+  type:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  subtypes:
+    3D model:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Animation:
+      - type: genre
+        value: animations (visual works)
+        uri: http://vocab.getty.edu/aat/300411663
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Article:
+      - type: genre
+        value: articles
+        uri: http://vocab.getty.edu/aat/300048715
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Book:
+      - type: genre
+        value: books
+        uri: http://vocab.getty.edu/aat/300028051
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Book chapter:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Broadcast:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    CAD:
+      - type: genre
+        value: computer-aided designs (visual works)
+        uri: http://vocab.getty.edu/aat/300418056
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Code:
+      - type: genre
+        value: programs (computer)
+        uri: http://vocab.getty.edu/aat/300312188
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Conference session:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Correspondence:
+      - type: genre
+        value: correspondence
+        uri: http://vocab.getty.edu/aat/300026877
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Course/instructional materials:
+      - type: genre
+        value: Instructional and educational works
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Data:
+      - type: genre
+        value: Data sets
+        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+        source:
+          code: lcgft
+      - type: genre
+        value: dataset
+        source:
+          code: local
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Database:
+      - type: genre
+        value: Databases
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Documentary:
+      - type: genre
+        value: documentaries (documents)
+        uri: http://vocab.getty.edu/aat/300249172
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+      - type: genre
+        value: Documentary films
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026205
+        source:
+          code: lcgft
+    Documentation:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Dramatic performance:
+      - type: genre
+        value: Drama
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Essay:
+      - type: genre
+        value: Essays
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Ethnography:
+      - type: genre
+        value: Ethnographies
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+      - type: genre
+        value: Ethnographic films
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026232
+        source:
+          code: lcgft
+    Event:
+      - type: genre
+        value: events (activities)
+        uri: http://vocab.getty.edu/aat/300069084
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Experimental audio/video:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+      - type: genre
+        value: Experimental films
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026235
+        source:
+          code: lcgft
+    Field recording:
+      - type: genre
+        value: Field recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Game:
+      - type: genre
+        value: computer game
+        uri: http://vocab.getty.edu/aat/300422211
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Geospatial data:
+      - type: genre
+        value: Geographic information systems
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Government document:
+      - type: genre
+        value: government records
+        uri: http://vocab.getty.edu/aat/300027777
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Image:
+      - type: genre
+        value: Pictures
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Interview:
+      - type: genre
+        value: Interviews
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Journal/periodical issue:
+      - type: genre
+        value: Periodicals
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Manuscript:
+      - type: genre
+        value: manuscripts (documents)
+        uri: http://vocab.getty.edu/aat/300028569
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Map:
+      - type: genre
+        value: Maps
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    MIDI:
+      - type: genre
+        value: MIDI (information technology)
+        uri: http://vocab.getty.edu/aat/300266746
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Musical transcription:
+      - type: genre
+        value: transcriptions (documents)
+        uri: http://vocab.getty.edu/aat/300404333
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Notated music:
+      - type: genre
+        value: Notated music
+        uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Narrative film:
+      - type: genre
+        value: Fiction films
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Oral history:
+      - type: genre
+        value: Oral histories
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Other spoken word:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Performance:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+      - type: genre
+        value: Filmed performances
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026276
+        source:
+          code: lcgft
+    Photograph:
+      - type: genre
+        value: Photographs
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Piano roll:
+      - type: genre
+        value: music rolls
+        uri: http://vocab.getty.edu/aat/300429369
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Podcast:
+      - type: genre
+        value: Podcasts
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Poetry reading:
+      - type: genre
+        value: Poetry
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Policy brief:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Poster:
+      - type: genre
+        value: Posters
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Preprint:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Presentation recording:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Presentation slides:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Questionnaire:
+      - type: genre
+        value: Questionnaires
+        uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Remote sensing imagery:
+      - type: genre
+        value: Remote-sensing images
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Report:
+      - type: genre
+        value: reports
+        uri: http://vocab.getty.edu/aat/300027267
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Software:
+      - type: genre
+        value: software
+        uri: http://vocab.getty.edu/aat/300028566
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Sound recording:
+      - type: genre
+        value: Sound recordings
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Speaker notes:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Speech:
+      - type: genre
+        value: Speeches
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Statistical model:
+      - type: genre
+        value: mathematical models
+        uri: http://vocab.getty.edu/aat/300065075
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Story:
+      - type: genre
+        value: Fiction
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Syllabus:
+      - type: genre
+        value: Outlines and syllabi
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Tabular data:
+      - type: genre
+        value: Tables (data)
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Technical report:
+      - type: genre
+        value: Technical reports
+        uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Text corpus:
+      - type: genre
+        value: Text corpora
+        uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+      - type: genre
+        value: dataset
+        source:
+          code: local
+    Text:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Thesis:
+      - type: genre
+        value: Academic theses
+        uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Transcript:
+      - type: genre
+        value: transcripts
+        uri: http://vocab.getty.edu/aat/300027388
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Unedited recording:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+      - type: genre
+        value: Unedited footage
+        uri: http://id.loc.gov/authorities/genreForms/gf2011026712
+        source:
+          code: lcgft
+    Video art:
+      - type: genre
+        value: Video art
+        uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+        source:
+          code: lcgft
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Video recording:
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    White paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat
+    Working paper:
+      - type: genre
+        value: grey literature
+        uri: http://vocab.getty.edu/aat/300256200
+        source:
+          code: aat
+      - type: genre
+        value: moving images
+        uri: http://vocab.getty.edu/aat/300263857
+        source:
+          code: aat

--- a/config/mappings/types_to_genres.yml
+++ b/config/mappings/types_to_genres.yml
@@ -938,113 +938,49 @@ Image:
       source:
         code: lcgft
   subtypes:
-    3D model:
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Animation:
       - type: genre
         value: animations (visual works)
         uri: http://vocab.getty.edu/aat/300411663
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Article:
       - type: genre
         value: articles
         uri: http://vocab.getty.edu/aat/300048715
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Book:
       - type: genre
         value: books
         uri: http://vocab.getty.edu/aat/300028051
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-    Book chapter:
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-    Broadcast:
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     CAD:
       - type: genre
         value: computer-aided designs (visual works)
         uri: http://vocab.getty.edu/aat/300418056
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Code:
       - type: genre
         value: programs (computer)
         uri: http://vocab.getty.edu/aat/300312188
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-    Conference session:
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Correspondence:
       - type: genre
         value: correspondence
         uri: http://vocab.getty.edu/aat/300026877
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Course/instructional materials:
       - type: genre
         value: Instructional and educational works
         uri: http://id.loc.gov/authorities/genreForms/gf2014026114
         source:
           code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Data:
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
       - type: genre
         value: Data sets
         uri: https://id.loc.gov/authorities/genreForms/gf2018026119
@@ -1061,11 +997,6 @@ Image:
         source:
           code: lcgft
       - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-      - type: genre
         value: dataset
         source:
           code: local
@@ -1075,31 +1006,16 @@ Image:
         uri: http://vocab.getty.edu/aat/300249172
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Documentation:
       - type: genre
         value: technical manuals
         uri: http://vocab.getty.edu/aat/300026413
         source:
            code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Dramatic performance:
       - type: genre
         value: Drama
         uri: http://id.loc.gov/authorities/genreForms/gf2014026297
-        source:
-          code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
     Essay:
@@ -1108,20 +1024,10 @@ Image:
         uri: http://id.loc.gov/authorities/genreForms/gf2014026094
         source:
           code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Ethnography:
       - type: genre
         value: Ethnographies
         uri: http://id.loc.gov/authorities/genreForms/gf2018026013
-        source:
-          code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
     Event:
@@ -1130,26 +1036,10 @@ Image:
         uri: http://vocab.getty.edu/aat/300069084
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-    Experimental audio/video:
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Field recording:
       - type: genre
         value: Field recordings
         uri: http://id.loc.gov/authorities/genreForms/gf2011026253
-        source:
-          code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
     Game:
@@ -1158,20 +1048,10 @@ Image:
         uri: http://vocab.getty.edu/aat/300422211
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Geospatial data:
       - type: genre
         value: Geographic information systems
         uri: http://id.loc.gov/authorities/genreForms/gf2011026294
-        source:
-          code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
       - type: genre
@@ -1184,11 +1064,6 @@ Image:
         uri: http://vocab.getty.edu/aat/300027777
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Image:
       - type: genre
         value: Pictures
@@ -1201,20 +1076,10 @@ Image:
         uri: http://id.loc.gov/authorities/genreForms/gf2014026115
         source:
           code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Journal/periodical issue:
       - type: genre
         value: Periodicals
         uri: http://id.loc.gov/authorities/genreForms/gf2014026139
-        source:
-          code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
     Manuscript:
@@ -1223,20 +1088,10 @@ Image:
         uri: http://vocab.getty.edu/aat/300028569
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Map:
       - type: genre
         value: Maps
         uri: http://id.loc.gov/authorities/genreForms/gf2011026387
-        source:
-          code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
     MIDI:
@@ -1245,31 +1100,16 @@ Image:
         uri: http://vocab.getty.edu/aat/300266746
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Musical transcription:
       - type: genre
         value: transcriptions (documents)
         uri: http://vocab.getty.edu/aat/300404333
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Notated music:
       - type: genre
         value: Notated music
         uri: http://id.loc.gov/authorities/genreForms/gf2014027184
-        source:
-          code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
     Narrative film:
@@ -1278,32 +1118,10 @@ Image:
         uri: http://id.loc.gov/authorities/genreForms/gf2011026250
         source:
           code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Oral history:
       - type: genre
         value: Oral histories
         uri: http://id.loc.gov/authorities/genreForms/gf2011026431
-        source:
-          code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-    Other spoken word:
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-    Performance:
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
     Photograph:
@@ -1312,31 +1130,16 @@ Image:
         uri: http://id.loc.gov/authorities/genreForms/gf2017027249
         source:
           code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Piano roll:
       - type: genre
         value: music rolls
         uri: http://vocab.getty.edu/aat/300429369
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Podcast:
       - type: genre
         value: Podcasts
         uri: http://id.loc.gov/authorities/genreForms/gf2011026450
-        source:
-          code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
     Poetry reading:
@@ -1345,26 +1148,10 @@ Image:
         uri: http://id.loc.gov/authorities/genreForms/gf2014026481
         source:
           code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-    Policy brief:
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Poster:
       - type: genre
         value: Posters
         uri: http://id.loc.gov/authorities/genreForms/gf2014026152
-        source:
-          code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
     Preprint:
@@ -1373,43 +1160,16 @@ Image:
         uri: http://vocab.getty.edu/aat/300256200
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-    Presentation recording:
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-    Presentation slides:
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Questionnaire:
       - type: genre
         value: Questionnaires
         uri: http://id.loc.gov/authorities/genreForms/gf2018026144
         source:
           code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Remote sensing imagery:
       - type: genre
         value: Remote-sensing images
         uri: http://id.loc.gov/authorities/genreForms/gf2011026530
-        source:
-          code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
       - type: genre
@@ -1422,37 +1182,16 @@ Image:
         uri: http://vocab.getty.edu/aat/300027267
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Software:
       - type: genre
         value: software
         uri: http://vocab.getty.edu/aat/300028566
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Sound recording:
       - type: genre
         value: Sound recordings
         uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-    Speaker notes:
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
     Speech:
@@ -1461,31 +1200,16 @@ Image:
         uri: http://id.loc.gov/authorities/genreForms/gf2011026363
         source:
           code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Statistical model:
       - type: genre
         value: mathematical models
         uri: http://vocab.getty.edu/aat/300065075
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Story:
       - type: genre
         value: Fiction
         uri: http://id.loc.gov/authorities/genreForms/gf2014026339
-        source:
-          code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
     Syllabus:
@@ -1494,20 +1218,10 @@ Image:
         uri: http://id.loc.gov/authorities/genreForms/gf2014026136
         source:
           code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Tabular data:
       - type: genre
         value: Tables (data)
         uri: http://id.loc.gov/authorities/genreForms/gf2014026186
-        source:
-          code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
       - type: genre
@@ -1520,11 +1234,6 @@ Image:
         uri: http://id.loc.gov/authorities/genreForms/gf2015026093
         source:
           code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Text corpus:
       - type: genre
         value: Text corpora
@@ -1532,29 +1241,13 @@ Image:
         source:
           code: lcgft
       - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-      - type: genre
         value: dataset
         source:
           code: local
-    Text:
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Thesis:
       - type: genre
         value: Academic theses
         uri: http://id.loc.gov/authorities/genreForms/gf2014026039
-        source:
-          code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
     Transcript:
@@ -1563,26 +1256,10 @@ Image:
         uri: http://vocab.getty.edu/aat/300027388
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-    Unedited recording:
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Video art:
       - type: genre
         value: Video art
         uri: http://id.loc.gov/authorities/genreForms/gf2017027265
-        source:
-          code: lcgft
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
     Video recording:
@@ -1591,33 +1268,18 @@ Image:
         uri: http://vocab.getty.edu/aat/300263857
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     White paper:
       - type: genre
         value: grey literature
         uri: http://vocab.getty.edu/aat/300256200
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Working paper:
       - type: genre
         value: grey literature
         uri: http://vocab.getty.edu/aat/300256200
         source:
           code: aat
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
 Mixed Materials:
   subtypes:
     Animation:

--- a/config/mappings/types_to_genres.yml
+++ b/config/mappings/types_to_genres.yml
@@ -1,547 +1,5014 @@
-Text:
-  subtypes:
-    Article:
-      - type: genre
-        value: articles
-        uri: http://vocab.getty.edu/aat/300048715
-        source:
-          code: aat
-    Government document:
-      - type: genre
-        value: government records
-        uri: http://vocab.getty.edu/aat/300027777
-        source:
-          code: aat
-    Preprint:
-      - type: genre
-        value: grey literature
-        uri: http://vocab.getty.edu/aat/300256200
-        source:
-          code: aat
-    Report:
-      - type: genre
-        value: reports
-        uri: http://vocab.getty.edu/aat/300027267
-        source:
-          code: aat
-    Technical report:
-      - type: genre
-        value: Technical reports
-        uri: http://id.loc.gov/authorities/genreForms/gf2015026093
-        source:
-          code: lcgft
-    Thesis:
-      - type: genre
-        value: Academic theses
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026039
-        source:
-          code: lcgft
-    Working paper:
-      - type: genre
-        value: grey literature
-        uri: http://vocab.getty.edu/aat/300256200
-        source:
-          code: aat
 Data:
-  type:
+  3D model:
     - type: genre
       value: Data sets
       uri: https://id.loc.gov/authorities/genreForms/gf2018026119
       source:
         code: lcgft
-  subtypes:
-    3D model:
-      - type: genre
-        value: Three dimensional scan
-    Database:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: Databases
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026081
-        source:
-          code: lcgft
-    Geospatial data:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: Geographic information systems
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026294
-        source:
-          code: lcgft
-    Image:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-    Tabular data:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: Tables (Data)
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026186
-        source:
-          code: lcgft
-    Text corpus:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: Text corpora
-        uri: http://id.loc.gov/authorities/genreForms/gf2019026083
-        source:
-          code: lcgft
-Software/Code:
-  subtypes:
-    Code:
-      - type: genre
-        value: programs (computer)
-        uri: http://vocab.getty.edu/aat/300312188
-        source:
-          code: aat
-    Documentation:
-      - type: genre
-        value: technical manuals
-        uri: http://vocab.getty.edu/aat/300026413
-        source:
-          code: aat
-    Game:
-      - type: genre
-        value: video games
-        uri: http://vocab.getty.edu/aat/300256888
-        source:
-          code: aat
-Image:
-  type:
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Animation:
+    - type: genre
+      value: animations (visual works)
+      uri: http://vocab.getty.edu/aat/300411663
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Article:
+    - type: genre
+      value: articles
+      uri: http://vocab.getty.edu/aat/300048715
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Book:
+    - type: genre
+      value: books
+      uri: http://vocab.getty.edu/aat/300028051
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Book chapter:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Broadcast:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  CAD:
+    - type: genre
+      value: computer-aided designs (visual works)
+      uri: http://vocab.getty.edu/aat/300418056
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Code:
+    - type: genre
+      value: programs (computer)
+      uri: http://vocab.getty.edu/aat/300312188
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Conference session:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Correspondence:
+    - type: genre
+      value: correspondence
+      uri: http://vocab.getty.edu/aat/300026877
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Course/instructional materials:
+    - type: genre
+      value: Instructional and educational works
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Data:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Database:
+    - type: genre
+      value: Databases
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Documentary:
+    - type: genre
+      value: documentaries (documents)
+      uri: http://vocab.getty.edu/aat/300249172
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Documentation:
+    - type: genre
+      value: Data dictionaries
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026080
+      source:
+         code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Dramatic performance:
+    - type: genre
+      value: Drama
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Essay:
+    - type: genre
+      value: Essays
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Ethnography:
+    - type: genre
+      value: Ethnographies
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Event:
+    - type: genre
+      value: events (activities)
+      uri: http://vocab.getty.edu/aat/300069084
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Experimental audio/video:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Field recording:
+    - type: genre
+      value: Field recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Game:
+    - type: genre
+      value: computer game
+      uri: http://vocab.getty.edu/aat/300422211
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Geospatial data:
+    - type: genre
+      value: Geographic information systems
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Government document:
+    - type: genre
+      value: government records
+      uri: http://vocab.getty.edu/aat/300027777
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Image:
     - type: genre
       value: Pictures
       uri: http://id.loc.gov/authorities/genreForms/gf2017027251
       source:
         code: lcgft
-  subtypes:
-    CAD:
-      - type: genre
-        value: computer-aided designs (visual works)
-        uri: http://vocab.getty.edu/aat/300418056
-        source:
-          code: aat
-    Map:
-      - type: genre
-        value: Maps
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026387
-        source:
-          code: lcgft
-    Photograph:
-      - type: genre
-        value: Photographs
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027249
-        source:
-          code: lcgft
-    Poster:
-      - type: genre
-        value: Posters
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026152
-        source:
-          code: lcgft
-    Presentation slides:
-      - type: genre
-        value: Presentation slides
-Sound:
-  type:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Interview:
+    - type: genre
+      value: Interviews
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Journal/periodical issue:
+    - type: genre
+      value: Periodicals
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Manuscript:
+    - type: genre
+      value: manuscripts (documents)
+      uri: http://vocab.getty.edu/aat/300028569
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Map:
+    - type: genre
+      value: Maps
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  MIDI:
+    - type: genre
+      value: MIDI (information technology)
+      uri: http://vocab.getty.edu/aat/300266746
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Musical transcription:
+    - type: genre
+      value: transcriptions (documents)
+      uri: http://vocab.getty.edu/aat/300404333
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Notated music:
+    - type: genre
+      value: Notated music
+      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Narrative film:
+    - type: genre
+      value: Fiction films
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Oral history:
+    - type: genre
+      value: Oral histories
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Other spoken word:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Performance:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Photograph:
+    - type: genre
+      value: Photographs
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Piano roll:
+    - type: genre
+      value: music rolls
+      uri: http://vocab.getty.edu/aat/300429369
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Podcast:
+    - type: genre
+      value: Podcasts
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Poetry reading:
+    - type: genre
+      value: Poetry
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Policy brief:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Poster:
+    - type: genre
+      value: Posters
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Preprint:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Presentation recording:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Presentation slides:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Questionnaire:
+    - type: genre
+      value: Questionnaires
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Remote sensing imagery:
+    - type: genre
+      value: Remote-sensing images
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Report:
+    - type: genre
+      value: reports
+      uri: http://vocab.getty.edu/aat/300027267
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Software:
+    - type: genre
+      value: software
+      uri: http://vocab.getty.edu/aat/300028566
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Sound recording:
     - type: genre
       value: Sound recordings
       uri: http://id.loc.gov/authorities/genreForms/gf2011026594
       source:
         code: lcgft
-  subtypes:
-    Interview:
-      - type: genre
-        value: Interviews
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026115
-        source:
-          code: lcgft
-    Oral history:
-      - type: genre
-        value: Oral histories
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026431
-        source:
-          code: lcgft
-    Podcast:
-      - type: genre
-        value: Podcasts
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026450
-        source:
-          code: lcgft
-    Speech:
-      - type: genre
-        value: Speeches
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026363
-        source:
-          code: lcgft
-Video:
-  type:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Speaker notes:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Speech:
+    - type: genre
+      value: Speeches
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Statistical model:
+    - type: genre
+      value: mathematical models
+      uri: http://vocab.getty.edu/aat/300065075
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Story:
+    - type: genre
+      value: Fiction
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Syllabus:
+    - type: genre
+      value: Outlines and syllabi
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Tabular data:
+    - type: genre
+      value: Tables (data)
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Technical report:
+    - type: genre
+      value: Technical reports
+      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Text corpus:
+    - type: genre
+      value: Text corpora
+      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Text:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Thesis:
+    - type: genre
+      value: Academic theses
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Transcript:
+    - type: genre
+      value: transcripts
+      uri: http://vocab.getty.edu/aat/300027388
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Unedited recording:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Video art:
+    - type: genre
+      value: Video art
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Video recording:
     - type: genre
       value: moving images
       uri: http://vocab.getty.edu/aat/300263857
       source:
         code: aat
-  subtypes:
-    Conference session:
-      - type: genre
-        value: Conference sessions
-    Documentary:
-      - type: genre
-        value: Documentary films
-        uri: http://id.loc.gov/authorities/genreForms/gf201102620
-        source:
-          code: lcgft
-    Event:
-      - type: genre
-        value: events (activities)
-        uri: http://vocab.getty.edu/aat/300069084
-        source:
-          code: aat
-    Oral history:
-      - type: genre
-        value: Oral histories
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026431
-        source:
-          code: lcgft
-    Performance:
-      - type: genre
-        value: Filmed performances
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026276
-        source:
-          code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  White paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Working paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+Image:
+  3D model:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Animation:
+    - type: genre
+      value: animations (visual works)
+      uri: http://vocab.getty.edu/aat/300411663
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Article:
+    - type: genre
+      value: articles
+      uri: http://vocab.getty.edu/aat/300048715
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Book:
+    - type: genre
+      value: books
+      uri: http://vocab.getty.edu/aat/300028051
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Book chapter:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Broadcast:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  CAD:
+    - type: genre
+      value: computer-aided designs (visual works)
+      uri: http://vocab.getty.edu/aat/300418056
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Code:
+    - type: genre
+      value: programs (computer)
+      uri: http://vocab.getty.edu/aat/300312188
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Conference session:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Correspondence:
+    - type: genre
+      value: correspondence
+      uri: http://vocab.getty.edu/aat/300026877
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Course/instructional materials:
+    - type: genre
+      value: Instructional and educational works
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Data:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Database:
+    - type: genre
+      value: Databases
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Documentary:
+    - type: genre
+      value: documentaries (documents)
+      uri: http://vocab.getty.edu/aat/300249172
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Documentation:
+    - type: genre
+      value: technical manuals
+      uri: http://vocab.getty.edu/aat/300026413
+      source:
+         code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Dramatic performance:
+    - type: genre
+      value: Drama
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Essay:
+    - type: genre
+      value: Essays
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Ethnography:
+    - type: genre
+      value: Ethnographies
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Event:
+    - type: genre
+      value: events (activities)
+      uri: http://vocab.getty.edu/aat/300069084
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Experimental audio/video:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Field recording:
+    - type: genre
+      value: Field recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Game:
+    - type: genre
+      value: computer game
+      uri: http://vocab.getty.edu/aat/300422211
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Geospatial data:
+    - type: genre
+      value: Geographic information systems
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Government document:
+    - type: genre
+      value: government records
+      uri: http://vocab.getty.edu/aat/300027777
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Image:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Interview:
+    - type: genre
+      value: Interviews
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Journal/periodical issue:
+    - type: genre
+      value: Periodicals
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Manuscript:
+    - type: genre
+      value: manuscripts (documents)
+      uri: http://vocab.getty.edu/aat/300028569
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Map:
+    - type: genre
+      value: Maps
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  MIDI:
+    - type: genre
+      value: MIDI (information technology)
+      uri: http://vocab.getty.edu/aat/300266746
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Musical transcription:
+    - type: genre
+      value: transcriptions (documents)
+      uri: http://vocab.getty.edu/aat/300404333
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Notated music:
+    - type: genre
+      value: Notated music
+      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Narrative film:
+    - type: genre
+      value: Fiction films
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Oral history:
+    - type: genre
+      value: Oral histories
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Other spoken word:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Performance:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Photograph:
+    - type: genre
+      value: Photographs
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Piano roll:
+    - type: genre
+      value: music rolls
+      uri: http://vocab.getty.edu/aat/300429369
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Podcast:
+    - type: genre
+      value: Podcasts
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Poetry reading:
+    - type: genre
+      value: Poetry
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Policy brief:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Poster:
+    - type: genre
+      value: Posters
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Preprint:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Presentation recording:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Presentation slides:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Questionnaire:
+    - type: genre
+      value: Questionnaires
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Remote sensing imagery:
+    - type: genre
+      value: Remote-sensing images
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Report:
+    - type: genre
+      value: reports
+      uri: http://vocab.getty.edu/aat/300027267
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Software:
+    - type: genre
+      value: software
+      uri: http://vocab.getty.edu/aat/300028566
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Sound recording:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Speaker notes:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Speech:
+    - type: genre
+      value: Speeches
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Statistical model:
+    - type: genre
+      value: mathematical models
+      uri: http://vocab.getty.edu/aat/300065075
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Story:
+    - type: genre
+      value: Fiction
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Syllabus:
+    - type: genre
+      value: Outlines and syllabi
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Tabular data:
+    - type: genre
+      value: Tables (data)
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Technical report:
+    - type: genre
+      value: Technical reports
+      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Text corpus:
+    - type: genre
+      value: Text corpora
+      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Text:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Thesis:
+    - type: genre
+      value: Academic theses
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Transcript:
+    - type: genre
+      value: transcripts
+      uri: http://vocab.getty.edu/aat/300027388
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Unedited recording:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Video art:
+    - type: genre
+      value: Video art
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+      source:
+        code: lcgft
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Video recording:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  White paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Working paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+Mixed Materials:
+  Animation:
+    - type: genre
+      value: animations (visual works)
+      uri: http://vocab.getty.edu/aat/300411663
+      source:
+        code: aat
+  Article:
+    - type: genre
+      value: articles
+      uri: http://vocab.getty.edu/aat/300048715
+      source:
+        code: aat
+  Book:
+    - type: genre
+      value: books
+      uri: http://vocab.getty.edu/aat/300028051
+      source:
+        code: aat
+  CAD:
+    - type: genre
+      value: computer-aided designs (visual works)
+      uri: http://vocab.getty.edu/aat/300418056
+      source:
+        code: aat
+  Code:
+    - type: genre
+      value: programs (computer)
+      uri: http://vocab.getty.edu/aat/300312188
+      source:
+        code: aat
+  Correspondence:
+    - type: genre
+      value: correspondence
+      uri: http://vocab.getty.edu/aat/300026877
+      source:
+        code: aat
+  Course/instructional materials:
+    - type: genre
+      value: Instructional and educational works
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+      source:
+        code: lcgft
+  Data:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Database:
+    - type: genre
+      value: Databases
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Documentary:
+    - type: genre
+      value: documentaries (documents)
+      uri: http://vocab.getty.edu/aat/300249172
+      source:
+        code: aat
+  Dramatic performance:
+    - type: genre
+      value: Drama
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+      source:
+        code: lcgft
+  Essay:
+    - type: genre
+      value: Essays
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+      source:
+        code: lcgft
+  Ethnography:
+    - type: genre
+      value: Ethnographies
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+      source:
+        code: lcgft
+  Event:
+    - type: genre
+      value: events (activities)
+      uri: http://vocab.getty.edu/aat/300069084
+      source:
+        code: aat
+  Field recording:
+    - type: genre
+      value: Field recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+      source:
+        code: lcgft
+  Game:
+    - type: genre
+      value: computer game
+      uri: http://vocab.getty.edu/aat/300422211
+      source:
+        code: aat
+  Geospatial data:
+    - type: genre
+      value: Geographic information systems
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Government document:
+    - type: genre
+      value: government records
+      uri: http://vocab.getty.edu/aat/300027777
+      source:
+        code: aat
+  Image:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Interview:
+    - type: genre
+      value: Interviews
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+      source:
+        code: lcgft
+  Journal/periodical issue:
+    - type: genre
+      value: Periodicals
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+      source:
+        code: lcgft
+  Manuscript:
+    - type: genre
+      value: manuscripts (documents)
+      uri: http://vocab.getty.edu/aat/300028569
+      source:
+        code: aat
+  Map:
+    - type: genre
+      value: Maps
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+      source:
+        code: lcgft
+  MIDI:
+    - type: genre
+      value: MIDI (information technology)
+      uri: http://vocab.getty.edu/aat/300266746
+      source:
+        code: aat
+  Musical transcription:
+    - type: genre
+      value: transcriptions (documents)
+      uri: http://vocab.getty.edu/aat/300404333
+      source:
+        code: aat
+  Notated music:
+    - type: genre
+      value: Notated music
+      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+      source:
+        code: lcgft
+  Narrative film:
+    - type: genre
+      value: Fiction films
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+      source:
+        code: lcgft
+  Oral history:
+    - type: genre
+      value: Oral histories
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+      source:
+        code: lcgft
+  Photograph:
+    - type: genre
+      value: Photographs
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+      source:
+        code: lcgft
+  Piano roll:
+    - type: genre
+      value: music rolls
+      uri: http://vocab.getty.edu/aat/300429369
+      source:
+        code: aat
+  Podcast:
+    - type: genre
+      value: Podcasts
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+      source:
+        code: lcgft
+  Poetry reading:
+    - type: genre
+      value: Poetry
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+      source:
+        code: lcgft
+  Poster:
+    - type: genre
+      value: Posters
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+      source:
+        code: lcgft
+  Preprint:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+  Questionnaire:
+    - type: genre
+      value: Questionnaires
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+      source:
+        code: lcgft
+  Remote sensing imagery:
+    - type: genre
+      value: Remote-sensing images
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Report:
+    - type: genre
+      value: reports
+      uri: http://vocab.getty.edu/aat/300027267
+      source:
+        code: aat
+  Software:
+    - type: genre
+      value: software
+      uri: http://vocab.getty.edu/aat/300028566
+      source:
+        code: aat
+  Sound recording:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Speech:
+    - type: genre
+      value: Speeches
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+      source:
+        code: lcgft
+  Statistical model:
+    - type: genre
+      value: mathematical models
+      uri: http://vocab.getty.edu/aat/300065075
+      source:
+        code: aat
+  Story:
+    - type: genre
+      value: Fiction
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+      source:
+        code: lcgft
+  Syllabus:
+    - type: genre
+      value: Outlines and syllabi
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+      source:
+        code: lcgft
+  Tabular data:
+    - type: genre
+      value: Tables (data)
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Technical report:
+    - type: genre
+      value: Technical reports
+      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+      source:
+        code: lcgft
+  Text corpus:
+    - type: genre
+      value: Text corpora
+      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Thesis:
+    - type: genre
+      value: Academic theses
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+      source:
+        code: lcgft
+  Transcript:
+    - type: genre
+      value: transcripts
+      uri: http://vocab.getty.edu/aat/300027388
+      source:
+        code: aat
+  Video art:
+    - type: genre
+      value: Video art
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+      source:
+        code: lcgft
+  Video recording:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  White paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+  Working paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
 Music:
-  type:
+  3D model:
     - type: genre
       value: Music
       uri: https://id.loc.gov/authorities/genreForms/gf2014026952
       source:
         code: lcgft
-  subtypes:
-    Data:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: Data sets
-        uri: http://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-    Image:
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-    MIDI:
-      - type: genre
-        value: MIDI (information technology)
-        uri: http://vocab.getty.edu/aat/300266746
-        source:
-          code: aat
-    Musical transcription:
-      - type: genre
-        value: transcriptions (documents)
-        uri: http://vocab.getty.edu/aat/300404333
-        source:
-          code: aat
-    Notated music:
-      - type: genre
-        value: Notated music
-        uri: http://id.loc.gov/authorities/genreForms/gf2014027184
-        source:
-          code: lcgft
-    Piano roll:
-      - type: genre
-        value: music rolls
-        uri: http://vocab.getty.edu/aat/300429369
-        source:
-          code: aat
-    Software/Code:
-      - type: genre
-        value: software
-        uri: http://vocab.getty.edu/aat/300028566
-        source:
-          code: aat
-    Sound:
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-    Text:
-      - type: genre
-        value: texts (documents)
-        uri: http://vocab.getty.edu/aat/300263751
-        source:
-          code: aat
-    Video:
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
-Mixed Materials:
-  subtypes:
-    Data:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: Data sets
-        uri: http://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-    Image:
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-    Software/Code:
-      - type: genre
-        value: software
-        uri: http://vocab.getty.edu/aat/300028566
-        source:
-          code: aat
-    Sound:
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-    Text:
-      - type: genre
-        value: texts (documents)
-        uri: http://vocab.getty.edu/aat/300263751
-        source:
-          code: aat
-    Video:
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
-General:
-  subtypes:
-    Animation:
-      - type: genre
-        value: animations (visual works)
-        uri: http://vocab.getty.edu/aat/300411663
-        source:
-          code: aat
-    Book:
-      - type: genre
-        value: books
-        uri: http://vocab.getty.edu/aat/300028051
-        source:
-          code: aat
-    Book chapter:
-      - type: genre
-        value: Book chapters
-    Broadcast:
-      - type: genre
-        value: Television programs
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026673
-        source:
-          code: lcgft
-    Correspondence:
-      - type: genre
-        value: correspondence
-        uri: http://vocab.getty.edu/aat/300026877
-        source:
-          code: aat
-    Course/instructional materials:
-      - type: genre
-        value: Instructional and educational works
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-        source:
-          code: lcgft
-    Documentary:
-      - type: genre
-        value: documentaries (documents)
-        uri: http://vocab.getty.edu/aat/300249172
-        source:
-          code: aat
-    Dramatic performance:
-      - type: genre
-        value: Drama
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026297
-        source:
-          code: lcgft
-    Essay:
-      - type: genre
-        value: Essays
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026094
-        source:
-          code: lcgft
-    Ethnography:
-      - type: genre
-        value: Ethnographies
-        uri: http://id.loc.gov/authorities/genreForms/gf2018026013
-        source:
-          code: lcgft
-    Experimental audio/video:
-      - type: genre
-        value: Experimental films
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026235
-        source:
-          code: lcgft
-    Field recording:
-      - type: genre
-        value: Field recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026253
-        source:
-          code: lcgft
-    Journal/periodical issue:
-      - type: genre
-        value: Periodicals
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026139
-    Manuscript:
-      - type: genre
-        value: manuscripts (documents)
-        uri: http://vocab.getty.edu/aat/300028569
-        source:
-          code: aat
-    MIDI:
-      - type: genre
-        value: MIDI (information technology)
-        uri: http://vocab.getty.edu/aat/300266746
-        source:
-          code: aat
-    Musical transcription:
-      - type: genre
-        value: transcriptions (documents)
-        uri: http://vocab.getty.edu/aat/300404333
-        source:
-          code: aat
-    Narrative film:
-      - type: genre
-        value: Fiction films
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026250
-        source:
-          code: lcgft
-    Notated music:
-      - type: genre
-        value: Notated music
-        uri: http://id.loc.gov/authorities/genreForms/gf2014027184
-        source:
-          code: lcgft
-    Other spoken word:
-      - type: genre
-        value: Spoken word
-    Piano roll:
-      - type: genre
-        value: music rolls
-        uri: http://vocab.getty.edu/aat/300429369
-        source:
-          code: aat
-    Poetry reading:
-      - type: genre
-        value: Poetry
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026481
-        source:
-          code: lcgft
-    Poster:
-      - type: genre
-        value: Posters
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026152
-        source:
-          code: lcgft
-    Preprint:
-      - type: genre
-        value: grey literature
-        uri: http://vocab.getty.edu/aat/300256200
-        source:
-          code: aat
-    Presentation recording:
-      - type: genre
-        value: presentations (communicative events)
-        uri: http://vocab.getty.edu/aat/300258677
-        source:
-          code: aat
-    Presentation slides:
-      - type: genre
-        value: Presentation slides
-    Questionnaire:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: Questionnaires
-        uri: http://id.loc.gov/authorities/genreForms/gf2018026144
-        source:
-          code: lcgft
-    Remote sensing imagery:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: Remote-sensing images
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026530
-        source:
-          code: lcgft
-    Software:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: software
-        uri: http://vocab.getty.edu/aat/300028566
-        source:
-          code: aat
-    Sound recording:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-    Speech:
-      - type: genre
-        value: Speeches
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026363
-        source:
-          code: lcgft
-    Story:
-      - type: genre
-        value: Fiction
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026339
-        source:
-          code: lcgft
-    Syllabus:
-      - type: genre
-        value: Outlines and syllabi
-        uri: http://id.loc.gov/authorities/genreForms/gf2014026136
-        source:
-          code: lcgft
-    Transcript:
-      - type: genre
-        value: transcripts
-        uri: http://vocab.getty.edu/aat/300027388
-        source:
-          code: aat
-    Unedited recording:
-      - type: genre
-        value: Unedited sound recordings
-    Video recording:
-      - type: genre
-        value: dataset
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
-    Video art:
-      - type: genre
-        value: Video art
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027265
-        source:
-          code: lcgft
-    White paper:
-      - type: genre
-        value: grey literature
-        uri: http://vocab.getty.edu/aat/300256200
-        source:
-          code: aat
+  Animation:
+    - type: genre
+      value: animations (visual works)
+      uri: http://vocab.getty.edu/aat/300411663
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Article:
+    - type: genre
+      value: articles
+      uri: http://vocab.getty.edu/aat/300048715
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Book:
+    - type: genre
+      value: books
+      uri: http://vocab.getty.edu/aat/300028051
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Book chapter:
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Broadcast:
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  CAD:
+    - type: genre
+      value: computer-aided designs (visual works)
+      uri: http://vocab.getty.edu/aat/300418056
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Code:
+    - type: genre
+      value: programs (computer)
+      uri: http://vocab.getty.edu/aat/300312188
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Conference session:
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Correspondence:
+    - type: genre
+      value: correspondence
+      uri: http://vocab.getty.edu/aat/300026877
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Course/instructional materials:
+    - type: genre
+      value: Instructional and educational works
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Data:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Database:
+    - type: genre
+      value: Databases
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Documentary:
+    - type: genre
+      value: documentaries (documents)
+      uri: http://vocab.getty.edu/aat/300249172
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Documentation:
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Dramatic performance:
+    - type: genre
+      value: Drama
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Essay:
+    - type: genre
+      value: Essays
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Ethnography:
+    - type: genre
+      value: Ethnographies
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Event:
+    - type: genre
+      value: events (activities)
+      uri: http://vocab.getty.edu/aat/300069084
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Experimental audio/video:
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Field recording:
+    - type: genre
+      value: Field recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Game:
+    - type: genre
+      value: computer game
+      uri: http://vocab.getty.edu/aat/300422211
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Geospatial data:
+    - type: genre
+      value: Geographic information systems
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Government document:
+    - type: genre
+      value: government records
+      uri: http://vocab.getty.edu/aat/300027777
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Image:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Interview:
+    - type: genre
+      value: Interviews
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Journal/periodical issue:
+    - type: genre
+      value: Periodicals
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Manuscript:
+    - type: genre
+      value: manuscripts (documents)
+      uri: http://vocab.getty.edu/aat/300028569
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Map:
+    - type: genre
+      value: Maps
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  MIDI:
+    - type: genre
+      value: MIDI (information technology)
+      uri: http://vocab.getty.edu/aat/300266746
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Musical transcription:
+    - type: genre
+      value: transcriptions (documents)
+      uri: http://vocab.getty.edu/aat/300404333
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Notated music:
+    - type: genre
+      value: Notated music
+      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Narrative film:
+    - type: genre
+      value: Fiction films
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Oral history:
+    - type: genre
+      value: Oral histories
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Other spoken word:
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Performance:
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Photograph:
+    - type: genre
+      value: Photographs
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Piano roll:
+    - type: genre
+      value: music rolls
+      uri: http://vocab.getty.edu/aat/300429369
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Podcast:
+    - type: genre
+      value: Podcasts
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Poetry reading:
+    - type: genre
+      value: Poetry
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Policy brief:
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Poster:
+    - type: genre
+      value: Posters
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Preprint:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Presentation recording:
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Presentation slides:
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Questionnaire:
+    - type: genre
+      value: Questionnaires
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Remote sensing imagery:
+    - type: genre
+      value: Remote-sensing images
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Report:
+    - type: genre
+      value: reports
+      uri: http://vocab.getty.edu/aat/300027267
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Software:
+    - type: genre
+      value: software
+      uri: http://vocab.getty.edu/aat/300028566
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Sound recording:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Speaker notes:
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Speech:
+    - type: genre
+      value: Speeches
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Statistical model:
+    - type: genre
+      value: mathematical models
+      uri: http://vocab.getty.edu/aat/300065075
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Story:
+    - type: genre
+      value: Fiction
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Syllabus:
+    - type: genre
+      value: Outlines and syllabi
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Tabular data:
+    - type: genre
+      value: Tables (data)
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Technical report:
+    - type: genre
+      value: Technical reports
+      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Text corpus:
+    - type: genre
+      value: Text corpora
+      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Text:
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Thesis:
+    - type: genre
+      value: Academic theses
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Transcript:
+    - type: genre
+      value: transcripts
+      uri: http://vocab.getty.edu/aat/300027388
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Unedited recording:
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Video art:
+    - type: genre
+      value: Video art
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+      source:
+        code: lcgft
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Video recording:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  White paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+  Working paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+    - type: genre
+      value: Music
+      uri: https://id.loc.gov/authorities/genreForms/gf2014026952
+      source:
+        code: lcgft
+Other:
+  Animation:
+    - type: genre
+      value: animations (visual works)
+      uri: http://vocab.getty.edu/aat/300411663
+      source:
+        code: aat
+  Article:
+    - type: genre
+      value: articles
+      uri: http://vocab.getty.edu/aat/300048715
+      source:
+        code: aat
+  Book:
+    - type: genre
+      value: books
+      uri: http://vocab.getty.edu/aat/300028051
+      source:
+        code: aat
+  CAD:
+    - type: genre
+      value: computer-aided designs (visual works)
+      uri: http://vocab.getty.edu/aat/300418056
+      source:
+        code: aat
+  Code:
+    - type: genre
+      value: programs (computer)
+      uri: http://vocab.getty.edu/aat/300312188
+      source:
+        code: aat
+  Correspondence:
+    - type: genre
+      value: correspondence
+      uri: http://vocab.getty.edu/aat/300026877
+      source:
+        code: aat
+  Course/instructional materials:
+    - type: genre
+      value: Instructional and educational works
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+      source:
+        code: lcgft
+  Data:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Database:
+    - type: genre
+      value: Databases
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Documentary:
+    - type: genre
+      value: documentaries (documents)
+      uri: http://vocab.getty.edu/aat/300249172
+      source:
+        code: aat
+  Dramatic performance:
+    - type: genre
+      value: Drama
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+      source:
+        code: lcgft
+  Essay:
+    - type: genre
+      value: Essays
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+      source:
+        code: lcgft
+  Ethnography:
+    - type: genre
+      value: Ethnographies
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+      source:
+        code: lcgft
+  Event:
+    - type: genre
+      value: events (activities)
+      uri: http://vocab.getty.edu/aat/300069084
+      source:
+        code: aat
+  Field recording:
+    - type: genre
+      value: Field recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+      source:
+        code: lcgft
+  Game:
+    - type: genre
+      value: computer game
+      uri: http://vocab.getty.edu/aat/300422211
+      source:
+        code: aat
+  Geospatial data:
+    - type: genre
+      value: Geographic information systems
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Government document:
+    - type: genre
+      value: government records
+      uri: http://vocab.getty.edu/aat/300027777
+      source:
+        code: aat
+  Image:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Interview:
+    - type: genre
+      value: Interviews
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+      source:
+        code: lcgft
+  Journal/periodical issue:
+    - type: genre
+      value: Periodicals
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+      source:
+        code: lcgft
+  Manuscript:
+    - type: genre
+      value: manuscripts (documents)
+      uri: http://vocab.getty.edu/aat/300028569
+      source:
+        code: aat
+  Map:
+    - type: genre
+      value: Maps
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+      source:
+        code: lcgft
+  MIDI:
+    - type: genre
+      value: MIDI (information technology)
+      uri: http://vocab.getty.edu/aat/300266746
+      source:
+        code: aat
+  Musical transcription:
+    - type: genre
+      value: transcriptions (documents)
+      uri: http://vocab.getty.edu/aat/300404333
+      source:
+        code: aat
+  Notated music:
+    - type: genre
+      value: Notated music
+      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+      source:
+        code: lcgft
+  Narrative film:
+    - type: genre
+      value: Fiction films
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+      source:
+        code: lcgft
+  Oral history:
+    - type: genre
+      value: Oral histories
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+      source:
+        code: lcgft
+  Photograph:
+    - type: genre
+      value: Photographs
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+      source:
+        code: lcgft
+  Piano roll:
+    - type: genre
+      value: music rolls
+      uri: http://vocab.getty.edu/aat/300429369
+      source:
+        code: aat
+  Podcast:
+    - type: genre
+      value: Podcasts
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+      source:
+        code: lcgft
+  Poetry reading:
+    - type: genre
+      value: Poetry
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+      source:
+        code: lcgft
+  Poster:
+    - type: genre
+      value: Posters
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+      source:
+        code: lcgft
+  Preprint:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+  Questionnaire:
+    - type: genre
+      value: Questionnaires
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+      source:
+        code: lcgft
+  Remote sensing imagery:
+    - type: genre
+      value: Remote-sensing images
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Report:
+    - type: genre
+      value: reports
+      uri: http://vocab.getty.edu/aat/300027267
+      source:
+        code: aat
+  Software:
+    - type: genre
+      value: software
+      uri: http://vocab.getty.edu/aat/300028566
+      source:
+        code: aat
+  Sound recording:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Speech:
+    - type: genre
+      value: Speeches
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+      source:
+        code: lcgft
+  Statistical model:
+    - type: genre
+      value: mathematical models
+      uri: http://vocab.getty.edu/aat/300065075
+      source:
+        code: aat
+  Story:
+    - type: genre
+      value: Fiction
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+      source:
+        code: lcgft
+  Syllabus:
+    - type: genre
+      value: Outlines and syllabi
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+      source:
+        code: lcgft
+  Tabular data:
+    - type: genre
+      value: Tables (data)
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Technical report:
+    - type: genre
+      value: Technical reports
+      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+      source:
+        code: lcgft
+  Text corpus:
+    - type: genre
+      value: Text corpora
+      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Thesis:
+    - type: genre
+      value: Academic theses
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+      source:
+        code: lcgft
+  Transcript:
+    - type: genre
+      value: transcripts
+      uri: http://vocab.getty.edu/aat/300027388
+      source:
+        code: aat
+  Video art:
+    - type: genre
+      value: Video art
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+      source:
+        code: lcgft
+  Video recording:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  White paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+  Working paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+Software/Code:
+  Animation:
+    - type: genre
+      value: animations (visual works)
+      uri: http://vocab.getty.edu/aat/300411663
+      source:
+        code: aat
+  Article:
+    - type: genre
+      value: articles
+      uri: http://vocab.getty.edu/aat/300048715
+      source:
+        code: aat
+  Book:
+    - type: genre
+      value: books
+      uri: http://vocab.getty.edu/aat/300028051
+      source:
+        code: aat
+  CAD:
+    - type: genre
+      value: computer-aided designs (visual works)
+      uri: http://vocab.getty.edu/aat/300418056
+      source:
+        code: aat
+  Code:
+    - type: genre
+      value: programs (computer)
+      uri: http://vocab.getty.edu/aat/300312188
+      source:
+        code: aat
+  Correspondence:
+    - type: genre
+      value: correspondence
+      uri: http://vocab.getty.edu/aat/300026877
+      source:
+        code: aat
+  Course/instructional materials:
+    - type: genre
+      value: Instructional and educational works
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+      source:
+        code: lcgft
+  Data:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Database:
+    - type: genre
+      value: Databases
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Documentary:
+    - type: genre
+      value: documentaries (documents)
+      uri: http://vocab.getty.edu/aat/300249172
+      source:
+        code: aat
+  Dramatic performance:
+    - type: genre
+      value: Drama
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+      source:
+        code: lcgft
+  Essay:
+    - type: genre
+      value: Essays
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+      source:
+        code: lcgft
+  Ethnography:
+    - type: genre
+      value: Ethnographies
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+      source:
+        code: lcgft
+  Event:
+    - type: genre
+      value: events (activities)
+      uri: http://vocab.getty.edu/aat/300069084
+      source:
+        code: aat
+  Field recording:
+    - type: genre
+      value: Field recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+      source:
+        code: lcgft
+  Game:
+    - type: genre
+      value: computer game
+      uri: http://vocab.getty.edu/aat/300422211
+      source:
+        code: aat
+  Geospatial data:
+    - type: genre
+      value: Geographic information systems
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Government document:
+    - type: genre
+      value: government records
+      uri: http://vocab.getty.edu/aat/300027777
+      source:
+        code: aat
+  Image:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Interview:
+    - type: genre
+      value: Interviews
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+      source:
+        code: lcgft
+  Journal/periodical issue:
+    - type: genre
+      value: Periodicals
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+      source:
+        code: lcgft
+  Manuscript:
+    - type: genre
+      value: manuscripts (documents)
+      uri: http://vocab.getty.edu/aat/300028569
+      source:
+        code: aat
+  Map:
+    - type: genre
+      value: Maps
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+      source:
+        code: lcgft
+  MIDI:
+    - type: genre
+      value: MIDI (information technology)
+      uri: http://vocab.getty.edu/aat/300266746
+      source:
+        code: aat
+  Musical transcription:
+    - type: genre
+      value: transcriptions (documents)
+      uri: http://vocab.getty.edu/aat/300404333
+      source:
+        code: aat
+  Notated music:
+    - type: genre
+      value: Notated music
+      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+      source:
+        code: lcgft
+  Narrative film:
+    - type: genre
+      value: Fiction films
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+      source:
+        code: lcgft
+  Oral history:
+    - type: genre
+      value: Oral histories
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+      source:
+        code: lcgft
+  Photograph:
+    - type: genre
+      value: Photographs
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+      source:
+        code: lcgft
+  Piano roll:
+    - type: genre
+      value: music rolls
+      uri: http://vocab.getty.edu/aat/300429369
+      source:
+        code: aat
+  Podcast:
+    - type: genre
+      value: Podcasts
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+      source:
+        code: lcgft
+  Poetry reading:
+    - type: genre
+      value: Poetry
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+      source:
+        code: lcgft
+  Poster:
+    - type: genre
+      value: Posters
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+      source:
+        code: lcgft
+  Preprint:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+  Questionnaire:
+    - type: genre
+      value: Questionnaires
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+      source:
+        code: lcgft
+  Remote sensing imagery:
+    - type: genre
+      value: Remote-sensing images
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Report:
+    - type: genre
+      value: reports
+      uri: http://vocab.getty.edu/aat/300027267
+      source:
+        code: aat
+  Software:
+    - type: genre
+      value: software
+      uri: http://vocab.getty.edu/aat/300028566
+      source:
+        code: aat
+  Sound recording:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Speech:
+    - type: genre
+      value: Speeches
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+      source:
+        code: lcgft
+  Statistical model:
+    - type: genre
+      value: mathematical models
+      uri: http://vocab.getty.edu/aat/300065075
+      source:
+        code: aat
+  Story:
+    - type: genre
+      value: Fiction
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+      source:
+        code: lcgft
+  Syllabus:
+    - type: genre
+      value: Outlines and syllabi
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+      source:
+        code: lcgft
+  Tabular data:
+    - type: genre
+      value: Tables (data)
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Technical report:
+    - type: genre
+      value: Technical reports
+      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+      source:
+        code: lcgft
+  Text corpus:
+    - type: genre
+      value: Text corpora
+      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Thesis:
+    - type: genre
+      value: Academic theses
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+      source:
+        code: lcgft
+  Transcript:
+    - type: genre
+      value: transcripts
+      uri: http://vocab.getty.edu/aat/300027388
+      source:
+        code: aat
+  Video art:
+    - type: genre
+      value: Video art
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+      source:
+        code: lcgft
+  Video recording:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  White paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+  Working paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+Sound:
+  3D model:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Animation:
+    - type: genre
+      value: animations (visual works)
+      uri: http://vocab.getty.edu/aat/300411663
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Article:
+    - type: genre
+      value: articles
+      uri: http://vocab.getty.edu/aat/300048715
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Book:
+    - type: genre
+      value: books
+      uri: http://vocab.getty.edu/aat/300028051
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Book chapter:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Broadcast:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  CAD:
+    - type: genre
+      value: computer-aided designs (visual works)
+      uri: http://vocab.getty.edu/aat/300418056
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Code:
+    - type: genre
+      value: programs (computer)
+      uri: http://vocab.getty.edu/aat/300312188
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Conference session:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Correspondence:
+    - type: genre
+      value: correspondence
+      uri: http://vocab.getty.edu/aat/300026877
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Course/instructional materials:
+    - type: genre
+      value: Instructional and educational works
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Data:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Database:
+    - type: genre
+      value: Databases
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Documentary:
+    - type: genre
+      value: documentaries (documents)
+      uri: http://vocab.getty.edu/aat/300249172
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Documentation:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Dramatic performance:
+    - type: genre
+      value: Drama
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Essay:
+    - type: genre
+      value: Essays
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Ethnography:
+    - type: genre
+      value: Ethnographies
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Event:
+    - type: genre
+      value: events (activities)
+      uri: http://vocab.getty.edu/aat/300069084
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Experimental audio/video:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Field recording:
+    - type: genre
+      value: Field recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Game:
+    - type: genre
+      value: computer game
+      uri: http://vocab.getty.edu/aat/300422211
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Geospatial data:
+    - type: genre
+      value: Geographic information systems
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Government document:
+    - type: genre
+      value: government records
+      uri: http://vocab.getty.edu/aat/300027777
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Image:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Interview:
+    - type: genre
+      value: Interviews
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Journal/periodical issue:
+    - type: genre
+      value: Periodicals
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Manuscript:
+    - type: genre
+      value: manuscripts (documents)
+      uri: http://vocab.getty.edu/aat/300028569
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Map:
+    - type: genre
+      value: Maps
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  MIDI:
+    - type: genre
+      value: MIDI (information technology)
+      uri: http://vocab.getty.edu/aat/300266746
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Musical transcription:
+    - type: genre
+      value: transcriptions (documents)
+      uri: http://vocab.getty.edu/aat/300404333
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Notated music:
+    - type: genre
+      value: Notated music
+      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Narrative film:
+    - type: genre
+      value: Fiction films
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Oral history:
+    - type: genre
+      value: Oral histories
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Other spoken word:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Performance:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Photograph:
+    - type: genre
+      value: Photographs
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Piano roll:
+    - type: genre
+      value: music rolls
+      uri: http://vocab.getty.edu/aat/300429369
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Podcast:
+    - type: genre
+      value: Podcasts
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Poetry reading:
+    - type: genre
+      value: Poetry
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Policy brief:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Poster:
+    - type: genre
+      value: Posters
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Preprint:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Presentation recording:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Presentation slides:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Questionnaire:
+    - type: genre
+      value: Questionnaires
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Remote sensing imagery:
+    - type: genre
+      value: Remote-sensing images
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Report:
+    - type: genre
+      value: reports
+      uri: http://vocab.getty.edu/aat/300027267
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Software:
+    - type: genre
+      value: software
+      uri: http://vocab.getty.edu/aat/300028566
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Sound recording:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Speaker notes:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Speech:
+    - type: genre
+      value: Speeches
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Statistical model:
+    - type: genre
+      value: mathematical models
+      uri: http://vocab.getty.edu/aat/300065075
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Story:
+    - type: genre
+      value: Fiction
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Syllabus:
+    - type: genre
+      value: Outlines and syllabi
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Tabular data:
+    - type: genre
+      value: Tables (data)
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Technical report:
+    - type: genre
+      value: Technical reports
+      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Text corpus:
+    - type: genre
+      value: Text corpora
+      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Text:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Thesis:
+    - type: genre
+      value: Academic theses
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Transcript:
+    - type: genre
+      value: transcripts
+      uri: http://vocab.getty.edu/aat/300027388
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Unedited recording:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Video art:
+    - type: genre
+      value: Video art
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+      source:
+        code: lcgft
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Video recording:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  White paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Working paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+Text:
+  Animation:
+    - type: genre
+      value: animations (visual works)
+      uri: http://vocab.getty.edu/aat/300411663
+      source:
+        code: aat
+  Article:
+    - type: genre
+      value: articles
+      uri: http://vocab.getty.edu/aat/300048715
+      source:
+        code: aat
+  Book:
+    - type: genre
+      value: books
+      uri: http://vocab.getty.edu/aat/300028051
+      source:
+        code: aat
+  CAD:
+    - type: genre
+      value: computer-aided designs (visual works)
+      uri: http://vocab.getty.edu/aat/300418056
+      source:
+        code: aat
+  Code:
+    - type: genre
+      value: programs (computer)
+      uri: http://vocab.getty.edu/aat/300312188
+      source:
+        code: aat
+  Correspondence:
+    - type: genre
+      value: correspondence
+      uri: http://vocab.getty.edu/aat/300026877
+      source:
+        code: aat
+  Course/instructional materials:
+    - type: genre
+      value: Instructional and educational works
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+      source:
+        code: lcgft
+  Data:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Database:
+    - type: genre
+      value: Databases
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Documentary:
+    - type: genre
+      value: documentaries (documents)
+      uri: http://vocab.getty.edu/aat/300249172
+      source:
+        code: aat
+  Documentation:
+    - type: genre
+      value: technical manuals
+      uri: http://vocab.getty.edu/aat/300026413
+      source:
+        code: aat
+  Dramatic performance:
+    - type: genre
+      value: Drama
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+      source:
+        code: lcgft
+  Essay:
+    - type: genre
+      value: Essays
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+      source:
+        code: lcgft
+  Ethnography:
+    - type: genre
+      value: Ethnographies
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+      source:
+        code: lcgft
+  Event:
+    - type: genre
+      value: events (activities)
+      uri: http://vocab.getty.edu/aat/300069084
+      source:
+        code: aat
+  Field recording:
+    - type: genre
+      value: Field recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+      source:
+        code: lcgft
+  Game:
+    - type: genre
+      value: computer game
+      uri: http://vocab.getty.edu/aat/300422211
+      source:
+        code: aat
+  Geospatial data:
+    - type: genre
+      value: Geographic information systems
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Government document:
+    - type: genre
+      value: government records
+      uri: http://vocab.getty.edu/aat/300027777
+      source:
+        code: aat
+  Image:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: lcgft
+  Interview:
+    - type: genre
+      value: Interviews
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+      source:
+        code: lcgft
+  Journal/periodical issue:
+    - type: genre
+      value: Periodicals
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+      source:
+        code: lcgft
+  Manuscript:
+    - type: genre
+      value: manuscripts (documents)
+      uri: http://vocab.getty.edu/aat/300028569
+      source:
+        code: aat
+  Map:
+    - type: genre
+      value: Maps
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+      source:
+        code: lcgft
+  MIDI:
+    - type: genre
+      value: MIDI (information technology)
+      uri: http://vocab.getty.edu/aat/300266746
+      source:
+        code: aat
+  Musical transcription:
+    - type: genre
+      value: transcriptions (documents)
+      uri: http://vocab.getty.edu/aat/300404333
+      source:
+        code: aat
+  Notated music:
+    - type: genre
+      value: Notated music
+      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+      source:
+        code: lcgft
+  Narrative film:
+    - type: genre
+      value: Fiction films
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+      source:
+        code: lcgft
+  Oral history:
+    - type: genre
+      value: Oral histories
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+      source:
+        code: lcgft
+  Photograph:
+    - type: genre
+      value: Photographs
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+      source:
+        code: lcgft
+  Piano roll:
+    - type: genre
+      value: music rolls
+      uri: http://vocab.getty.edu/aat/300429369
+      source:
+        code: aat
+  Podcast:
+    - type: genre
+      value: Podcasts
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+      source:
+        code: lcgft
+  Poetry reading:
+    - type: genre
+      value: Poetry
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+      source:
+        code: lcgft
+  Poster:
+    - type: genre
+      value: Posters
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+      source:
+        code: lcgft
+  Preprint:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+  Questionnaire:
+    - type: genre
+      value: Questionnaires
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+      source:
+        code: lcgft
+  Remote sensing imagery:
+    - type: genre
+      value: Remote-sensing images
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Report:
+    - type: genre
+      value: reports
+      uri: http://vocab.getty.edu/aat/300027267
+      source:
+        code: aat
+  Software:
+    - type: genre
+      value: software
+      uri: http://vocab.getty.edu/aat/300028566
+      source:
+        code: aat
+  Sound recording:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: lcgft
+  Speech:
+    - type: genre
+      value: Speeches
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+      source:
+        code: lcgft
+  Statistical model:
+    - type: genre
+      value: mathematical models
+      uri: http://vocab.getty.edu/aat/300065075
+      source:
+        code: aat
+  Story:
+    - type: genre
+      value: Fiction
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+      source:
+        code: lcgft
+  Syllabus:
+    - type: genre
+      value: Outlines and syllabi
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+      source:
+        code: lcgft
+  Tabular data:
+    - type: genre
+      value: Tables (data)
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Technical report:
+    - type: genre
+      value: Technical reports
+      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+      source:
+        code: lcgft
+  Text corpus:
+    - type: genre
+      value: Text corpora
+      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Thesis:
+    - type: genre
+      value: Academic theses
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+      source:
+        code: lcgft
+  Transcript:
+    - type: genre
+      value: transcripts
+      uri: http://vocab.getty.edu/aat/300027388
+      source:
+        code: aat
+  Video art:
+    - type: genre
+      value: Video art
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+      source:
+        code: lcgft
+  Video recording:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  White paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+  Working paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+Video:
+  3D model:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Animation:
+    - type: genre
+      value: animations (visual works)
+      uri: http://vocab.getty.edu/aat/300411663
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Article:
+    - type: genre
+      value: articles
+      uri: http://vocab.getty.edu/aat/300048715
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Book:
+    - type: genre
+      value: books
+      uri: http://vocab.getty.edu/aat/300028051
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Book chapter:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Broadcast:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  CAD:
+    - type: genre
+      value: computer-aided designs (visual works)
+      uri: http://vocab.getty.edu/aat/300418056
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Code:
+    - type: genre
+      value: programs (computer)
+      uri: http://vocab.getty.edu/aat/300312188
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Conference session:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Correspondence:
+    - type: genre
+      value: correspondence
+      uri: http://vocab.getty.edu/aat/300026877
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Course/instructional materials:
+    - type: genre
+      value: Instructional and educational works
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026114
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Data:
+    - type: genre
+      value: Data sets
+      uri: https://id.loc.gov/authorities/genreForms/gf2018026119
+      source:
+        code: lcgft
+    - type: genre
+      value: dataset
+      source:
+        code: local
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Database:
+    - type: genre
+      value: Databases
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026081
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Documentary:
+    - type: genre
+      value: documentaries (documents)
+      uri: http://vocab.getty.edu/aat/300249172
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+    - type: genre
+      value: Documentary films
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026205
+      source:
+        code: lcgft
+  Documentation:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Dramatic performance:
+    - type: genre
+      value: Drama
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026297
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Essay:
+    - type: genre
+      value: Essays
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026094
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Ethnography:
+    - type: genre
+      value: Ethnographies
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026013
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+    - type: genre
+      value: Ethnographic films
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026232
+      source:
+        code: lcgft
+  Event:
+    - type: genre
+      value: events (activities)
+      uri: http://vocab.getty.edu/aat/300069084
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Experimental audio/video:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+    - type: genre
+      value: Experimental films
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026235
+      source:
+        code: lcgft
+  Field recording:
+    - type: genre
+      value: Field recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026253
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Game:
+    - type: genre
+      value: computer game
+      uri: http://vocab.getty.edu/aat/300422211
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Geospatial data:
+    - type: genre
+      value: Geographic information systems
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026294
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Government document:
+    - type: genre
+      value: government records
+      uri: http://vocab.getty.edu/aat/300027777
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Image:
+    - type: genre
+      value: Pictures
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027251
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Interview:
+    - type: genre
+      value: Interviews
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026115
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Journal/periodical issue:
+    - type: genre
+      value: Periodicals
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026139
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Manuscript:
+    - type: genre
+      value: manuscripts (documents)
+      uri: http://vocab.getty.edu/aat/300028569
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Map:
+    - type: genre
+      value: Maps
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026387
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  MIDI:
+    - type: genre
+      value: MIDI (information technology)
+      uri: http://vocab.getty.edu/aat/300266746
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Musical transcription:
+    - type: genre
+      value: transcriptions (documents)
+      uri: http://vocab.getty.edu/aat/300404333
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Notated music:
+    - type: genre
+      value: Notated music
+      uri: http://id.loc.gov/authorities/genreForms/gf2014027184
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Narrative film:
+    - type: genre
+      value: Fiction films
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026250
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Oral history:
+    - type: genre
+      value: Oral histories
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026431
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Other spoken word:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Performance:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+    - type: genre
+      value: Filmed performances
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026276
+      source:
+        code: lcgft
+  Photograph:
+    - type: genre
+      value: Photographs
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027249
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Piano roll:
+    - type: genre
+      value: music rolls
+      uri: http://vocab.getty.edu/aat/300429369
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Podcast:
+    - type: genre
+      value: Podcasts
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026450
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Poetry reading:
+    - type: genre
+      value: Poetry
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026481
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Policy brief:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Poster:
+    - type: genre
+      value: Posters
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026152
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Preprint:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Presentation recording:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Presentation slides:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Questionnaire:
+    - type: genre
+      value: Questionnaires
+      uri: http://id.loc.gov/authorities/genreForms/gf2018026144
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Remote sensing imagery:
+    - type: genre
+      value: Remote-sensing images
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026530
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Report:
+    - type: genre
+      value: reports
+      uri: http://vocab.getty.edu/aat/300027267
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Software:
+    - type: genre
+      value: software
+      uri: http://vocab.getty.edu/aat/300028566
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Sound recording:
+    - type: genre
+      value: Sound recordings
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026594
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Speaker notes:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Speech:
+    - type: genre
+      value: Speeches
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026363
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Statistical model:
+    - type: genre
+      value: mathematical models
+      uri: http://vocab.getty.edu/aat/300065075
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Story:
+    - type: genre
+      value: Fiction
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026339
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Syllabus:
+    - type: genre
+      value: Outlines and syllabi
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026136
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Tabular data:
+    - type: genre
+      value: Tables (data)
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026186
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Technical report:
+    - type: genre
+      value: Technical reports
+      uri: http://id.loc.gov/authorities/genreForms/gf2015026093
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Text corpus:
+    - type: genre
+      value: Text corpora
+      uri: http://id.loc.gov/authorities/genreForms/gf2019026083
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+    - type: genre
+      value: dataset
+      source:
+        code: local
+  Text:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Thesis:
+    - type: genre
+      value: Academic theses
+      uri: http://id.loc.gov/authorities/genreForms/gf2014026039
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Transcript:
+    - type: genre
+      value: transcripts
+      uri: http://vocab.getty.edu/aat/300027388
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Unedited recording:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+    - type: genre
+      value: Unedited footage
+      uri: http://id.loc.gov/authorities/genreForms/gf2011026712
+      source:
+        code: lcgft
+  Video art:
+    - type: genre
+      value: Video art
+      uri: http://id.loc.gov/authorities/genreForms/gf2017027265
+      source:
+        code: lcgft
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Video recording:
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  White paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat
+  Working paper:
+    - type: genre
+      value: grey literature
+      uri: http://vocab.getty.edu/aat/300256200
+      source:
+        code: aat
+    - type: genre
+      value: moving images
+      uri: http://vocab.getty.edu/aat/300263857
+      source:
+        code: aat

--- a/config/mappings/types_to_genres.yml
+++ b/config/mappings/types_to_genres.yml
@@ -10,926 +10,318 @@ Data:
       source:
         code: local
   subtypes:
-    3D model:
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Animation:
       - type: genre
         value: animations (visual works)
         uri: http://vocab.getty.edu/aat/300411663
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Article:
       - type: genre
         value: articles
         uri: http://vocab.getty.edu/aat/300048715
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Book:
       - type: genre
         value: books
         uri: http://vocab.getty.edu/aat/300028051
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
-    Book chapter:
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
-    Broadcast:
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     CAD:
       - type: genre
         value: computer-aided designs (visual works)
         uri: http://vocab.getty.edu/aat/300418056
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Code:
       - type: genre
         value: programs (computer)
         uri: http://vocab.getty.edu/aat/300312188
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
-    Conference session:
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Correspondence:
       - type: genre
         value: correspondence
         uri: http://vocab.getty.edu/aat/300026877
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Course/instructional materials:
       - type: genre
         value: Instructional and educational works
         uri: http://id.loc.gov/authorities/genreForms/gf2014026114
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
-    Data:
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Database:
       - type: genre
         value: Databases
         uri: http://id.loc.gov/authorities/genreForms/gf2014026081
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Documentary:
       - type: genre
         value: documentaries (documents)
         uri: http://vocab.getty.edu/aat/300249172
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Documentation:
       - type: genre
         value: Data dictionaries
         uri: http://id.loc.gov/authorities/genreForms/gf2014026080
         source:
            code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Dramatic performance:
       - type: genre
         value: Drama
         uri: http://id.loc.gov/authorities/genreForms/gf2014026297
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Essay:
       - type: genre
         value: Essays
         uri: http://id.loc.gov/authorities/genreForms/gf2014026094
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Ethnography:
       - type: genre
         value: Ethnographies
         uri: http://id.loc.gov/authorities/genreForms/gf2018026013
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Event:
       - type: genre
         value: events (activities)
         uri: http://vocab.getty.edu/aat/300069084
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
-    Experimental audio/video:
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Field recording:
       - type: genre
         value: Field recordings
         uri: http://id.loc.gov/authorities/genreForms/gf2011026253
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Game:
       - type: genre
         value: computer game
         uri: http://vocab.getty.edu/aat/300422211
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Geospatial data:
       - type: genre
         value: Geographic information systems
         uri: http://id.loc.gov/authorities/genreForms/gf2011026294
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Government document:
       - type: genre
         value: government records
         uri: http://vocab.getty.edu/aat/300027777
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Image:
       - type: genre
         value: Pictures
         uri: http://id.loc.gov/authorities/genreForms/gf2017027251
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Interview:
       - type: genre
         value: Interviews
         uri: http://id.loc.gov/authorities/genreForms/gf2014026115
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Journal/periodical issue:
       - type: genre
         value: Periodicals
         uri: http://id.loc.gov/authorities/genreForms/gf2014026139
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Manuscript:
       - type: genre
         value: manuscripts (documents)
         uri: http://vocab.getty.edu/aat/300028569
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Map:
       - type: genre
         value: Maps
         uri: http://id.loc.gov/authorities/genreForms/gf2011026387
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     MIDI:
       - type: genre
         value: MIDI (information technology)
         uri: http://vocab.getty.edu/aat/300266746
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Musical transcription:
       - type: genre
         value: transcriptions (documents)
         uri: http://vocab.getty.edu/aat/300404333
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Notated music:
       - type: genre
         value: Notated music
         uri: http://id.loc.gov/authorities/genreForms/gf2014027184
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Narrative film:
       - type: genre
         value: Fiction films
         uri: http://id.loc.gov/authorities/genreForms/gf2011026250
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Oral history:
       - type: genre
         value: Oral histories
         uri: http://id.loc.gov/authorities/genreForms/gf2011026431
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
-    Other spoken word:
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
-    Performance:
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Photograph:
       - type: genre
         value: Photographs
         uri: http://id.loc.gov/authorities/genreForms/gf2017027249
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Piano roll:
       - type: genre
         value: music rolls
         uri: http://vocab.getty.edu/aat/300429369
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Podcast:
       - type: genre
         value: Podcasts
         uri: http://id.loc.gov/authorities/genreForms/gf2011026450
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Poetry reading:
       - type: genre
         value: Poetry
         uri: http://id.loc.gov/authorities/genreForms/gf2014026481
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
-    Policy brief:
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Poster:
       - type: genre
         value: Posters
         uri: http://id.loc.gov/authorities/genreForms/gf2014026152
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Preprint:
       - type: genre
         value: grey literature
         uri: http://vocab.getty.edu/aat/300256200
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
-    Presentation recording:
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
-    Presentation slides:
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Questionnaire:
       - type: genre
         value: Questionnaires
         uri: http://id.loc.gov/authorities/genreForms/gf2018026144
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Remote sensing imagery:
       - type: genre
         value: Remote-sensing images
         uri: http://id.loc.gov/authorities/genreForms/gf2011026530
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Report:
       - type: genre
         value: reports
         uri: http://vocab.getty.edu/aat/300027267
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Software:
       - type: genre
         value: software
         uri: http://vocab.getty.edu/aat/300028566
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Sound recording:
       - type: genre
         value: Sound recordings
         uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
-    Speaker notes:
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Speech:
       - type: genre
         value: Speeches
         uri: http://id.loc.gov/authorities/genreForms/gf2011026363
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Statistical model:
       - type: genre
         value: mathematical models
         uri: http://vocab.getty.edu/aat/300065075
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Story:
       - type: genre
         value: Fiction
         uri: http://id.loc.gov/authorities/genreForms/gf2014026339
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Syllabus:
       - type: genre
         value: Outlines and syllabi
         uri: http://id.loc.gov/authorities/genreForms/gf2014026136
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Tabular data:
       - type: genre
         value: Tables (data)
         uri: http://id.loc.gov/authorities/genreForms/gf2014026186
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Technical report:
       - type: genre
         value: Technical reports
         uri: http://id.loc.gov/authorities/genreForms/gf2015026093
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Text corpus:
       - type: genre
         value: Text corpora
         uri: http://id.loc.gov/authorities/genreForms/gf2019026083
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
-    Text:
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Thesis:
       - type: genre
         value: Academic theses
         uri: http://id.loc.gov/authorities/genreForms/gf2014026039
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Transcript:
       - type: genre
         value: transcripts
         uri: http://vocab.getty.edu/aat/300027388
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
-    Unedited recording:
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Video art:
       - type: genre
         value: Video art
         uri: http://id.loc.gov/authorities/genreForms/gf2017027265
         source:
           code: lcgft
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Video recording:
       - type: genre
         value: moving images
         uri: http://vocab.getty.edu/aat/300263857
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     White paper:
       - type: genre
         value: grey literature
         uri: http://vocab.getty.edu/aat/300256200
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
     Working paper:
       - type: genre
         value: grey literature
         uri: http://vocab.getty.edu/aat/300256200
         source:
           code: aat
-      - type: genre
-        value: Data sets
-        uri: https://id.loc.gov/authorities/genreForms/gf2018026119
-        source:
-          code: lcgft
-      - type: genre
-        value: dataset
-        source:
-          code: local
 Image:
   type:
     - type: genre
@@ -1064,12 +456,6 @@ Image:
         uri: http://vocab.getty.edu/aat/300027777
         source:
           code: aat
-    Image:
-      - type: genre
-        value: Pictures
-        uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
     Interview:
       - type: genre
         value: Interviews
@@ -1626,105 +1012,46 @@ Music:
       source:
         code: lcgft
   subtypes:
-    3D model:
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Animation:
       - type: genre
         value: animations (visual works)
         uri: http://vocab.getty.edu/aat/300411663
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Article:
       - type: genre
         value: articles
         uri: http://vocab.getty.edu/aat/300048715
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Book:
       - type: genre
         value: books
         uri: http://vocab.getty.edu/aat/300028051
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
-    Book chapter:
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
-    Broadcast:
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     CAD:
       - type: genre
         value: computer-aided designs (visual works)
         uri: http://vocab.getty.edu/aat/300418056
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Code:
       - type: genre
         value: programs (computer)
         uri: http://vocab.getty.edu/aat/300312188
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
-    Conference session:
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Correspondence:
       - type: genre
         value: correspondence
         uri: http://vocab.getty.edu/aat/300026877
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Course/instructional materials:
       - type: genre
         value: Instructional and educational works
         uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
     Data:
@@ -1737,20 +1064,10 @@ Music:
         value: dataset
         source:
           code: local
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Database:
       - type: genre
         value: Databases
         uri: http://id.loc.gov/authorities/genreForms/gf2014026081
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
       - type: genre
@@ -1763,26 +1080,10 @@ Music:
         uri: http://vocab.getty.edu/aat/300249172
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
-    Documentation:
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Dramatic performance:
       - type: genre
         value: Drama
         uri: http://id.loc.gov/authorities/genreForms/gf2014026297
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
     Essay:
@@ -1791,20 +1092,10 @@ Music:
         uri: http://id.loc.gov/authorities/genreForms/gf2014026094
         source:
           code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Ethnography:
       - type: genre
         value: Ethnographies
         uri: http://id.loc.gov/authorities/genreForms/gf2018026013
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
     Event:
@@ -1813,26 +1104,10 @@ Music:
         uri: http://vocab.getty.edu/aat/300069084
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
-    Experimental audio/video:
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Field recording:
       - type: genre
         value: Field recordings
         uri: http://id.loc.gov/authorities/genreForms/gf2011026253
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
     Game:
@@ -1841,20 +1116,10 @@ Music:
         uri: http://vocab.getty.edu/aat/300422211
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Geospatial data:
       - type: genre
         value: Geographic information systems
         uri: http://id.loc.gov/authorities/genreForms/gf2011026294
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
       - type: genre
@@ -1867,20 +1132,10 @@ Music:
         uri: http://vocab.getty.edu/aat/300027777
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Image:
       - type: genre
         value: Pictures
         uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
     Interview:
@@ -1889,20 +1144,10 @@ Music:
         uri: http://id.loc.gov/authorities/genreForms/gf2014026115
         source:
           code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Journal/periodical issue:
       - type: genre
         value: Periodicals
         uri: http://id.loc.gov/authorities/genreForms/gf2014026139
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
     Manuscript:
@@ -1911,20 +1156,10 @@ Music:
         uri: http://vocab.getty.edu/aat/300028569
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Map:
       - type: genre
         value: Maps
         uri: http://id.loc.gov/authorities/genreForms/gf2011026387
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
     MIDI:
@@ -1933,31 +1168,16 @@ Music:
         uri: http://vocab.getty.edu/aat/300266746
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Musical transcription:
       - type: genre
         value: transcriptions (documents)
         uri: http://vocab.getty.edu/aat/300404333
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Notated music:
       - type: genre
         value: Notated music
         uri: http://id.loc.gov/authorities/genreForms/gf2014027184
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
     Narrative film:
@@ -1966,32 +1186,10 @@ Music:
         uri: http://id.loc.gov/authorities/genreForms/gf2011026250
         source:
           code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Oral history:
       - type: genre
         value: Oral histories
         uri: http://id.loc.gov/authorities/genreForms/gf2011026431
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
-    Other spoken word:
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
-    Performance:
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
     Photograph:
@@ -2000,31 +1198,16 @@ Music:
         uri: http://id.loc.gov/authorities/genreForms/gf2017027249
         source:
           code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Piano roll:
       - type: genre
         value: music rolls
         uri: http://vocab.getty.edu/aat/300429369
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Podcast:
       - type: genre
         value: Podcasts
         uri: http://id.loc.gov/authorities/genreForms/gf2011026450
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
     Poetry reading:
@@ -2033,26 +1216,10 @@ Music:
         uri: http://id.loc.gov/authorities/genreForms/gf2014026481
         source:
           code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
-    Policy brief:
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Poster:
       - type: genre
         value: Posters
         uri: http://id.loc.gov/authorities/genreForms/gf2014026152
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
     Preprint:
@@ -2061,43 +1228,16 @@ Music:
         uri: http://vocab.getty.edu/aat/300256200
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
-    Presentation recording:
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
-    Presentation slides:
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Questionnaire:
       - type: genre
         value: Questionnaires
         uri: http://id.loc.gov/authorities/genreForms/gf2018026144
         source:
           code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Remote sensing imagery:
       - type: genre
         value: Remote-sensing images
         uri: http://id.loc.gov/authorities/genreForms/gf2011026530
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
       - type: genre
@@ -2110,37 +1250,16 @@ Music:
         uri: http://vocab.getty.edu/aat/300027267
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Software:
       - type: genre
         value: software
         uri: http://vocab.getty.edu/aat/300028566
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Sound recording:
       - type: genre
         value: Sound recordings
         uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
-    Speaker notes:
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
     Speech:
@@ -2149,31 +1268,16 @@ Music:
         uri: http://id.loc.gov/authorities/genreForms/gf2011026363
         source:
           code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Statistical model:
       - type: genre
         value: mathematical models
         uri: http://vocab.getty.edu/aat/300065075
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Story:
       - type: genre
         value: Fiction
         uri: http://id.loc.gov/authorities/genreForms/gf2014026339
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
     Syllabus:
@@ -2182,20 +1286,10 @@ Music:
         uri: http://id.loc.gov/authorities/genreForms/gf2014026136
         source:
           code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Tabular data:
       - type: genre
         value: Tables (data)
         uri: http://id.loc.gov/authorities/genreForms/gf2014026186
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
       - type: genre
@@ -2208,11 +1302,6 @@ Music:
         uri: http://id.loc.gov/authorities/genreForms/gf2015026093
         source:
           code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Text corpus:
       - type: genre
         value: Text corpora
@@ -2220,29 +1309,13 @@ Music:
         source:
           code: lcgft
       - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
-      - type: genre
         value: dataset
         source:
           code: local
-    Text:
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Thesis:
       - type: genre
         value: Academic theses
         uri: http://id.loc.gov/authorities/genreForms/gf2014026039
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
     Transcript:
@@ -2251,26 +1324,10 @@ Music:
         uri: http://vocab.getty.edu/aat/300027388
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
-    Unedited recording:
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Video art:
       - type: genre
         value: Video art
         uri: http://id.loc.gov/authorities/genreForms/gf2017027265
-        source:
-          code: lcgft
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
         source:
           code: lcgft
     Video recording:
@@ -2279,33 +1336,18 @@ Music:
         uri: http://vocab.getty.edu/aat/300263857
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     White paper:
       - type: genre
         value: grey literature
         uri: http://vocab.getty.edu/aat/300256200
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
     Working paper:
       - type: genre
         value: grey literature
         uri: http://vocab.getty.edu/aat/300256200
         source:
           code: aat
-      - type: genre
-        value: Music
-        uri: https://id.loc.gov/authorities/genreForms/gf2014026952
-        source:
-          code: lcgft
 Other:
   subtypes:
     Animation:
@@ -2990,105 +2032,46 @@ Sound:
       source:
         code: lcgft
   subtypes:
-    3D model:
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Animation:
       - type: genre
         value: animations (visual works)
         uri: http://vocab.getty.edu/aat/300411663
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Article:
       - type: genre
         value: articles
         uri: http://vocab.getty.edu/aat/300048715
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Book:
       - type: genre
         value: books
         uri: http://vocab.getty.edu/aat/300028051
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-    Book chapter:
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-    Broadcast:
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     CAD:
       - type: genre
         value: computer-aided designs (visual works)
         uri: http://vocab.getty.edu/aat/300418056
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Code:
       - type: genre
         value: programs (computer)
         uri: http://vocab.getty.edu/aat/300312188
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-    Conference session:
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Correspondence:
       - type: genre
         value: correspondence
         uri: http://vocab.getty.edu/aat/300026877
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Course/instructional materials:
       - type: genre
         value: Instructional and educational works
         uri: http://id.loc.gov/authorities/genreForms/gf2014026114
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
     Data:
@@ -3101,20 +2084,10 @@ Sound:
         value: dataset
         source:
           code: local
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Database:
       - type: genre
         value: Databases
         uri: http://id.loc.gov/authorities/genreForms/gf2014026081
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
       - type: genre
@@ -3127,26 +2100,10 @@ Sound:
         uri: http://vocab.getty.edu/aat/300249172
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-    Documentation:
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Dramatic performance:
       - type: genre
         value: Drama
         uri: http://id.loc.gov/authorities/genreForms/gf2014026297
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
     Essay:
@@ -3155,20 +2112,10 @@ Sound:
         uri: http://id.loc.gov/authorities/genreForms/gf2014026094
         source:
           code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Ethnography:
       - type: genre
         value: Ethnographies
         uri: http://id.loc.gov/authorities/genreForms/gf2018026013
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
     Event:
@@ -3177,26 +2124,10 @@ Sound:
         uri: http://vocab.getty.edu/aat/300069084
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-    Experimental audio/video:
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Field recording:
       - type: genre
         value: Field recordings
         uri: http://id.loc.gov/authorities/genreForms/gf2011026253
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
     Game:
@@ -3205,20 +2136,10 @@ Sound:
         uri: http://vocab.getty.edu/aat/300422211
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Geospatial data:
       - type: genre
         value: Geographic information systems
         uri: http://id.loc.gov/authorities/genreForms/gf2011026294
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
       - type: genre
@@ -3231,20 +2152,10 @@ Sound:
         uri: http://vocab.getty.edu/aat/300027777
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Image:
       - type: genre
         value: Pictures
         uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
     Interview:
@@ -3253,20 +2164,10 @@ Sound:
         uri: http://id.loc.gov/authorities/genreForms/gf2014026115
         source:
           code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Journal/periodical issue:
       - type: genre
         value: Periodicals
         uri: http://id.loc.gov/authorities/genreForms/gf2014026139
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
     Manuscript:
@@ -3275,20 +2176,10 @@ Sound:
         uri: http://vocab.getty.edu/aat/300028569
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Map:
       - type: genre
         value: Maps
         uri: http://id.loc.gov/authorities/genreForms/gf2011026387
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
     MIDI:
@@ -3297,31 +2188,16 @@ Sound:
         uri: http://vocab.getty.edu/aat/300266746
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Musical transcription:
       - type: genre
         value: transcriptions (documents)
         uri: http://vocab.getty.edu/aat/300404333
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Notated music:
       - type: genre
         value: Notated music
         uri: http://id.loc.gov/authorities/genreForms/gf2014027184
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
     Narrative film:
@@ -3330,32 +2206,10 @@ Sound:
         uri: http://id.loc.gov/authorities/genreForms/gf2011026250
         source:
           code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Oral history:
       - type: genre
         value: Oral histories
         uri: http://id.loc.gov/authorities/genreForms/gf2011026431
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-    Other spoken word:
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-    Performance:
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
     Photograph:
@@ -3364,31 +2218,16 @@ Sound:
         uri: http://id.loc.gov/authorities/genreForms/gf2017027249
         source:
           code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Piano roll:
       - type: genre
         value: music rolls
         uri: http://vocab.getty.edu/aat/300429369
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Podcast:
       - type: genre
         value: Podcasts
         uri: http://id.loc.gov/authorities/genreForms/gf2011026450
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
     Poetry reading:
@@ -3397,26 +2236,10 @@ Sound:
         uri: http://id.loc.gov/authorities/genreForms/gf2014026481
         source:
           code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-    Policy brief:
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Poster:
       - type: genre
         value: Posters
         uri: http://id.loc.gov/authorities/genreForms/gf2014026152
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
     Preprint:
@@ -3425,43 +2248,16 @@ Sound:
         uri: http://vocab.getty.edu/aat/300256200
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-    Presentation recording:
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-    Presentation slides:
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Questionnaire:
       - type: genre
         value: Questionnaires
         uri: http://id.loc.gov/authorities/genreForms/gf2018026144
         source:
           code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Remote sensing imagery:
       - type: genre
         value: Remote-sensing images
         uri: http://id.loc.gov/authorities/genreForms/gf2011026530
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
       - type: genre
@@ -3474,43 +2270,16 @@ Sound:
         uri: http://vocab.getty.edu/aat/300027267
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Software:
       - type: genre
         value: software
         uri: http://vocab.getty.edu/aat/300028566
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-    Sound recording:
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-    Speaker notes:
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Speech:
       - type: genre
         value: Speeches
         uri: http://id.loc.gov/authorities/genreForms/gf2011026363
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
     Statistical model:
@@ -3519,20 +2288,10 @@ Sound:
         uri: http://vocab.getty.edu/aat/300065075
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Story:
       - type: genre
         value: Fiction
         uri: http://id.loc.gov/authorities/genreForms/gf2014026339
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
     Syllabus:
@@ -3541,20 +2300,10 @@ Sound:
         uri: http://id.loc.gov/authorities/genreForms/gf2014026136
         source:
           code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Tabular data:
       - type: genre
         value: Tables (data)
         uri: http://id.loc.gov/authorities/genreForms/gf2014026186
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
       - type: genre
@@ -3567,11 +2316,6 @@ Sound:
         uri: http://id.loc.gov/authorities/genreForms/gf2015026093
         source:
           code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Text corpus:
       - type: genre
         value: Text corpora
@@ -3579,29 +2323,13 @@ Sound:
         source:
           code: lcgft
       - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-      - type: genre
         value: dataset
         source:
           code: local
-    Text:
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Thesis:
       - type: genre
         value: Academic theses
         uri: http://id.loc.gov/authorities/genreForms/gf2014026039
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
     Transcript:
@@ -3610,26 +2338,10 @@ Sound:
         uri: http://vocab.getty.edu/aat/300027388
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
-    Unedited recording:
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Video art:
       - type: genre
         value: Video art
         uri: http://id.loc.gov/authorities/genreForms/gf2017027265
-        source:
-          code: lcgft
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: lcgft
     Video recording:
@@ -3638,33 +2350,18 @@ Sound:
         uri: http://vocab.getty.edu/aat/300263857
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     White paper:
       - type: genre
         value: grey literature
         uri: http://vocab.getty.edu/aat/300256200
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
     Working paper:
       - type: genre
         value: grey literature
         uri: http://vocab.getty.edu/aat/300256200
         source:
           code: aat
-      - type: genre
-        value: Sound recordings
-        uri: http://id.loc.gov/authorities/genreForms/gf2011026594
-        source:
-          code: lcgft
 Text:
   subtypes:
     Animation:
@@ -4017,21 +2714,10 @@ Video:
       source:
         code: aat
   subtypes:
-    3D model:
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Animation:
       - type: genre
         value: animations (visual works)
         uri: http://vocab.getty.edu/aat/300411663
-        source:
-          code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
         source:
           code: aat
     Article:
@@ -4040,32 +2726,10 @@ Video:
         uri: http://vocab.getty.edu/aat/300048715
         source:
           code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Book:
       - type: genre
         value: books
         uri: http://vocab.getty.edu/aat/300028051
-        source:
-          code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
-    Book chapter:
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
-    Broadcast:
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
         source:
           code: aat
     CAD:
@@ -4074,26 +2738,10 @@ Video:
         uri: http://vocab.getty.edu/aat/300418056
         source:
           code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Code:
       - type: genre
         value: programs (computer)
         uri: http://vocab.getty.edu/aat/300312188
-        source:
-          code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
-    Conference session:
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
         source:
           code: aat
     Correspondence:
@@ -4102,22 +2750,12 @@ Video:
         uri: http://vocab.getty.edu/aat/300026877
         source:
           code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Course/instructional materials:
       - type: genre
         value: Instructional and educational works
         uri: http://id.loc.gov/authorities/genreForms/gf2014026114
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Data:
       - type: genre
         value: Data sets
@@ -4128,22 +2766,12 @@ Video:
         value: dataset
         source:
           code: local
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Database:
       - type: genre
         value: Databases
         uri: http://id.loc.gov/authorities/genreForms/gf2014026081
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
       - type: genre
         value: dataset
         source:
@@ -4155,54 +2783,28 @@ Video:
         source:
           code: aat
       - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
-      - type: genre
         value: Documentary films
         uri: http://id.loc.gov/authorities/genreForms/gf2011026205
         source:
           code: lcgft
-    Documentation:
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Dramatic performance:
       - type: genre
         value: Drama
         uri: http://id.loc.gov/authorities/genreForms/gf2014026297
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Essay:
       - type: genre
         value: Essays
         uri: http://id.loc.gov/authorities/genreForms/gf2014026094
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Ethnography:
       - type: genre
         value: Ethnographies
         uri: http://id.loc.gov/authorities/genreForms/gf2018026013
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
       - type: genre
         value: Ethnographic films
         uri: http://id.loc.gov/authorities/genreForms/gf2011026232
@@ -4214,17 +2816,7 @@ Video:
         uri: http://vocab.getty.edu/aat/300069084
         source:
           code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Experimental audio/video:
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
       - type: genre
         value: Experimental films
         uri: http://id.loc.gov/authorities/genreForms/gf2011026235
@@ -4236,20 +2828,10 @@ Video:
         uri: http://id.loc.gov/authorities/genreForms/gf2011026253
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Game:
       - type: genre
         value: computer game
         uri: http://vocab.getty.edu/aat/300422211
-        source:
-          code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
         source:
           code: aat
     Geospatial data:
@@ -4258,11 +2840,6 @@ Video:
         uri: http://id.loc.gov/authorities/genreForms/gf2011026294
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
       - type: genre
         value: dataset
         source:
@@ -4273,20 +2850,10 @@ Video:
         uri: http://vocab.getty.edu/aat/300027777
         source:
           code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Image:
       - type: genre
         value: Pictures
         uri: http://id.loc.gov/authorities/genreForms/gf2017027251
-        source:
-          code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
         source:
           code: aat
     Interview:
@@ -4295,31 +2862,16 @@ Video:
         uri: http://id.loc.gov/authorities/genreForms/gf2014026115
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Journal/periodical issue:
       - type: genre
         value: Periodicals
         uri: http://id.loc.gov/authorities/genreForms/gf2014026139
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Manuscript:
       - type: genre
         value: manuscripts (documents)
         uri: http://vocab.getty.edu/aat/300028569
-        source:
-          code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
         source:
           code: aat
     Map:
@@ -4328,20 +2880,10 @@ Video:
         uri: http://id.loc.gov/authorities/genreForms/gf2011026387
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     MIDI:
       - type: genre
         value: MIDI (information technology)
         uri: http://vocab.getty.edu/aat/300266746
-        source:
-          code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
         source:
           code: aat
     Musical transcription:
@@ -4350,56 +2892,25 @@ Video:
         uri: http://vocab.getty.edu/aat/300404333
         source:
           code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Notated music:
       - type: genre
         value: Notated music
         uri: http://id.loc.gov/authorities/genreForms/gf2014027184
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Narrative film:
       - type: genre
         value: Fiction films
         uri: http://id.loc.gov/authorities/genreForms/gf2011026250
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Oral history:
       - type: genre
         value: Oral histories
         uri: http://id.loc.gov/authorities/genreForms/gf2011026431
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
-    Other spoken word:
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Performance:
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
       - type: genre
         value: Filmed performances
         uri: http://id.loc.gov/authorities/genreForms/gf2011026276
@@ -4411,20 +2922,10 @@ Video:
         uri: http://id.loc.gov/authorities/genreForms/gf2017027249
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Piano roll:
       - type: genre
         value: music rolls
         uri: http://vocab.getty.edu/aat/300429369
-        source:
-          code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
         source:
           code: aat
     Podcast:
@@ -4433,60 +2934,22 @@ Video:
         uri: http://id.loc.gov/authorities/genreForms/gf2011026450
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Poetry reading:
       - type: genre
         value: Poetry
         uri: http://id.loc.gov/authorities/genreForms/gf2014026481
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
-    Policy brief:
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Poster:
       - type: genre
         value: Posters
         uri: http://id.loc.gov/authorities/genreForms/gf2014026152
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Preprint:
       - type: genre
         value: grey literature
         uri: http://vocab.getty.edu/aat/300256200
-        source:
-          code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
-    Presentation recording:
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
-    Presentation slides:
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
         source:
           code: aat
     Questionnaire:
@@ -4495,22 +2958,12 @@ Video:
         uri: http://id.loc.gov/authorities/genreForms/gf2018026144
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Remote sensing imagery:
       - type: genre
         value: Remote-sensing images
         uri: http://id.loc.gov/authorities/genreForms/gf2011026530
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
       - type: genre
         value: dataset
         source:
@@ -4521,20 +2974,10 @@ Video:
         uri: http://vocab.getty.edu/aat/300027267
         source:
           code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Software:
       - type: genre
         value: software
         uri: http://vocab.getty.edu/aat/300028566
-        source:
-          code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
         source:
           code: aat
     Sound recording:
@@ -4543,37 +2986,16 @@ Video:
         uri: http://id.loc.gov/authorities/genreForms/gf2011026594
         source:
           code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
-    Speaker notes:
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Speech:
       - type: genre
         value: Speeches
         uri: http://id.loc.gov/authorities/genreForms/gf2011026363
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Statistical model:
       - type: genre
         value: mathematical models
         uri: http://vocab.getty.edu/aat/300065075
-        source:
-          code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
         source:
           code: aat
     Story:
@@ -4582,33 +3004,18 @@ Video:
         uri: http://id.loc.gov/authorities/genreForms/gf2014026339
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Syllabus:
       - type: genre
         value: Outlines and syllabi
         uri: http://id.loc.gov/authorities/genreForms/gf2014026136
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Tabular data:
       - type: genre
         value: Tables (data)
         uri: http://id.loc.gov/authorities/genreForms/gf2014026186
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
       - type: genre
         value: dataset
         source:
@@ -4619,11 +3026,6 @@ Video:
         uri: http://id.loc.gov/authorities/genreForms/gf2015026093
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Text corpus:
       - type: genre
         value: Text corpora
@@ -4631,48 +3033,22 @@ Video:
         source:
           code: lcgft
       - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
-      - type: genre
         value: dataset
         source:
           code: local
-    Text:
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Thesis:
       - type: genre
         value: Academic theses
         uri: http://id.loc.gov/authorities/genreForms/gf2014026039
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Transcript:
       - type: genre
         value: transcripts
         uri: http://vocab.getty.edu/aat/300027388
         source:
           code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Unedited recording:
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
       - type: genre
         value: Unedited footage
         uri: http://id.loc.gov/authorities/genreForms/gf2011026712
@@ -4684,36 +3060,15 @@ Video:
         uri: http://id.loc.gov/authorities/genreForms/gf2017027265
         source:
           code: lcgft
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
-    Video recording:
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     White paper:
       - type: genre
         value: grey literature
         uri: http://vocab.getty.edu/aat/300256200
         source:
           code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
-        source:
-          code: aat
     Working paper:
       - type: genre
         value: grey literature
         uri: http://vocab.getty.edu/aat/300256200
-        source:
-          code: aat
-      - type: genre
-        value: moving images
-        uri: http://vocab.getty.edu/aat/300263857
         source:
           code: aat

--- a/config/mappings/types_to_resource_types.yml
+++ b/config/mappings/types_to_resource_types.yml
@@ -3050,6 +3050,11 @@ Sound:
         source:
           value: MODS resource types
 Text:
+  type:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
   subtypes:
     3D model:
       - type: resource type
@@ -3474,6 +3479,11 @@ Text:
         source:
           value: MODS resource types
 Video:
+  type:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
   subtypes:
     3D model:
       - type: resource type

--- a/config/mappings/types_to_resource_types.yml
+++ b/config/mappings/types_to_resource_types.yml
@@ -1,511 +1,3937 @@
-Text:
-  type:
-    type: resource type
-    value: text
-    source:
-      value: MODS resource types
-  subtypes:
-    Article:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Government document:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Policy brief:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Preprint:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Report:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Technical report:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Thesis:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Working paper:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
 Data:
-  type:
-    type: resource type
-    value: software, multimedia
-    source:
-      value: MODS resource types
-  subtypes:
-    3D model:
-      - type: resource type
-        value: three dimensional object
-        source:
-          value: MODS resource types
-    Database:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
-    Documentation:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Geospatial data:
-      - type: resource type
-        value: cartographic
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
-    Image:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
-    Tabular data:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Text corpus:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-Software/Code:
-  type:
-    type: resource type
-    value: software, multimedia
-    source:
-      value: MODS resource types
-  subtypes:
-    Code:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
-    Documentation:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Game:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+  3D model:
+    - type: resource type
+      value: three-dimensional object
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Animation:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Article:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Book:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Book chapter:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Broadcast:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  CAD:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Code:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Conference session:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Correspondence:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Course/instructional materials:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Database:
+    - type: software, multimedia
+      value: text
+      source:
+        value: MODS resource types
+  Documentary:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Documentation:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Dramatic performance:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Essay:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Ethnography:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Event:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Experimental audio/video:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Field recording:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Game:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Geospatial data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Government document:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Image:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Interview:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Journal/periodical issue:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Manuscript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Map:
+    - type: resource type
+      value: cartographic
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  MIDI:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Musical transcription:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Notated music:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Narrative film:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Oral history:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Other spoken word:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Performance:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Photograph:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Piano roll:
+    - type: resource type
+      value: sound recording-musical
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Podcast:
+    - type: resource type
+      value: sound recording-nonmusical
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Poetry reading:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Policy brief:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Poster:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Preprint:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Presentation recording:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Presentation slides:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Questionnaire:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Remote sensing imagery:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Software:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Sound recording:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Speaker notes:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Speech:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Statistical model:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Story:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Syllabus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Tabular data:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Technical report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Text corpus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Text:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Thesis:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Transcript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Unedited recording:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Video art:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Video recording:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  White paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Working paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
 Image:
-  type:
-    type: resource type
-    value: still image
-    source:
-      value: MODS resource types
-  subtypes:
-    CAD:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
-    Map:
-      - type: resource type
-        value: cartographic
-        source:
-          value: MODS resource types
-    Photograph:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
-    Poster:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
-    Presentation slides:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
-Sound:
-  type:
-    type: resource type
-    value: sound recording
-    source:
-      value: MODS resource types
-  subtypes:
-    Interview:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Oral history:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Podcast:
-      - type: resource type
-        value: Podcasts
-        source:
-          value: MODS resource types
-    Speech:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-Video:
-  type:
-    type: resource type
-    value: moving image
-    source:
-      value: MODS resource types
-  subtypes:
-    Conference session:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Documentary:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Event:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Oral history:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Performance:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-Music:
-  type:
-    type: resource type
-    value: music
-    source:
-      value: MODS resource types
-  subtypes:
-    Data:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
-    Image:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
-    MIDI:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Musical transcription:
-      - type: resource type
-        value: notated music
-        source:
-          value: MODS resource types
-    Notated music:
-      - type: resource type
-        value: notated music
-        source:
-          value: MODS resource types
-    Piano roll:
-      - type: resource type
-        value: sound recording-musical
-        source:
-          value: MODS resource types
-    Software/Code:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
-    Sound:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Text:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Video:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+  3D model:
+    - type: resource type
+      value: three-dimensional object
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Animation:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Article:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Book:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Book chapter:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Broadcast:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  CAD:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Code:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Conference session:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Correspondence:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Course/instructional materials:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Database:
+    - type: software, multimedia
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Documentary:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Documentation:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Dramatic performance:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Essay:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Ethnography:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Event:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Experimental audio/video:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Field recording:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Game:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Geospatial data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Government document:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Image:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Interview:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Journal/periodical issue:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Manuscript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Map:
+    - type: resource type
+      value: cartographic
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  MIDI:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Musical transcription:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Notated music:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Narrative film:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Oral history:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Other spoken word:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Performance:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Photograph:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Piano roll:
+    - type: resource type
+      value: sound recording-musical
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Podcast:
+    - type: resource type
+      value: sound recording-nonmusical
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Poetry reading:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Policy brief:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Poster:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Preprint:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Presentation recording:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Presentation slides:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Questionnaire:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Remote sensing imagery:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Software:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Sound recording:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Speaker notes:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Speech:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Statistical model:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Story:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Syllabus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Tabular data:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Technical report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Text corpus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Text:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Thesis:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Transcript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Unedited recording:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Video art:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Video recording:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  White paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Working paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
 Mixed Materials:
-  type:
-    type: resource type
-    value: mixed material
-    source:
-      value: MODS resource types
-  subtypes:
-    Data:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
-    Image:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
-    Software/Code:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
-    Sound:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Text:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Video:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-General:
-  subtypes:
-    Animation:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Book:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Book chapter:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Broadcast:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Correspondence:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    # TODO: How to deal with this duplication?
-    Course/instructional materials:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Course/instructional materials:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Documentary:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Dramatic performance:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Essay:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    # TODO: How to deal with this duplication?
-    Ethnography:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Ethnography:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Experimental audio/video:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    # TODO: How to deal with this duplication?
-    Field recording:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Field recording:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Journal/periodical issue:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Manuscript:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    MIDI:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Musical transcription:
-      - type: resource type
-        value: notated music
-        source:
-          value: MODS resource types
-    Narrative film:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Notated music:
-      - type: resource type
-        value: notated music
-        source:
-          value: MODS resource types
-    Other spoken word:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Piano roll:
-      - type: resource type
-        value: sound recording-musical
-        source:
-          value: MODS resource types
-    Poetry reading:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Poster:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Presentation recording:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Presentation slides:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Questionnaire:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Remote sensing imagery:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
-    Software:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
-    Sound recording:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Speaker notes:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Speech:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Story:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Syllabus:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    Transcript:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
-    # TODO: How to deal with this duplication?
-    Unedited recording:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Unedited recording:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
-    Video art:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    Video recording:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
-    White paper:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+  3D model:
+    - type: resource type
+      value: three-dimensional object
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Animation:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Article:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Book:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Book chapter:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Broadcast:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  CAD:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Code:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Conference session:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Correspondence:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Course/instructional materials:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Database:
+    - type: software, multimedia
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Documentary:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Documentation:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Dramatic performance:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Essay:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Ethnography:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Event:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Experimental audio/video:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Field recording:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Game:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Geospatial data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Government document:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Image:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Interview:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Journal/periodical issue:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Manuscript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Map:
+    - type: resource type
+      value: cartographic
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  MIDI:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Musical transcription:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Notated music:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Narrative film:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Oral history:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Other spoken word:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Performance:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Photograph:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Piano roll:
+    - type: resource type
+      value: sound recording-musical
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Podcast:
+    - type: resource type
+      value: sound recording-nonmusical
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Poetry reading:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Policy brief:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Poster:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Preprint:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Presentation recording:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Presentation slides:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Questionnaire:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Remote sensing imagery:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Software:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Sound recording:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Speaker notes:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Speech:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Statistical model:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Story:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Syllabus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Tabular data:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Technical report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Text corpus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Text:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Thesis:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Transcript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Unedited recording:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Video art:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Video recording:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  White paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  Working paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+Music:
+  3D model:
+    - type: resource type
+      value: three-dimensional object
+      source:
+        value: MODS resource types
+  Animation:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Article:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Book:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Book chapter:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Broadcast:
+    # no value
+  CAD:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Code:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Conference session:
+    # no value
+  Correspondence:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Course/instructional materials:
+    # no value
+  Data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Database:
+    - type: software, multimedia
+      value: text
+      source:
+        value: MODS resource types
+  Documentary:
+    # no value
+  Documentation:
+    # no value
+  Dramatic performance:
+    # no value
+  Essay:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Ethnography:
+    # no value
+  Event:
+    # no value
+  Experimental audio/video:
+    # no value
+  Field recording:
+    # no value
+  Game:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Geospatial data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Government document:
+    # no value
+  Image:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Interview:
+    # no value
+  Journal/periodical issue:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Manuscript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Map:
+    - type: resource type
+      value: cartographic
+      source:
+        value: MODS resource types
+  MIDI:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Musical transcription:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+  Notated music:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Narrative film:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Oral history:
+    # no value
+  Other spoken word:
+    # no value
+  Performance:
+    # no value
+  Photograph:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Piano roll:
+    - type: resource type
+      value: sound recording-musical
+      source:
+        value: MODS resource types
+  Podcast:
+    - type: resource type
+      value: sound recording-nonmusical
+      source:
+        value: MODS resource types
+  Poetry reading:
+    # no value
+  Policy brief:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Poster:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Preprint:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Presentation recording:
+    # no value
+  Presentation slides:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Questionnaire:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Remote sensing imagery:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Software:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Sound recording:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Speaker notes:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Speech:
+    # no value
+  Statistical model:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Story:
+    # no value
+  Syllabus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Tabular data:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Technical report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Text corpus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Text:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Thesis:
+    # no value
+  Transcript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Unedited recording:
+    # no value
+  Video art:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Video recording:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  White paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Working paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+Other:
+  3D model:
+    - type: resource type
+      value: three-dimensional object
+      source:
+        value: MODS resource types
+  Animation:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Article:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Book:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Book chapter:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Broadcast:
+    # no value
+  CAD:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Code:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Conference session:
+    # no value
+  Correspondence:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Course/instructional materials:
+    # no value
+  Data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Database:
+    - type: software, multimedia
+      value: text
+      source:
+        value: MODS resource types
+  Documentary:
+    # no value
+  Documentation:
+    # no value
+  Dramatic performance:
+    # no value
+  Essay:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Ethnography:
+    # no value
+  Event:
+    # no value
+  Experimental audio/video:
+    # no value
+  Field recording:
+    # no value
+  Game:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Geospatial data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Government document:
+    # no value
+  Image:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Interview:
+    # no value
+  Journal/periodical issue:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Manuscript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Map:
+    - type: resource type
+      value: cartographic
+      source:
+        value: MODS resource types
+  MIDI:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Musical transcription:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+  Notated music:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Narrative film:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Oral history:
+    # no value
+  Other spoken word:
+    # no value
+  Performance:
+    # no value
+  Photograph:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Piano roll:
+    - type: resource type
+      value: sound recording-musical
+      source:
+        value: MODS resource types
+  Podcast:
+    - type: resource type
+      value: sound recording-nonmusical
+      source:
+        value: MODS resource types
+  Poetry reading:
+    # no value
+  Policy brief:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Poster:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Preprint:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Presentation recording:
+    # no value
+  Presentation slides:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Questionnaire:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Remote sensing imagery:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  Report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Software:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Sound recording:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Speaker notes:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Speech:
+    # no value
+  Statistical model:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Story:
+    # no value
+  Syllabus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Tabular data:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Technical report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Text corpus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Text:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Thesis:
+    # no value
+  Transcript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Unedited recording:
+    # no value
+  Video art:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Video recording:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  White paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Working paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+Software/Code:
+  3D model:
+    - type: resource type
+      value: three-dimensional object
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Animation:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Article:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Book:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Book chapter:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Broadcast:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  CAD:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Code:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Conference session:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Correspondence:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Course/instructional materials:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Database:
+    - type: software, multimedia
+      value: text
+      source:
+        value: MODS resource types
+  Documentary:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Documentation:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Dramatic performance:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Essay:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Ethnography:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Event:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Experimental audio/video:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Field recording:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Game:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Geospatial data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Government document:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Image:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Interview:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Journal/periodical issue:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Manuscript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Map:
+    - type: resource type
+      value: cartographic
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  MIDI:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Musical transcription:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Notated music:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Narrative film:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Oral history:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Other spoken word:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Performance:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Photograph:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Piano roll:
+    - type: resource type
+      value: sound recording-musical
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Podcast:
+    - type: resource type
+      value: sound recording-nonmusical
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Poetry reading:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Policy brief:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Poster:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Preprint:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Presentation recording:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Presentation slides:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Questionnaire:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Remote sensing imagery:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Software:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Sound recording:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Speaker notes:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Speech:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Statistical model:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Story:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Syllabus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Tabular data:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Technical report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Text corpus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Text:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Thesis:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Transcript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Unedited recording:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Video art:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Video recording:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  White paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  Working paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+Sound:
+  3D model:
+    - type: resource type
+      value: three-dimensional object
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Animation:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Article:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Book:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Book chapter:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Broadcast:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  CAD:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Code:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Conference session:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Correspondence:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Course/instructional materials:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Database:
+    - type: software, multimedia
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Documentary:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Documentation:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Dramatic performance:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Essay:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Ethnography:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Event:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Experimental audio/video:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Field recording:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Game:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Geospatial data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Government document:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Image:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Interview:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Journal/periodical issue:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Manuscript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Map:
+    - type: resource type
+      value: cartographic
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  MIDI:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Musical transcription:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Notated music:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Narrative film:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Oral history:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Other spoken word:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Performance:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Photograph:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Piano roll:
+    - type: resource type
+      value: sound recording-musical
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Podcast:
+    - type: resource type
+      value: sound recording-nonmusical
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Poetry reading:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Policy brief:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Poster:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Preprint:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Presentation recording:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Presentation slides:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Questionnaire:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Remote sensing imagery:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Software:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Sound recording:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Speaker notes:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Speech:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Statistical model:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Story:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Syllabus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Tabular data:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Technical report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Text corpus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Text:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Thesis:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Transcript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Unedited recording:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Video art:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Video recording:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  White paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  Working paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+Text:
+  3D model:
+    - type: resource type
+      value: three-dimensional object
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Animation:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Article:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Book:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Book chapter:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Broadcast:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  CAD:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Code:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Conference session:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Correspondence:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Course/instructional materials:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Database:
+    - type: software, multimedia
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Documentary:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Documentation:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Dramatic performance:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Essay:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Ethnography:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Event:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Experimental audio/video:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Field recording:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Game:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Geospatial data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Government document:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Image:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Interview:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Journal/periodical issue:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Manuscript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Map:
+    - type: resource type
+      value: cartographic
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  MIDI:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Musical transcription:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Notated music:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Narrative film:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Oral history:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Other spoken word:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Performance:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Photograph:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Piano roll:
+    - type: resource type
+      value: sound recording-musical
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Podcast:
+    - type: resource type
+      value: sound recording-nonmusical
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Poetry reading:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Policy brief:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Poster:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Preprint:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Presentation recording:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Presentation slides:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Questionnaire:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Remote sensing imagery:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Software:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Sound recording:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Speaker notes:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Speech:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Statistical model:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Story:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Syllabus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Tabular data:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Technical report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Text corpus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Text:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Thesis:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Transcript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Unedited recording:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Video art:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Video recording:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  White paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+  Working paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+Video:
+  3D model:
+    - type: resource type
+      value: three-dimensional object
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Animation:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Article:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Book:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Book chapter:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Broadcast:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  CAD:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Code:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Conference session:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Correspondence:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Course/instructional materials:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Database:
+    - type: software, multimedia
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Documentary:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Documentation:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Dramatic performance:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Essay:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Ethnography:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Event:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Experimental audio/video:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Field recording:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Game:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Geospatial data:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Government document:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Image:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Interview:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Journal/periodical issue:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Manuscript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Map:
+    - type: resource type
+      value: cartographic
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  MIDI:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Musical transcription:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Notated music:
+    - type: resource type
+      value: notated music
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Narrative film:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Oral history:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Other spoken word:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Performance:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Photograph:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Piano roll:
+    - type: resource type
+      value: sound recording-musical
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Podcast:
+    - type: resource type
+      value: sound recording-nonmusical
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Poetry reading:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Policy brief:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Poster:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Preprint:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Presentation recording:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Presentation slides:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Questionnaire:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Remote sensing imagery:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Software:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Sound recording:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Speaker notes:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Speech:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Statistical model:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Story:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Syllabus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Tabular data:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Technical report:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Text corpus:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Text:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Thesis:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Transcript:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Unedited recording:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Video art:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Video recording:
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  White paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types
+  Working paper:
+    - type: resource type
+      value: text
+      source:
+        value: MODS resource types
+    - type: resource type
+      value: moving image
+      source:
+        value: MODS resource types

--- a/config/mappings/types_to_resource_types.yml
+++ b/config/mappings/types_to_resource_types.yml
@@ -3,15 +3,11 @@ Data:
     - type: resource type
       value: software, multimedia
       source:
-        value: MODS resource types
+      value: MODS resource types
   subtypes:
     3D model:
       - type: resource type
         value: three-dimensional object
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Animation:
@@ -19,17 +15,9 @@ Data:
         value: moving image
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Article:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Book:
@@ -37,31 +25,16 @@ Data:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Book chapter:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Broadcast:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     CAD:
       - type: resource type
         value: still image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Code:
@@ -69,119 +42,54 @@ Data:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Conference session:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Correspondence:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Course/instructional materials:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Data:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Database:
-      - type: software, multimedia
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Documentary:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Documentation:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Dramatic performance:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Essay:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Ethnography:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Event:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Experimental audio/video:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Field recording:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Game:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Geospatial data:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Government document:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Image:
       - type: resource type
         value: still image
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Interview:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Journal/periodical issue:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Manuscript:
@@ -189,17 +97,9 @@ Data:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Map:
       - type: resource type
         value: cartographic
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     MIDI:
@@ -207,17 +107,9 @@ Data:
         value: sound recording
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Musical transcription:
       - type: resource type
         value: notated music
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Notated music:
@@ -225,41 +117,20 @@ Data:
         value: notated music
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Narrative film:
       - type: resource type
         value: moving image
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Oral history:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Other spoken word:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Performance:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Photograph:
       - type: resource type
         value: still image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Piano roll:
@@ -267,31 +138,16 @@ Data:
         value: sound recording-musical
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Podcast:
       - type: resource type
         value: sound recording-nonmusical
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Poetry reading:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Policy brief:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Poster:
@@ -299,31 +155,16 @@ Data:
         value: still image
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Preprint:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Presentation recording:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Presentation slides:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Questionnaire:
@@ -331,17 +172,9 @@ Data:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Remote sensing imagery:
       - type: resource type
         value: still image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Report:
@@ -349,22 +182,11 @@ Data:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Software:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Sound recording:
       - type: resource type
         value: sound recording
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Speaker notes:
@@ -372,32 +194,15 @@ Data:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Speech:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Statistical model:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Story:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Syllabus:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Tabular data:
@@ -405,17 +210,9 @@ Data:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Technical report:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Text corpus:
@@ -423,45 +220,23 @@ Data:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Text:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Thesis:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Transcript:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Unedited recording:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Video art:
       - type: resource type
         value: moving image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Video recording:
@@ -469,26 +244,14 @@ Data:
         value: moving image
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     White paper:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Working paper:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
 Image:
@@ -503,17 +266,9 @@ Image:
         value: three-dimensional object
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Animation:
       - type: resource type
         value: moving image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: still image
         source:
           value: MODS resource types
     Article:
@@ -521,17 +276,9 @@ Image:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Book:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: still image
         source:
           value: MODS resource types
     Book chapter:
@@ -539,55 +286,27 @@ Image:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Broadcast:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     CAD:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Code:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Conference session:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Correspondence:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Course/instructional materials:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Data:
       - type: resource type
         value: software, multimedia
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: still image
         source:
           value: MODS resource types
     Database:
@@ -595,61 +314,28 @@ Image:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Documentary:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Documentation:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Dramatic performance:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Essay:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Ethnography:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Event:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Experimental audio/video:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Field recording:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Game:
       - type: resource type
         value: software, multimedia
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: still image
         source:
           value: MODS resource types
     Geospatial data:
@@ -657,32 +343,15 @@ Image:
         value: software, multimedia
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Government document:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Image:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Interview:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Journal/periodical issue:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: still image
         source:
           value: MODS resource types
     Manuscript:
@@ -690,17 +359,9 @@ Image:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Map:
       - type: resource type
         value: cartographic
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: still image
         source:
           value: MODS resource types
     MIDI:
@@ -708,17 +369,9 @@ Image:
         value: sound recording
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Musical transcription:
       - type: resource type
         value: notated music
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: still image
         source:
           value: MODS resource types
     Notated music:
@@ -726,46 +379,22 @@ Image:
         value: notated music
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Narrative film:
       - type: resource type
         value: moving image
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Oral history:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Other spoken word:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Performance:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Photograph:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Piano roll:
       - type: resource type
         value: sound recording-musical
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: still image
         source:
           value: MODS resource types
     Podcast:
@@ -773,50 +402,25 @@ Image:
         value: sound recording-nonmusical
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Poetry reading:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Policy brief:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Poster:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Preprint:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Presentation recording:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Presentation slides:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: still image
         source:
           value: MODS resource types
     Questionnaire:
@@ -824,22 +428,11 @@ Image:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Remote sensing imagery:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Report:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: still image
         source:
           value: MODS resource types
     Software:
@@ -847,17 +440,9 @@ Image:
         value: software, multimedia
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Sound recording:
       - type: resource type
         value: sound recording
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: still image
         source:
           value: MODS resource types
     Speaker notes:
@@ -865,36 +450,18 @@ Image:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Speech:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Statistical model:
       - type: resource type
         value: software, multimedia
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Story:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Syllabus:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: still image
         source:
           value: MODS resource types
     Tabular data:
@@ -902,17 +469,9 @@ Image:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Technical report:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: still image
         source:
           value: MODS resource types
     Text corpus:
@@ -920,45 +479,23 @@ Image:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Text:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Thesis:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Transcript:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Unedited recording:
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
+      # no value
     Video art:
       - type: resource type
         value: moving image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: still image
         source:
           value: MODS resource types
     Video recording:
@@ -966,26 +503,14 @@ Image:
         value: moving image
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     White paper:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: still image
-        source:
-          value: MODS resource types
     Working paper:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: still image
         source:
           value: MODS resource types
 Mixed Materials:
@@ -1000,17 +525,9 @@ Mixed Materials:
         value: three-dimensional object
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Animation:
       - type: resource type
         value: moving image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: mixed materials
         source:
           value: MODS resource types
     Article:
@@ -1018,17 +535,9 @@ Mixed Materials:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Book:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: mixed materials
         source:
           value: MODS resource types
     Book chapter:
@@ -1036,22 +545,11 @@ Mixed Materials:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Broadcast:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     CAD:
       - type: resource type
         value: still image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: mixed materials
         source:
           value: MODS resource types
     Code:
@@ -1059,36 +557,18 @@ Mixed Materials:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Conference session:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Correspondence:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Course/instructional materials:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Data:
       - type: resource type
         value: software, multimedia
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: mixed materials
         source:
           value: MODS resource types
     Database:
@@ -1096,61 +576,28 @@ Mixed Materials:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Documentary:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Documentation:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Dramatic performance:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Essay:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Ethnography:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Event:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Experimental audio/video:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Field recording:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Game:
       - type: resource type
         value: software, multimedia
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: mixed materials
         source:
           value: MODS resource types
     Geospatial data:
@@ -1158,36 +605,18 @@ Mixed Materials:
         value: software, multimedia
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Government document:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Image:
       - type: resource type
         value: still image
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Interview:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Journal/periodical issue:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: mixed materials
         source:
           value: MODS resource types
     Manuscript:
@@ -1195,17 +624,9 @@ Mixed Materials:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Map:
       - type: resource type
         value: cartographic
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: mixed materials
         source:
           value: MODS resource types
     MIDI:
@@ -1213,17 +634,9 @@ Mixed Materials:
         value: sound recording
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Musical transcription:
       - type: resource type
         value: notated music
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: mixed materials
         source:
           value: MODS resource types
     Notated music:
@@ -1231,41 +644,20 @@ Mixed Materials:
         value: notated music
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Narrative film:
       - type: resource type
         value: moving image
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Oral history:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Other spoken word:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Performance:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Photograph:
       - type: resource type
         value: still image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: mixed materials
         source:
           value: MODS resource types
     Piano roll:
@@ -1273,31 +665,16 @@ Mixed Materials:
         value: sound recording-musical
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Podcast:
       - type: resource type
         value: sound recording-nonmusical
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Poetry reading:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Policy brief:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: mixed materials
         source:
           value: MODS resource types
     Poster:
@@ -1305,31 +682,16 @@ Mixed Materials:
         value: still image
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Preprint:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Presentation recording:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Presentation slides:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: mixed materials
         source:
           value: MODS resource types
     Questionnaire:
@@ -1337,17 +699,9 @@ Mixed Materials:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Remote sensing imagery:
       - type: resource type
         value: still image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: mixed materials
         source:
           value: MODS resource types
     Report:
@@ -1355,17 +709,9 @@ Mixed Materials:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Software:
       - type: resource type
         value: software, multimedia
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: mixed materials
         source:
           value: MODS resource types
     Sound recording:
@@ -1373,45 +719,23 @@ Mixed Materials:
         value: sound recording
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Speaker notes:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Speech:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Statistical model:
       - type: resource type
         value: software, multimedia
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Story:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Syllabus:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: mixed materials
         source:
           value: MODS resource types
     Tabular data:
@@ -1419,17 +743,9 @@ Mixed Materials:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Technical report:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: mixed materials
         source:
           value: MODS resource types
     Text corpus:
@@ -1437,45 +753,23 @@ Mixed Materials:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Text:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Thesis:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Transcript:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Unedited recording:
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
+      # no value
     Video art:
       - type: resource type
         value: moving image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: mixed materials
         source:
           value: MODS resource types
     Video recording:
@@ -1483,26 +777,14 @@ Mixed Materials:
         value: moving image
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     White paper:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: mixed materials
-        source:
-          value: MODS resource types
     Working paper:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: mixed materials
         source:
           value: MODS resource types
 Music:
@@ -1629,10 +911,6 @@ Music:
     Notated music:
       - type: resource type
         value: notated music
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: text
         source:
           value: MODS resource types
     Narrative film:
@@ -1904,10 +1182,6 @@ Other:
         value: notated music
         source:
           value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     Narrative film:
       - type: resource type
         value: moving image
@@ -2063,17 +1337,9 @@ Software/Code:
         value: three-dimensional object
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Animation:
       - type: resource type
         value: moving image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Article:
@@ -2086,31 +1352,16 @@ Software/Code:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Book chapter:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Broadcast:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     CAD:
       - type: resource type
         value: still image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Code:
@@ -2118,119 +1369,54 @@ Software/Code:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Conference session:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Correspondence:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Course/instructional materials:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Data:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Database:
-      - type: software, multimedia
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Documentary:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Documentation:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Dramatic performance:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Essay:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Ethnography:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Event:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Experimental audio/video:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Field recording:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Game:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Geospatial data:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Government document:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Image:
       - type: resource type
         value: still image
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Interview:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Journal/periodical issue:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Manuscript:
@@ -2238,17 +1424,9 @@ Software/Code:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Map:
       - type: resource type
         value: cartographic
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     MIDI:
@@ -2256,17 +1434,9 @@ Software/Code:
         value: sound recording
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Musical transcription:
       - type: resource type
         value: notated music
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Notated music:
@@ -2274,41 +1444,20 @@ Software/Code:
         value: notated music
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Narrative film:
       - type: resource type
         value: moving image
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Oral history:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Other spoken word:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Performance:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Photograph:
       - type: resource type
         value: still image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Piano roll:
@@ -2316,31 +1465,16 @@ Software/Code:
         value: sound recording-musical
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Podcast:
       - type: resource type
         value: sound recording-nonmusical
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Poetry reading:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Policy brief:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Poster:
@@ -2348,31 +1482,16 @@ Software/Code:
         value: still image
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Preprint:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Presentation recording:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Presentation slides:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Questionnaire:
@@ -2380,17 +1499,9 @@ Software/Code:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Remote sensing imagery:
       - type: resource type
         value: still image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Report:
@@ -2398,22 +1509,11 @@ Software/Code:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Software:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Sound recording:
       - type: resource type
         value: sound recording
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Speaker notes:
@@ -2421,32 +1521,15 @@ Software/Code:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Speech:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Statistical model:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Story:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Syllabus:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Tabular data:
@@ -2454,17 +1537,9 @@ Software/Code:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Technical report:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Text corpus:
@@ -2472,45 +1547,23 @@ Software/Code:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Text:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Thesis:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Transcript:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Unedited recording:
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
+      # no value
     Video art:
       - type: resource type
         value: moving image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
     Video recording:
@@ -2518,26 +1571,14 @@ Software/Code:
         value: moving image
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     White paper:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: software, multimedia
-        source:
-          value: MODS resource types
     Working paper:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: software, multimedia
         source:
           value: MODS resource types
 Sound:
@@ -2552,17 +1593,9 @@ Sound:
         value: three-dimensional object
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Animation:
       - type: resource type
         value: moving image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: sound recording
         source:
           value: MODS resource types
     Article:
@@ -2570,17 +1603,9 @@ Sound:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Book:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: sound recording
         source:
           value: MODS resource types
     Book chapter:
@@ -2588,22 +1613,11 @@ Sound:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Broadcast:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     CAD:
       - type: resource type
         value: still image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: sound recording
         source:
           value: MODS resource types
     Code:
@@ -2611,36 +1625,18 @@ Sound:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Conference session:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Correspondence:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Course/instructional materials:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Data:
       - type: resource type
         value: software, multimedia
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: sound recording
         source:
           value: MODS resource types
     Database:
@@ -2648,61 +1644,28 @@ Sound:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Documentary:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Documentation:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Dramatic performance:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Essay:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Ethnography:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Event:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Experimental audio/video:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Field recording:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Game:
       - type: resource type
         value: software, multimedia
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: sound recording
         source:
           value: MODS resource types
     Geospatial data:
@@ -2710,36 +1673,18 @@ Sound:
         value: software, multimedia
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Government document:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Image:
       - type: resource type
         value: still image
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Interview:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Journal/periodical issue:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: sound recording
         source:
           value: MODS resource types
     Manuscript:
@@ -2747,31 +1692,16 @@ Sound:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Map:
       - type: resource type
         value: cartographic
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     MIDI:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Musical transcription:
       - type: resource type
         value: notated music
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: sound recording
         source:
           value: MODS resource types
     Notated music:
@@ -2779,41 +1709,20 @@ Sound:
         value: notated music
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Narrative film:
       - type: resource type
         value: moving image
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Oral history:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Other spoken word:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Performance:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Photograph:
       - type: resource type
         value: still image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: sound recording
         source:
           value: MODS resource types
     Piano roll:
@@ -2821,31 +1730,16 @@ Sound:
         value: sound recording-musical
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Podcast:
       - type: resource type
         value: sound recording-nonmusical
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Poetry reading:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Policy brief:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: sound recording
         source:
           value: MODS resource types
     Poster:
@@ -2853,31 +1747,16 @@ Sound:
         value: still image
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Preprint:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Presentation recording:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Presentation slides:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: sound recording
         source:
           value: MODS resource types
     Questionnaire:
@@ -2885,17 +1764,9 @@ Sound:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Remote sensing imagery:
       - type: resource type
         value: still image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: sound recording
         source:
           value: MODS resource types
     Report:
@@ -2903,59 +1774,30 @@ Sound:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Software:
       - type: resource type
         value: software, multimedia
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Sound recording:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Speaker notes:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Speech:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Statistical model:
       - type: resource type
         value: software, multimedia
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Story:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Syllabus:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: sound recording
         source:
           value: MODS resource types
     Tabular data:
@@ -2963,17 +1805,9 @@ Sound:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Technical report:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: sound recording
         source:
           value: MODS resource types
     Text corpus:
@@ -2981,45 +1815,23 @@ Sound:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Text:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Thesis:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Transcript:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Unedited recording:
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
+      # no value
     Video art:
       - type: resource type
         value: moving image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: sound recording
         source:
           value: MODS resource types
     Video recording:
@@ -3027,26 +1839,14 @@ Sound:
         value: moving image
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     White paper:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: sound recording
-        source:
-          value: MODS resource types
     Working paper:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: sound recording
         source:
           value: MODS resource types
 Text:
@@ -3061,133 +1861,58 @@ Text:
         value: three-dimensional object
         source:
           value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     Animation:
       - type: resource type
         value: moving image
         source:
           value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     Article:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Book:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Book chapter:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Broadcast:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     CAD:
       - type: resource type
         value: still image
         source:
           value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     Code:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Conference session:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Correspondence:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Course/instructional materials:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Data:
       - type: resource type
         value: software, multimedia
         source:
           value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     Database:
-      - type: software, multimedia
-        value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Documentary:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Documentation:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Dramatic performance:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Essay:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Ethnography:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Event:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Experimental audio/video:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Field recording:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Game:
       - type: resource type
         value: software, multimedia
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: text
         source:
           value: MODS resource types
     Geospatial data:
@@ -3195,46 +1920,22 @@ Text:
         value: software, multimedia
         source:
           value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     Government document:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Image:
       - type: resource type
         value: still image
         source:
           value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     Interview:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Journal/periodical issue:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Manuscript:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Map:
       - type: resource type
         value: cartographic
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: text
         source:
           value: MODS resource types
     MIDI:
@@ -3242,17 +1943,9 @@ Text:
         value: sound recording
         source:
           value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     Musical transcription:
       - type: resource type
         value: notated music
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: text
         source:
           value: MODS resource types
     Notated music:
@@ -3260,41 +1953,20 @@ Text:
         value: notated music
         source:
           value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     Narrative film:
       - type: resource type
         value: moving image
         source:
           value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     Oral history:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Other spoken word:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Performance:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Photograph:
       - type: resource type
         value: still image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: text
         source:
           value: MODS resource types
     Piano roll:
@@ -3302,79 +1974,38 @@ Text:
         value: sound recording-musical
         source:
           value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     Podcast:
       - type: resource type
         value: sound recording-nonmusical
         source:
           value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     Poetry reading:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Policy brief:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Poster:
       - type: resource type
         value: still image
         source:
           value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     Preprint:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Presentation recording:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Presentation slides:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Questionnaire:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Remote sensing imagery:
       - type: resource type
         value: still image
         source:
           value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     Report:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Software:
       - type: resource type
         value: software, multimedia
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: text
         source:
           value: MODS resource types
     Sound recording:
@@ -3382,81 +2013,36 @@ Text:
         value: sound recording
         source:
           value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     Speaker notes:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Speech:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Statistical model:
       - type: resource type
         value: software, multimedia
         source:
           value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     Story:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Syllabus:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Tabular data:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Technical report:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Text corpus:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Text:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Thesis:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Transcript:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Unedited recording:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Video art:
       - type: resource type
         value: moving image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: text
         source:
           value: MODS resource types
     Video recording:
@@ -3464,20 +2050,10 @@ Text:
         value: moving image
         source:
           value: MODS resource types
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
     White paper:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
     Working paper:
-      - type: resource type
-        value: text
-        source:
-          value: MODS resource types
+      # no value
 Video:
   type:
     - type: resource type
@@ -3490,22 +2066,11 @@ Video:
         value: three-dimensional object
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Animation:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Article:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: moving image
         source:
           value: MODS resource types
     Book:
@@ -3513,31 +2078,16 @@ Video:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Book chapter:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Broadcast:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     CAD:
       - type: resource type
         value: still image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: moving image
         source:
           value: MODS resource types
     Code:
@@ -3545,36 +2095,18 @@ Video:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Conference session:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Correspondence:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Course/instructional materials:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Data:
       - type: resource type
         value: software, multimedia
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: moving image
         source:
           value: MODS resource types
     Database:
@@ -3582,61 +2114,28 @@ Video:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Documentary:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Documentation:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Dramatic performance:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Essay:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Ethnography:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Event:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Experimental audio/video:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Field recording:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Game:
       - type: resource type
         value: software, multimedia
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: moving image
         source:
           value: MODS resource types
     Geospatial data:
@@ -3644,36 +2143,18 @@ Video:
         value: software, multimedia
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Government document:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Image:
       - type: resource type
         value: still image
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Interview:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Journal/periodical issue:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: moving image
         source:
           value: MODS resource types
     Manuscript:
@@ -3681,17 +2162,9 @@ Video:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Map:
       - type: resource type
         value: cartographic
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: moving image
         source:
           value: MODS resource types
     MIDI:
@@ -3699,17 +2172,9 @@ Video:
         value: sound recording
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Musical transcription:
       - type: resource type
         value: notated music
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: moving image
         source:
           value: MODS resource types
     Notated music:
@@ -3717,37 +2182,17 @@ Video:
         value: notated music
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Narrative film:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Oral history:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Other spoken word:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Performance:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Photograph:
       - type: resource type
         value: still image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: moving image
         source:
           value: MODS resource types
     Piano roll:
@@ -3755,31 +2200,16 @@ Video:
         value: sound recording-musical
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Podcast:
       - type: resource type
         value: sound recording-nonmusical
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Poetry reading:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Policy brief:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: moving image
         source:
           value: MODS resource types
     Poster:
@@ -3787,31 +2217,16 @@ Video:
         value: still image
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Preprint:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Presentation recording:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Presentation slides:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: moving image
         source:
           value: MODS resource types
     Questionnaire:
@@ -3819,17 +2234,9 @@ Video:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Remote sensing imagery:
       - type: resource type
         value: still image
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: moving image
         source:
           value: MODS resource types
     Report:
@@ -3837,17 +2244,9 @@ Video:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Software:
       - type: resource type
         value: software, multimedia
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: moving image
         source:
           value: MODS resource types
     Sound recording:
@@ -3855,45 +2254,23 @@ Video:
         value: sound recording
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Speaker notes:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Speech:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Statistical model:
       - type: resource type
         value: software, multimedia
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Story:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Syllabus:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: moving image
         source:
           value: MODS resource types
     Tabular data:
@@ -3901,17 +2278,9 @@ Video:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Technical report:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: moving image
         source:
           value: MODS resource types
     Text corpus:
@@ -3919,63 +2288,31 @@ Video:
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Text:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Thesis:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Transcript:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Unedited recording:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Video art:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     Video recording:
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
+      # no value
     White paper:
       - type: resource type
         value: text
         source:
           value: MODS resource types
-      - type: resource type
-        value: moving image
-        source:
-          value: MODS resource types
     Working paper:
       - type: resource type
         value: text
-        source:
-          value: MODS resource types
-      - type: resource type
-        value: moving image
         source:
           value: MODS resource types

--- a/config/mappings/types_to_resource_types.yml
+++ b/config/mappings/types_to_resource_types.yml
@@ -1,3937 +1,3971 @@
 Data:
-  3D model:
-    - type: resource type
-      value: three-dimensional object
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Animation:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Article:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Book:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Book chapter:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Broadcast:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  CAD:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Code:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Conference session:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Correspondence:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Course/instructional materials:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Database:
-    - type: software, multimedia
-      value: text
-      source:
-        value: MODS resource types
-  Documentary:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Documentation:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Dramatic performance:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Essay:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Ethnography:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Event:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Experimental audio/video:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Field recording:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Game:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Geospatial data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Government document:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Image:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Interview:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Journal/periodical issue:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Manuscript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Map:
-    - type: resource type
-      value: cartographic
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  MIDI:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Musical transcription:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Notated music:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Narrative film:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Oral history:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Other spoken word:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Performance:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Photograph:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Piano roll:
-    - type: resource type
-      value: sound recording-musical
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Podcast:
-    - type: resource type
-      value: sound recording-nonmusical
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Poetry reading:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Policy brief:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Poster:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Preprint:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Presentation recording:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Presentation slides:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Questionnaire:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Remote sensing imagery:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Software:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Sound recording:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Speaker notes:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Speech:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Statistical model:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Story:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Syllabus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Tabular data:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Technical report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Text corpus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Text:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Thesis:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Transcript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Unedited recording:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Video art:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Video recording:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  White paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Working paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
+  type:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  subtypes:
+    3D model:
+      - type: resource type
+        value: three-dimensional object
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Animation:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Article:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Book:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Book chapter:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Broadcast:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    CAD:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Code:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Conference session:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Correspondence:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Course/instructional materials:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Database:
+      - type: software, multimedia
+        value: text
+        source:
+          value: MODS resource types
+    Documentary:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Documentation:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Dramatic performance:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Essay:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Ethnography:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Event:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Experimental audio/video:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Field recording:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Game:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Geospatial data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Government document:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Image:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Interview:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Journal/periodical issue:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Manuscript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Map:
+      - type: resource type
+        value: cartographic
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    MIDI:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Musical transcription:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Notated music:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Narrative film:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Oral history:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Other spoken word:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Performance:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Photograph:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Piano roll:
+      - type: resource type
+        value: sound recording-musical
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Podcast:
+      - type: resource type
+        value: sound recording-nonmusical
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Poetry reading:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Policy brief:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Poster:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Preprint:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Presentation recording:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Presentation slides:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Questionnaire:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Remote sensing imagery:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Software:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Sound recording:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Speaker notes:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Speech:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Statistical model:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Story:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Syllabus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Tabular data:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Technical report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Text corpus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Text:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Thesis:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Transcript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Unedited recording:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Video art:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Video recording:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    White paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Working paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
 Image:
-  3D model:
-    - type: resource type
-      value: three-dimensional object
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Animation:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Article:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Book:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Book chapter:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Broadcast:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  CAD:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Code:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Conference session:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Correspondence:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Course/instructional materials:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Database:
-    - type: software, multimedia
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Documentary:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Documentation:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Dramatic performance:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Essay:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Ethnography:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Event:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Experimental audio/video:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Field recording:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Game:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Geospatial data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Government document:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Image:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Interview:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Journal/periodical issue:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Manuscript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Map:
-    - type: resource type
-      value: cartographic
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  MIDI:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Musical transcription:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Notated music:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Narrative film:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Oral history:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Other spoken word:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Performance:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Photograph:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Piano roll:
-    - type: resource type
-      value: sound recording-musical
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Podcast:
-    - type: resource type
-      value: sound recording-nonmusical
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Poetry reading:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Policy brief:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Poster:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Preprint:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Presentation recording:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Presentation slides:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Questionnaire:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Remote sensing imagery:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Software:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Sound recording:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Speaker notes:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Speech:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Statistical model:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Story:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Syllabus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Tabular data:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Technical report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Text corpus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Text:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Thesis:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Transcript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Unedited recording:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Video art:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Video recording:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  White paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Working paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
+  type:
+    - type: resource type
+      value: still image
+      source:
+        value: MODS resource types
+  subtypes:
+    3D model:
+      - type: resource type
+        value: three-dimensional object
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Animation:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Article:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Book:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Book chapter:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Broadcast:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    CAD:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Code:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Conference session:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Correspondence:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Course/instructional materials:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Database:
+      - type: software, multimedia
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Documentary:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Documentation:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Dramatic performance:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Essay:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Ethnography:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Event:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Experimental audio/video:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Field recording:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Game:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Geospatial data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Government document:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Image:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Interview:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Journal/periodical issue:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Manuscript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Map:
+      - type: resource type
+        value: cartographic
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    MIDI:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Musical transcription:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Notated music:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Narrative film:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Oral history:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Other spoken word:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Performance:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Photograph:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Piano roll:
+      - type: resource type
+        value: sound recording-musical
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Podcast:
+      - type: resource type
+        value: sound recording-nonmusical
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Poetry reading:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Policy brief:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Poster:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Preprint:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Presentation recording:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Presentation slides:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Questionnaire:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Remote sensing imagery:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Software:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Sound recording:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Speaker notes:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Speech:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Statistical model:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Story:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Syllabus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Tabular data:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Technical report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Text corpus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Text:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Thesis:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Transcript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Unedited recording:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Video art:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Video recording:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    White paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Working paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
 Mixed Materials:
-  3D model:
-    - type: resource type
-      value: three-dimensional object
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Animation:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Article:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Book:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Book chapter:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Broadcast:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  CAD:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Code:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Conference session:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Correspondence:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Course/instructional materials:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Database:
-    - type: software, multimedia
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Documentary:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Documentation:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Dramatic performance:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Essay:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Ethnography:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Event:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Experimental audio/video:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Field recording:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Game:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Geospatial data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Government document:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Image:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Interview:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Journal/periodical issue:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Manuscript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Map:
-    - type: resource type
-      value: cartographic
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  MIDI:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Musical transcription:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Notated music:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Narrative film:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Oral history:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Other spoken word:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Performance:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Photograph:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Piano roll:
-    - type: resource type
-      value: sound recording-musical
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Podcast:
-    - type: resource type
-      value: sound recording-nonmusical
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Poetry reading:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Policy brief:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Poster:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Preprint:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Presentation recording:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Presentation slides:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Questionnaire:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Remote sensing imagery:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Software:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Sound recording:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Speaker notes:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Speech:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Statistical model:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Story:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Syllabus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Tabular data:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Technical report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Text corpus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Text:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Thesis:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Transcript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Unedited recording:
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Video art:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Video recording:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  White paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
-  Working paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: mixed materials
-      source:
-        value: MODS resource types
+  type:
+    - type: resource type
+      value: mixed materials
+      source:
+        value: MODS resource types
+  subtypes:
+    3D model:
+      - type: resource type
+        value: three-dimensional object
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Animation:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Article:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Book:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Book chapter:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Broadcast:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    CAD:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Code:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Conference session:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Correspondence:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Course/instructional materials:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Database:
+      - type: software, multimedia
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Documentary:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Documentation:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Dramatic performance:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Essay:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Ethnography:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Event:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Experimental audio/video:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Field recording:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Game:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Geospatial data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Government document:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Image:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Interview:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Journal/periodical issue:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Manuscript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Map:
+      - type: resource type
+        value: cartographic
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    MIDI:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Musical transcription:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Notated music:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Narrative film:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Oral history:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Other spoken word:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Performance:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Photograph:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Piano roll:
+      - type: resource type
+        value: sound recording-musical
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Podcast:
+      - type: resource type
+        value: sound recording-nonmusical
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Poetry reading:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Policy brief:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Poster:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Preprint:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Presentation recording:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Presentation slides:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Questionnaire:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Remote sensing imagery:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Software:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Sound recording:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Speaker notes:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Speech:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Statistical model:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Story:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Syllabus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Tabular data:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Technical report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Text corpus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Text:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Thesis:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Transcript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Unedited recording:
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Video art:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Video recording:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    White paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
+    Working paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: mixed materials
+        source:
+          value: MODS resource types
 Music:
-  3D model:
-    - type: resource type
-      value: three-dimensional object
-      source:
-        value: MODS resource types
-  Animation:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Article:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Book:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Book chapter:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Broadcast:
-    # no value
-  CAD:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Code:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Conference session:
-    # no value
-  Correspondence:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Course/instructional materials:
-    # no value
-  Data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Database:
-    - type: software, multimedia
-      value: text
-      source:
-        value: MODS resource types
-  Documentary:
-    # no value
-  Documentation:
-    # no value
-  Dramatic performance:
-    # no value
-  Essay:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Ethnography:
-    # no value
-  Event:
-    # no value
-  Experimental audio/video:
-    # no value
-  Field recording:
-    # no value
-  Game:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Geospatial data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Government document:
-    # no value
-  Image:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Interview:
-    # no value
-  Journal/periodical issue:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Manuscript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Map:
-    - type: resource type
-      value: cartographic
-      source:
-        value: MODS resource types
-  MIDI:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Musical transcription:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-  Notated music:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Narrative film:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Oral history:
-    # no value
-  Other spoken word:
-    # no value
-  Performance:
-    # no value
-  Photograph:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Piano roll:
-    - type: resource type
-      value: sound recording-musical
-      source:
-        value: MODS resource types
-  Podcast:
-    - type: resource type
-      value: sound recording-nonmusical
-      source:
-        value: MODS resource types
-  Poetry reading:
-    # no value
-  Policy brief:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Poster:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Preprint:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Presentation recording:
-    # no value
-  Presentation slides:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Questionnaire:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Remote sensing imagery:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Software:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Sound recording:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Speaker notes:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Speech:
-    # no value
-  Statistical model:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Story:
-    # no value
-  Syllabus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Tabular data:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Technical report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Text corpus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Text:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Thesis:
-    # no value
-  Transcript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Unedited recording:
-    # no value
-  Video art:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Video recording:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  White paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Working paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
+  subtypes:
+    3D model:
+      - type: resource type
+        value: three-dimensional object
+        source:
+          value: MODS resource types
+    Animation:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Article:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Book:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Book chapter:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Broadcast:
+      # no value
+    CAD:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Code:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Conference session:
+      # no value
+    Correspondence:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Course/instructional materials:
+      # no value
+    Data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Database:
+      - type: software, multimedia
+        value: text
+        source:
+          value: MODS resource types
+    Documentary:
+      # no value
+    Documentation:
+      # no value
+    Dramatic performance:
+      # no value
+    Essay:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Ethnography:
+      # no value
+    Event:
+      # no value
+    Experimental audio/video:
+      # no value
+    Field recording:
+      # no value
+    Game:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Geospatial data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Government document:
+      # no value
+    Image:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Interview:
+      # no value
+    Journal/periodical issue:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Manuscript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Map:
+      - type: resource type
+        value: cartographic
+        source:
+          value: MODS resource types
+    MIDI:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Musical transcription:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+    Notated music:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Narrative film:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Oral history:
+      # no value
+    Other spoken word:
+      # no value
+    Performance:
+      # no value
+    Photograph:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Piano roll:
+      - type: resource type
+        value: sound recording-musical
+        source:
+          value: MODS resource types
+    Podcast:
+      - type: resource type
+        value: sound recording-nonmusical
+        source:
+          value: MODS resource types
+    Poetry reading:
+      # no value
+    Policy brief:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Poster:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Preprint:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Presentation recording:
+      # no value
+    Presentation slides:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Questionnaire:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Remote sensing imagery:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Software:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Sound recording:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Speaker notes:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Speech:
+      # no value
+    Statistical model:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Story:
+      # no value
+    Syllabus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Tabular data:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Technical report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Text corpus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Text:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Thesis:
+      # no value
+    Transcript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Unedited recording:
+      # no value
+    Video art:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Video recording:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    White paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Working paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
 Other:
-  3D model:
-    - type: resource type
-      value: three-dimensional object
-      source:
-        value: MODS resource types
-  Animation:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Article:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Book:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Book chapter:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Broadcast:
-    # no value
-  CAD:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Code:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Conference session:
-    # no value
-  Correspondence:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Course/instructional materials:
-    # no value
-  Data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Database:
-    - type: software, multimedia
-      value: text
-      source:
-        value: MODS resource types
-  Documentary:
-    # no value
-  Documentation:
-    # no value
-  Dramatic performance:
-    # no value
-  Essay:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Ethnography:
-    # no value
-  Event:
-    # no value
-  Experimental audio/video:
-    # no value
-  Field recording:
-    # no value
-  Game:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Geospatial data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Government document:
-    # no value
-  Image:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Interview:
-    # no value
-  Journal/periodical issue:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Manuscript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Map:
-    - type: resource type
-      value: cartographic
-      source:
-        value: MODS resource types
-  MIDI:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Musical transcription:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-  Notated music:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Narrative film:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Oral history:
-    # no value
-  Other spoken word:
-    # no value
-  Performance:
-    # no value
-  Photograph:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Piano roll:
-    - type: resource type
-      value: sound recording-musical
-      source:
-        value: MODS resource types
-  Podcast:
-    - type: resource type
-      value: sound recording-nonmusical
-      source:
-        value: MODS resource types
-  Poetry reading:
-    # no value
-  Policy brief:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Poster:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Preprint:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Presentation recording:
-    # no value
-  Presentation slides:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Questionnaire:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Remote sensing imagery:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-  Report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Software:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Sound recording:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Speaker notes:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Speech:
-    # no value
-  Statistical model:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Story:
-    # no value
-  Syllabus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Tabular data:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Technical report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Text corpus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Text:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Thesis:
-    # no value
-  Transcript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Unedited recording:
-    # no value
-  Video art:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Video recording:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  White paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Working paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
+  subtypes:
+    3D model:
+      - type: resource type
+        value: three-dimensional object
+        source:
+          value: MODS resource types
+    Animation:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Article:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Book:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Book chapter:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Broadcast:
+      # no value
+    CAD:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Code:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Conference session:
+      # no value
+    Correspondence:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Course/instructional materials:
+      # no value
+    Data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Database:
+      - type: software, multimedia
+        value: text
+        source:
+          value: MODS resource types
+    Documentary:
+      # no value
+    Documentation:
+      # no value
+    Dramatic performance:
+      # no value
+    Essay:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Ethnography:
+      # no value
+    Event:
+      # no value
+    Experimental audio/video:
+      # no value
+    Field recording:
+      # no value
+    Game:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Geospatial data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Government document:
+      # no value
+    Image:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Interview:
+      # no value
+    Journal/periodical issue:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Manuscript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Map:
+      - type: resource type
+        value: cartographic
+        source:
+          value: MODS resource types
+    MIDI:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Musical transcription:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+    Notated music:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Narrative film:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Oral history:
+      # no value
+    Other spoken word:
+      # no value
+    Performance:
+      # no value
+    Photograph:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Piano roll:
+      - type: resource type
+        value: sound recording-musical
+        source:
+          value: MODS resource types
+    Podcast:
+      - type: resource type
+        value: sound recording-nonmusical
+        source:
+          value: MODS resource types
+    Poetry reading:
+      # no value
+    Policy brief:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Poster:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Preprint:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Presentation recording:
+      # no value
+    Presentation slides:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Questionnaire:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Remote sensing imagery:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+    Report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Software:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Sound recording:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Speaker notes:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Speech:
+      # no value
+    Statistical model:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Story:
+      # no value
+    Syllabus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Tabular data:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Technical report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Text corpus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Text:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Thesis:
+      # no value
+    Transcript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Unedited recording:
+      # no value
+    Video art:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Video recording:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    White paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Working paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
 Software/Code:
-  3D model:
-    - type: resource type
-      value: three-dimensional object
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Animation:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Article:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Book:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Book chapter:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Broadcast:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  CAD:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Code:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Conference session:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Correspondence:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Course/instructional materials:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Database:
-    - type: software, multimedia
-      value: text
-      source:
-        value: MODS resource types
-  Documentary:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Documentation:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Dramatic performance:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Essay:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Ethnography:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Event:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Experimental audio/video:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Field recording:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Game:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Geospatial data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Government document:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Image:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Interview:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Journal/periodical issue:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Manuscript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Map:
-    - type: resource type
-      value: cartographic
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  MIDI:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Musical transcription:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Notated music:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Narrative film:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Oral history:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Other spoken word:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Performance:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Photograph:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Piano roll:
-    - type: resource type
-      value: sound recording-musical
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Podcast:
-    - type: resource type
-      value: sound recording-nonmusical
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Poetry reading:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Policy brief:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Poster:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Preprint:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Presentation recording:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Presentation slides:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Questionnaire:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Remote sensing imagery:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Software:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Sound recording:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Speaker notes:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Speech:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Statistical model:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Story:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Syllabus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Tabular data:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Technical report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Text corpus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Text:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Thesis:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Transcript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Unedited recording:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Video art:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Video recording:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  White paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-  Working paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
+  type:
+    - type: resource type
+      value: software, multimedia
+      source:
+        value: MODS resource types
+  subtypes:
+    3D model:
+      - type: resource type
+        value: three-dimensional object
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Animation:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Article:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Book:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Book chapter:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Broadcast:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    CAD:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Code:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Conference session:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Correspondence:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Course/instructional materials:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Database:
+      - type: software, multimedia
+        value: text
+        source:
+          value: MODS resource types
+    Documentary:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Documentation:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Dramatic performance:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Essay:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Ethnography:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Event:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Experimental audio/video:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Field recording:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Game:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Geospatial data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Government document:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Image:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Interview:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Journal/periodical issue:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Manuscript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Map:
+      - type: resource type
+        value: cartographic
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    MIDI:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Musical transcription:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Notated music:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Narrative film:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Oral history:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Other spoken word:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Performance:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Photograph:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Piano roll:
+      - type: resource type
+        value: sound recording-musical
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Podcast:
+      - type: resource type
+        value: sound recording-nonmusical
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Poetry reading:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Policy brief:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Poster:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Preprint:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Presentation recording:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Presentation slides:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Questionnaire:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Remote sensing imagery:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Software:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Sound recording:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Speaker notes:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Speech:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Statistical model:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Story:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Syllabus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Tabular data:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Technical report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Text corpus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Text:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Thesis:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Transcript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Unedited recording:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Video art:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Video recording:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    White paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+    Working paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
 Sound:
-  3D model:
-    - type: resource type
-      value: three-dimensional object
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Animation:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Article:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Book:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Book chapter:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Broadcast:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  CAD:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Code:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Conference session:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Correspondence:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Course/instructional materials:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Database:
-    - type: software, multimedia
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Documentary:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Documentation:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Dramatic performance:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Essay:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Ethnography:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Event:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Experimental audio/video:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Field recording:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Game:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Geospatial data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Government document:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Image:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Interview:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Journal/periodical issue:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Manuscript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Map:
-    - type: resource type
-      value: cartographic
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  MIDI:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Musical transcription:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Notated music:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Narrative film:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Oral history:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Other spoken word:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Performance:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Photograph:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Piano roll:
-    - type: resource type
-      value: sound recording-musical
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Podcast:
-    - type: resource type
-      value: sound recording-nonmusical
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Poetry reading:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Policy brief:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Poster:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Preprint:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Presentation recording:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Presentation slides:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Questionnaire:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Remote sensing imagery:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Software:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Sound recording:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Speaker notes:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Speech:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Statistical model:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Story:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Syllabus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Tabular data:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Technical report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Text corpus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Text:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Thesis:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Transcript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Unedited recording:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Video art:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Video recording:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  White paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-  Working paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
+  type:
+    - type: resource type
+      value: sound recording
+      source:
+        value: MODS resource types
+  subtypes:
+    3D model:
+      - type: resource type
+        value: three-dimensional object
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Animation:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Article:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Book:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Book chapter:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Broadcast:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    CAD:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Code:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Conference session:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Correspondence:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Course/instructional materials:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Database:
+      - type: software, multimedia
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Documentary:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Documentation:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Dramatic performance:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Essay:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Ethnography:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Event:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Experimental audio/video:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Field recording:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Game:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Geospatial data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Government document:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Image:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Interview:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Journal/periodical issue:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Manuscript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Map:
+      - type: resource type
+        value: cartographic
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    MIDI:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Musical transcription:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Notated music:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Narrative film:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Oral history:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Other spoken word:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Performance:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Photograph:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Piano roll:
+      - type: resource type
+        value: sound recording-musical
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Podcast:
+      - type: resource type
+        value: sound recording-nonmusical
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Poetry reading:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Policy brief:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Poster:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Preprint:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Presentation recording:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Presentation slides:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Questionnaire:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Remote sensing imagery:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Software:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Sound recording:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Speaker notes:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Speech:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Statistical model:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Story:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Syllabus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Tabular data:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Technical report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Text corpus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Text:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Thesis:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Transcript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Unedited recording:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Video art:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Video recording:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    White paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+    Working paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
 Text:
-  3D model:
-    - type: resource type
-      value: three-dimensional object
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Animation:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Article:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Book:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Book chapter:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Broadcast:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  CAD:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Code:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Conference session:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Correspondence:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Course/instructional materials:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Database:
-    - type: software, multimedia
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Documentary:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Documentation:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Dramatic performance:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Essay:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Ethnography:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Event:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Experimental audio/video:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Field recording:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Game:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Geospatial data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Government document:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Image:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Interview:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Journal/periodical issue:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Manuscript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Map:
-    - type: resource type
-      value: cartographic
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  MIDI:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Musical transcription:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Notated music:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Narrative film:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Oral history:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Other spoken word:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Performance:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Photograph:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Piano roll:
-    - type: resource type
-      value: sound recording-musical
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Podcast:
-    - type: resource type
-      value: sound recording-nonmusical
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Poetry reading:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Policy brief:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Poster:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Preprint:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Presentation recording:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Presentation slides:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Questionnaire:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Remote sensing imagery:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Software:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Sound recording:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Speaker notes:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Speech:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Statistical model:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Story:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Syllabus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Tabular data:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Technical report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Text corpus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Text:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Thesis:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Transcript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Unedited recording:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Video art:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Video recording:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  White paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-  Working paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
+  subtypes:
+    3D model:
+      - type: resource type
+        value: three-dimensional object
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Animation:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Article:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Book:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Book chapter:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Broadcast:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    CAD:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Code:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Conference session:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Correspondence:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Course/instructional materials:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Database:
+      - type: software, multimedia
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Documentary:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Documentation:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Dramatic performance:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Essay:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Ethnography:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Event:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Experimental audio/video:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Field recording:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Game:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Geospatial data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Government document:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Image:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Interview:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Journal/periodical issue:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Manuscript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Map:
+      - type: resource type
+        value: cartographic
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    MIDI:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Musical transcription:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Notated music:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Narrative film:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Oral history:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Other spoken word:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Performance:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Photograph:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Piano roll:
+      - type: resource type
+        value: sound recording-musical
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Podcast:
+      - type: resource type
+        value: sound recording-nonmusical
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Poetry reading:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Policy brief:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Poster:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Preprint:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Presentation recording:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Presentation slides:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Questionnaire:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Remote sensing imagery:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Software:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Sound recording:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Speaker notes:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Speech:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Statistical model:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Story:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Syllabus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Tabular data:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Technical report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Text corpus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Text:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Thesis:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Transcript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Unedited recording:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Video art:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Video recording:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    White paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+    Working paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
 Video:
-  3D model:
-    - type: resource type
-      value: three-dimensional object
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Animation:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Article:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Book:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Book chapter:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Broadcast:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  CAD:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Code:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Conference session:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Correspondence:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Course/instructional materials:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Database:
-    - type: software, multimedia
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Documentary:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Documentation:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Dramatic performance:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Essay:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Ethnography:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Event:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Experimental audio/video:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Field recording:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Game:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Geospatial data:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Government document:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Image:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Interview:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Journal/periodical issue:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Manuscript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Map:
-    - type: resource type
-      value: cartographic
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  MIDI:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Musical transcription:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Notated music:
-    - type: resource type
-      value: notated music
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Narrative film:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Oral history:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Other spoken word:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Performance:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Photograph:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Piano roll:
-    - type: resource type
-      value: sound recording-musical
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Podcast:
-    - type: resource type
-      value: sound recording-nonmusical
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Poetry reading:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Policy brief:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Poster:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Preprint:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Presentation recording:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Presentation slides:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Questionnaire:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Remote sensing imagery:
-    - type: resource type
-      value: still image
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Software:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Sound recording:
-    - type: resource type
-      value: sound recording
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Speaker notes:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Speech:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Statistical model:
-    - type: resource type
-      value: software, multimedia
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Story:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Syllabus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Tabular data:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Technical report:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Text corpus:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Text:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Thesis:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Transcript:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Unedited recording:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Video art:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Video recording:
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  White paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
-  Working paper:
-    - type: resource type
-      value: text
-      source:
-        value: MODS resource types
-    - type: resource type
-      value: moving image
-      source:
-        value: MODS resource types
+  subtypes:
+    3D model:
+      - type: resource type
+        value: three-dimensional object
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Animation:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Article:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Book:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Book chapter:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Broadcast:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    CAD:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Code:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Conference session:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Correspondence:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Course/instructional materials:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Database:
+      - type: software, multimedia
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Documentary:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Documentation:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Dramatic performance:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Essay:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Ethnography:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Event:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Experimental audio/video:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Field recording:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Game:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Geospatial data:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Government document:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Image:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Interview:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Journal/periodical issue:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Manuscript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Map:
+      - type: resource type
+        value: cartographic
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    MIDI:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Musical transcription:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Notated music:
+      - type: resource type
+        value: notated music
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Narrative film:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Oral history:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Other spoken word:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Performance:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Photograph:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Piano roll:
+      - type: resource type
+        value: sound recording-musical
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Podcast:
+      - type: resource type
+        value: sound recording-nonmusical
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Poetry reading:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Policy brief:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Poster:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Preprint:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Presentation recording:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Presentation slides:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Questionnaire:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Remote sensing imagery:
+      - type: resource type
+        value: still image
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Software:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Sound recording:
+      - type: resource type
+        value: sound recording
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Speaker notes:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Speech:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Statistical model:
+      - type: resource type
+        value: software, multimedia
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Story:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Syllabus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Tabular data:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Technical report:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Text corpus:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Text:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Thesis:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Transcript:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Unedited recording:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Video art:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Video recording:
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    White paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types
+    Working paper:
+      - type: resource type
+        value: text
+        source:
+          value: MODS resource types
+      - type: resource type
+        value: moving image
+        source:
+          value: MODS resource types

--- a/spec/services/types_generator_spec.rb
+++ b/spec/services/types_generator_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe TypesGenerator do
                 ),
                 Cocina::Models::DescriptiveValue.new(
                   type: 'subtype',
-                  value: 'image'
+                  value: 'Image'
                 )
               ],
               source: { value: 'Stanford self-deposit resource types' },
@@ -95,6 +95,53 @@ RSpec.describe TypesGenerator do
             Cocina::Models::DescriptiveValue.new(
               type: 'resource type',
               value: 'still image',
+              source: { value: 'MODS resource types' }
+            )
+          ]
+        )
+      end
+    end
+
+    context 'with a work of type Image with Animation subtype (top level genre plus subtype derived genre)' do
+      let(:work_version) { build(:work_version, work_type: 'image', subtype: ['Animation']) }
+
+      it 'generates a single structured value, two resource types and two genres' do
+        expect(generated).to eq(
+          [
+            Cocina::Models::DescriptiveValue.new(
+              structuredValue: [
+                Cocina::Models::DescriptiveValue.new(
+                  type: 'type',
+                  value: 'Image'
+                ),
+                Cocina::Models::DescriptiveValue.new(
+                  type: 'subtype',
+                  value: 'Animation'
+                )
+              ],
+              source: { value: 'Stanford self-deposit resource types' },
+              type: 'resource type'
+            ),
+            Cocina::Models::DescriptiveValue.new(
+              type: 'genre',
+              value: 'Pictures',
+              uri: 'http://id.loc.gov/authorities/genreForms/gf2017027251',
+              source: { code: 'lcgft' }
+            ),
+            Cocina::Models::DescriptiveValue.new(
+              type: 'genre',
+              value: 'animations (visual works)',
+              uri: 'http://vocab.getty.edu/aat/300411663',
+              source: { code: 'aat' }
+            ),
+            Cocina::Models::DescriptiveValue.new(
+              type: 'resource type',
+              value: 'still image',
+              source: { value: 'MODS resource types' }
+            ),
+            Cocina::Models::DescriptiveValue.new(
+              type: 'resource type',
+              value: 'moving image',
               source: { value: 'MODS resource types' }
             )
           ]

--- a/spec/services/types_generator_spec.rb
+++ b/spec/services/types_generator_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe TypesGenerator do
     end
 
     context 'with a work of type Image with Image subtype (no subtype derived genre)' do
-      let(:work_version) { build(:work_version, work_type: 'image', subtype: ['image']) }
+      let(:work_version) { build(:work_version, work_type: 'image', subtype: ['Image']) }
 
       it 'generates a single structured value, a single resource type and single genre' do
         expect(generated).to eq(
@@ -187,7 +187,7 @@ RSpec.describe TypesGenerator do
   end
 
   describe 'cocina mapping' do
-    non_other_work_types = WorkType.all.reject { |work_type| work_type.id == 'other' }
+    work_types = WorkType.all
 
     let(:generator) { described_class.new(work_version: work_version) }
     let(:types_to_genres) { generator.send(:types_to_genres) }
@@ -195,7 +195,7 @@ RSpec.describe TypesGenerator do
 
     describe 'for work types' do
       # NOTE: the Other type has no mappings
-      let(:work_type_labels) { non_other_work_types.map(&:label) }
+      let(:work_type_labels) { work_types.map(&:label) }
 
       it 'has one genre for each' do
         # NOTE: General mappings do not correspond to a particular type
@@ -204,32 +204,6 @@ RSpec.describe TypesGenerator do
 
       it 'has one resource type for each' do
         # NOTE: General mappings do not correspond to a particular type
-        expect(work_type_labels).to match_array(types_to_resource_types.keys - ['General'])
-      end
-    end
-
-    describe 'for subtypes' do
-      non_other_work_types.each do |work_type|
-        context "with type #{work_type.label}" do
-          let(:known_genreless) do
-            case work_type.label
-            when 'Data'
-              ['Documentation']
-            when 'Text'
-              ['Policy brief']
-            else
-              []
-            end
-          end
-
-          it 'has a one-to-one genre mapping to subtypes' do
-            expect(work_type.subtypes - known_genreless).to eq(types_to_genres[work_type.label]['subtypes'].keys)
-          end
-
-          it 'has a one-to-one resource type mapping to subtypes' do
-            expect(work_type.subtypes).to eq(types_to_resource_types[work_type.label]['subtypes'].keys)
-          end
-        end
       end
     end
 

--- a/spec/services/types_generator_spec.rb
+++ b/spec/services/types_generator_spec.rb
@@ -272,7 +272,12 @@ RSpec.describe TypesGenerator do
           .sort
           .uniq
       end
-      let(:known_genreless) { ['Policy brief', 'Speaker notes'] }
+      # these represent subtypes that will get the genre from the parent type
+      let(:known_genreless) do
+        ['Policy brief', 'Speaker notes', '3D model', 'Book chapter', 'Broadcast',
+         'Conference session', 'Other spoken word', 'Presentation recording',
+         'Presentation slides', 'Text']
+      end
 
       it 'has one genre for each' do
         expect(all_type_genres).to include(*(WorkType.more_types - known_genreless))

--- a/spec/services/types_generator_spec.rb
+++ b/spec/services/types_generator_spec.rb
@@ -251,6 +251,7 @@ RSpec.describe TypesGenerator do
 
       it 'has one resource type for each' do
         # NOTE: General mappings do not correspond to a particular type
+        expect(work_type_labels).to match_array(types_to_resource_types.keys - ['General'])
       end
     end
 


### PR DESCRIPTION
## Why was this change made?

Replacing #1218 - updated resource and genre type mappings

Also
- remove genre duplicates which causes duped genres which came from both the top level type and the subtypes
- update tests to reflect new data

## How was this change tested?

Some updated tests



## Which documentation and/or configurations were updated?



