### PR TITLE
Pass collection version instead of collection to CollectionsMailer.

### DIFF
--- a/app/models/collection_version.rb
+++ b/app/models/collection_version.rb
@@ -26,12 +26,12 @@ class CollectionVersion < ApplicationRecord
     after_transition on: :begin_deposit do |collection_version, transition|
       if transition.from == 'first_draft'
         collection_version.collection.depositors.each do |depositor|
-          CollectionsMailer.with(collection: collection_version.collection, user: depositor)
+          CollectionsMailer.with(collection_version: collection_version, user: depositor)
                            .invitation_to_deposit_email.deliver_later
         end
 
         collection_version.collection.reviewed_by.each do |reviewer|
-          CollectionsMailer.with(collection: collection_version.collection, user: reviewer)
+          CollectionsMailer.with(collection_version: collection_version, user: reviewer)
                            .review_access_granted_email.deliver_later
         end
       end


### PR DESCRIPTION
closes #1215

## Why was this change made?
Fix error reported by HB.


## How was this change tested?
Not.


## Which documentation and/or configurations were updated?
NA


