### PR TITLE
Allow creating a draft without being prompted about not saving

### DIFF
--- a/app/components/works/buttons_component.html.erb
+++ b/app/components/works/buttons_component.html.erb
@@ -20,7 +20,9 @@
   </div>
   <div class="col-auto">
     <%= link_to 'Cancel', collection_works_path(collection), class: 'btn btn-link' %>
-    <%= form.submit 'Save as draft', class: 'btn btn-primary', id: 'save-draft-button', action: 'unsaved-changes#allowFormSubmission' %>
-    <%= form.submit submit_button_label, class: 'btn btn-primary', action: 'unsaved-changes#allowFormSubmission' %>
+    <%= form.submit 'Save as draft', class: 'btn btn-primary', id: 'save-draft-button',
+                                     data: { action: 'unsaved-changes#allowFormSubmission' } %>
+    <%= form.submit submit_button_label, class: 'btn btn-primary',
+                                         data: { action: 'unsaved-changes#allowFormSubmission' } %>
   </div>
 </div>

--- a/spec/features/create_new_draft_work_spec.rb
+++ b/spec/features/create_new_draft_work_spec.rb
@@ -1,0 +1,36 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Create a new work in a deposited collection', js: true do
+  let(:user) { create(:user) }
+  let(:collection_version) { create(:collection_version, :deposited, collection: collection) }
+  let(:collection) { create(:collection, :depositor_selects_access, depositors: [user]) }
+  let(:second_email) { 'second@example.com' }
+
+  before do
+    collection.update(head: collection_version)
+    sign_in user, groups: ['dlss:hydrus-app-collection-creators']
+    allow(Settings).to receive(:allow_sdr_content_changes).and_return(true)
+  end
+
+  it 'creates a draft and renders work show page' do
+    visit dashboard_path
+
+    click_button '+ Deposit to this collection'
+
+    expect(page).to have_content 'What type of content will you deposit?'
+
+    find('label', text: 'Sound').click
+
+    click_button 'Continue'
+
+    fill_in 'Title of deposit', with: 'My Draft'
+
+    click_button 'Save as draft'
+
+    expect(page).to have_content 'My Draft'
+    expect(page).to have_content 'Draft - Not deposited'
+  end
+end


### PR DESCRIPTION
Fixes #1258

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



