### PR TITLE
when editing collection on dashboard, go to the details tab which has the deposit button

### DIFF
--- a/app/components/dashboard/in_progress_collection_row_component.html.erb
+++ b/app/components/dashboard/in_progress_collection_row_component.html.erb
@@ -3,7 +3,7 @@
     <%= show_collection_link %>
   </div>
   <div class="col-3">
-    <%= link_to 'Complete draft', edit_collection_path(collection), class: "mb-2 btn btn-primary" %>
+    <%= link_to 'Complete draft', edit_collection_version_path(collection.head), class: "mb-2 btn btn-primary" %>
   </div>
   <div class="col-5">
     <%= helpers.turbo_frame_tag dom_id(collection, :delete), src: delete_button_collection_path(collection) if collection_version.first_draft?%>

--- a/spec/components/dashboard/in_progress_collection_component_spec.rb
+++ b/spec/components/dashboard/in_progress_collection_component_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe Dashboard::InProgressCollectionComponent, type: :component do
 
   context 'when presenter has one or more in progress collections' do
     before do
-      create(:collection_version)
-      create(:collection_version)
-      create(:collection_version)
+      create(:collection_version_with_collection)
+      create(:collection_version_with_collection)
+      create(:collection_version_with_collection)
     end
 
     let(:collection_versions) { CollectionVersion.all }

--- a/spec/components/dashboard/in_progress_collection_row_component_spec.rb
+++ b/spec/components/dashboard/in_progress_collection_row_component_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 
 RSpec.describe Dashboard::InProgressCollectionRowComponent, type: :component do
   let(:rendered) { render_inline(described_class.new(collection_version: collection_version)) }
-  let(:collection_version) { build_stubbed(:collection_version) }
+  let(:collection_version) { create(:collection_version_with_collection) }
 
   it 'renders the component' do
     expect(rendered.to_html).to include collection_version.name


### PR DESCRIPTION
## Why was this change made?

It is confusing for the user to edit a collection in progress and end up on a page that does not have a Deposit button.  We should instead link to the details part of the edit collection form, which has the Deposit button.

Extracted from #1257

## How was this change tested?

Localhost browser

## Which documentation and/or configurations were updated?



