### PR TITLE
Add translation for pid_assigned transition

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
       abbr_month: '%b %d, %Y %-I:%M %p'
   event:
     type:
+      pid_assigned: PURL assigned
       reserve_purl: PURL requested
       begin_deposit: Submitted for deposit
       deposit_complete: Deposit completed


### PR DESCRIPTION

## Why was this change made?

I'm not sure this will be surfaced in the UI, but I thought it might be useful to make sure we have a one-to-one mapping between defined transitions and labels.


## How was this change tested?

CI

## Which documentation and/or configurations were updated?

i18n.