### PR TITLE
Ignores blank notes (citations and abstracts).

### DIFF
--- a/app/services/description_generator.rb
+++ b/app/services/description_generator.rb
@@ -65,8 +65,10 @@ class DescriptionGenerator
     end
   end
 
-  sig { returns(Cocina::Models::DescriptiveValue) }
+  sig { returns(T.nilable(Cocina::Models::DescriptiveValue)) }
   def abstract
+    return if work_version.abstract.blank?
+
     Cocina::Models::DescriptiveValue.new(
       value: work_version.abstract,
       type: 'summary'
@@ -75,7 +77,7 @@ class DescriptionGenerator
 
   sig { returns(T.nilable(Cocina::Models::DescriptiveValue)) }
   def citation
-    return unless work_version.citation
+    return if work_version.citation.blank?
 
     # :link: is a special placeholder in dor-services-app.
     # See https://github.com/sul-dlss/dor-services-app/pull/1566/files#diff-30396654f0ad00ad1daa7292fd8327759d7ff7f3b92f98f40a2e25b6839807e2R13

--- a/spec/services/description_generator_spec.rb
+++ b/spec/services/description_generator_spec.rb
@@ -479,4 +479,14 @@ RSpec.describe DescriptionGenerator do
       end
     end
   end
+
+  context 'with blank abstract and citation' do
+    let(:work_version) do
+      build(:work_version, abstract: '', citation: '')
+    end
+
+    it 'does not add to model' do
+      expect(model[:note]).to be nil
+    end
+  end
 end


### PR DESCRIPTION
closes #1328

## Why was this change made?
Blank notes cause roundtrip validation errors.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


