### PR TITLE
Update the terms of deposit text

### DIFF
--- a/app/views/shared/_terms_of_deposit.html.erb
+++ b/app/views/shared/_terms_of_deposit.html.erb
@@ -21,22 +21,56 @@
         </div>
       <div class="modal-body">
         <p>
-          In depositing content to the Stanford Digital Repository (SDR), the Depositor grants The Trustees of Leland Stanford Junior University through the Stanford University Libraries (Stanford Libraries) the non-exclusive, worldwide, perpetual, irrevocable right to reproduce, distribute, display and transmit Depositor’s content (the Work), in whole or in part, in such print and electronic formats as may be in existence now or developed in the future, to sub-license others to do the same, and to preserve and protect the Work, subject to any third-party release or display restrictions specified by Depositor. Stanford Libraries may make the content available to users, subject to the applicable Terms of Use<sup>[1]</sup> and to any license applied by Depositor. Terms of Use are subject to change by Stanford Libraries; Stanford Libraries will make a reasonable effort to notify the Depositor when changes occur. More information is available at <a href="https://library.stanford.edu/research/stanford-digital-repository/depositor-services" target="_blank">https://library.stanford.edu/research/stanford-digital-repository/depositor-services</a>.
+          In depositing content to the Stanford Digital Repository (SDR), the Depositor grants The
+          Trustees of Leland Stanford Junior University through the Stanford Libraries (Stanford
+          Libraries) the non-exclusive, worldwide, perpetual, irrevocable right to reproduce, distribute,
+          display and transmit such content (the Work), in whole or in part, in such print and electronic
+          formats as may be in existence now or developed in the future, to sublicense others to do the
+          same, and to preserve and store the Work, subject to any third-party release or display
+          restrictions chosen by Depositor through Stanford Libraries’ deposit submission application.
+          Stanford Libraries may make the Work available to users, subject to the applicable Terms of Use1
+          and to any license applied by Depositor through Stanford Libraries’ deposit submission
+          application. These Terms of Use are subject to change by Stanford Libraries; Stanford Libraries
+          will make a reasonable effort to notify the Depositor when changes occur. More information is
+          available at <a href="http://library.stanford.edu/research/stanford-digital-repository/depositor-services" target="_blank">http://library.stanford.edu/research/stanford-digital-repository/depositor-services</a>.
         </p>
         <p>
-          Stanford Libraries is free to reformat, delete or remove access to any or all of the Work in the SDR. If Stanford Libraries determines it is necessary to remove access to or delete permanently a Work, it will make a reasonable effort to notify the Depositor and, provided it would be lawful in Stanford Libraries’ determination to do so, make available a copy of the Work to Depositor (at Depositor’s expense). Depositor grants no other rights under this license, including, without limitation, any copyright interests in the Work.
+          Stanford Libraries is free to reformat, delete or remove access to any or all of the Work in the
+          SDR at its discretion. If Stanford Libraries determines it is necessary to remove access to or
+          delete permanently any specific Work or portions thereof, it will make a reasonable effort to
+          notify the Depositor and make available a copy of the deleted file to Depositor (at Depositor’s
+          expense), provided that (i) it has Depositor’s contact information on file; and (ii) it would be
+          lawful in Stanford Libraries’ determination to do so. Depositor grants no other rights under this
+          license, including, without limitation, any copyright interests in the Work.        
         </p>
         <p>
-          Depositor represents and warrants that Depositor is the copyright holder of the Work, and/or has obtained the unrestricted permission of other copyright owner(s) to grant Stanford Libraries the rights required by this license or any applied license, including necessary licenses relating to any non-public, third-party software necessary to access, display, and run or print the Work. Depositor warrants that any jointly-owned or third-party owned material, such as graphs, images, photos, music, etc., is clearly identified and acknowledged within the content of the Work, and Depositor is solely responsible and will indemnify Stanford Libraries for any third party claims related to the Work as submitted.
+          Depositor represents and warrants that Depositor is the copyright holder of the Work, and/or has
+          obtained all necessary permission of other copyright owner(s) to grant Stanford Libraries the
+          rights required by this license or any applied license, including necessary licenses relating to any
+          third party copyrighted content included in the Work, and any third-party software necessary to
+          access, display, and run or print the Work. More specifically, Depositor warrants that any
+          jointly-owned or third-party owned material, such as graphs, images, photos, music, etc., is
+          clearly identified and acknowledged within the content of the Work, and Depositor is solely
+          responsible and will indemnify Stanford Libraries for any third party claims related to the Work,
+          including any third party content contained therein, as submitted.        
         </p>
         <p>
-          Depositor further warrants that the Work does not violate any law or agreement or infringe upon anyone's publicity, privacy or confidentiality rights, including but not limited to privacy rights protected by HIPAA or FERPA. Depositor warrants that the Work does not contain any high risk data, including but not limited to  Social Security Numbers, driver’s license numbers or bank account information. (More information is available at available at <a href="https://itservices.stanford.edu/guide/riskclassifications" target="_blank">https://itservices.stanford.edu/guide/riskclassifications</a>).
+          Depositor further warrants that the Work does not violate any applicable law or agreement, or
+          infringe upon anyone's publicity, privacy or confidentiality rights, including but not limited to
+          privacy rights protected by HIPAA or FERPA. Depositor warrants that the Work does not
+          contain any high risk data, including but not limited to Social Security Numbers, driver’s license
+          numbers or bank account information. (More information is available at
+          <a href="https://uit.stanford.edu/guide/riskclassifications" target="_blank">https://uit.stanford.edu/guide/riskclassifications</a>.)
+          Depositor represents that depositing to the SDR does not violate an existing publication agreement,
+          Institutional Review Board (IRB), or contract governing deposited content. If the content is original
+          work derived from a source work produced and/or owned by a third-party, Depositor represents compliance
+          with the terms of use associated with that source work.        
         </p>
         <p>
-          Depositor represents that, depositing to the SDR does not violate an existing publication agreement, Institutional Review Board (IRB), or contract governing deposited content. If the content is original work derived from a source work produced and/or owned by a third-party, Depositor represents compliance with the terms of use associated with that source work.
-        </p>
-        <p>
-          Depositor agrees to indemnify Stanford harmless against any third-party claim based on an allegation that Stanford’s actions under this agreement violate that third party’s copyrights, trademarks, other intellectual property, privacy, publicity or other legal rights.
+          Depositor agrees to indemnify and hold harmless Stanford against any third party claims
+          (including those related to copyright, trademark or other intellectual property rights) arising out
+          of or relating to Stanford's deposit, display or other use of the Work as permitted or authorized
+          by this agreement.        
         </p>
         <p>
           <sup>[1]</sup> <small>Stanford Digital Repository Terms of Use: User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.</small>


### PR DESCRIPTION
## Why was this change made?

Fixes #1353 

Before:

<img width="828" alt="Screen Shot 2021-05-10 at 10 14 42 AM" src="https://user-images.githubusercontent.com/2294288/117699833-216f4980-b17a-11eb-959a-1806b6f958e7.png">

After:

<img width="833" alt="Screen Shot 2021-05-10 at 10 23 21 AM" src="https://user-images.githubusercontent.com/2294288/117699860-27652a80-b17a-11eb-8631-9e2fb73371ee.png">


## How was this change tested?

N/A

## Which documentation and/or configurations were updated?

N/A

