### PR TITLE
hide save as draft button for new collections

### DIFF
--- a/app/components/collections/create/buttons_component.html.erb
+++ b/app/components/collections/create/buttons_component.html.erb
@@ -14,7 +14,9 @@
   </div>
   <div class="col-auto">
     <%= cancel_button %>
-    <%= form.submit 'Save as draft', class: 'btn btn-primary', id: 'save-draft-button', data: { action: 'unsaved-changes#allowFormSubmission' } %>
+    <%# The Save As Draft button is temporarily hidden on collection creation (first draft) ... see https://github.com/sul-dlss/happy-heron/issues/1250%>
+    <%# see also spec/components/collections/create/buttons_component_spec.rb which changes a test for this %>
+    <%#= form.submit 'Save as draft', class: 'btn btn-primary', id: 'save-draft-button', data: { action: 'unsaved-changes#allowFormSubmission' } %>
     <%= form.submit 'Deposit', class: 'btn btn-primary', data: { action: 'unsaved-changes#allowFormSubmission' } %>
   </div>
 </div>

--- a/spec/components/collections/create/buttons_component_spec.rb
+++ b/spec/components/collections/create/buttons_component_spec.rb
@@ -19,7 +19,14 @@ RSpec.describe Collections::Create::ButtonsComponent do
     expect(rendered.css('input[value="Deposit"]')).to be_present
   end
 
-  it 'renders the save draft button' do
+  # we are temporarily hiding the save draft button collection creation, renable this test and
+  # remove the following one when the button is added back
+  # see https://github.com/sul-dlss/happy-heron/issues/1250 and components/collections/create/button_compontent.html.erb
+  xit 'renders the save draft button' do
     expect(rendered.css('input[value="Save as draft"]')).to be_present
+  end
+
+  it 'temporary: it does not renders the save draft button' do
+    expect(rendered.css('input[value="Save as draft"]')).not_to be_present
   end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #1253 - temporarily hide save as draft button for brand new collections

## How was this change tested?

Unit test updated and localhost browser

## Which documentation and/or configurations were updated?



