### PR TITLE
Send the appropriate use and reproduction statement to sdr-api

### DIFF
--- a/app/components/collections/edit_license_component.html.erb
+++ b/app/components/collections/edit_license_component.html.erb
@@ -38,10 +38,6 @@
     </p>
 
     <p class="terms-of-use">
-      User agrees that, where applicable, content will not be used to identify
-      or to otherwise infringe the privacy or confidentiality rights of
-      individuals. Content distributed via the Stanford Digital Repository may
-      be subject to additional license and use restrictions applied by the
-      Depositor.
+      <%= Settings.access.use_and_reproduction_statement %>
     </p>
   </section>

--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -195,7 +195,7 @@
     </tr>
     <tr>
       <th scope="row">Terms of use</th>
-      <td>"User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the Depositor."</td>
+      <td><%= Settings.access.use_and_reproduction_statement %></td>
     </tr>
     </tbody>
   </table>

--- a/app/components/works/license_component.html.erb
+++ b/app/components/works/license_component.html.erb
@@ -22,6 +22,6 @@
   <hr>
   <p>In addition to the license, the following Terms of Use will also be displayed on your PURL page.</p>
   <p style="font-style: italic; margin-left: 2.5rem;">
-    User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the Depositor.
+    <%= Settings.access.use_and_reproduction_statement %>
   </p>
 </section>

--- a/app/services/access_generator.rb
+++ b/app/services/access_generator.rb
@@ -42,6 +42,9 @@ class AccessGenerator
   end
 
   def base_access
-    { license: License.find(work_version.license).uri.presence }.compact
+    {
+      license: License.find(work_version.license).uri.presence,
+      useAndReproductionStatement: Settings.access.use_and_reproduction_statement
+    }.compact
   end
 end

--- a/app/services/request_generator.rb
+++ b/app/services/request_generator.rb
@@ -52,15 +52,6 @@ class RequestGenerator
     WorkType.find(work_version.work_type).cocina_type
   end
 
-  sig { returns(Hash) }
-  # TODO: This varies based on what the user selected
-  def access
-    {
-      access: 'stanford',
-      download: 'stanford'
-    }
-  end
-
   sig { returns(T.any(Cocina::Models::DROStructural, Cocina::Models::RequestDROStructural)) }
   def structural
     StructuralGenerator.generate(work_version: work_version)

--- a/app/views/shared/_terms_of_deposit.html.erb
+++ b/app/views/shared/_terms_of_deposit.html.erb
@@ -39,7 +39,7 @@
           Depositor agrees to indemnify Stanford harmless against any third-party claim based on an allegation that Stanford’s actions under this agreement violate that third party’s copyrights, trademarks, other intellectual property, privacy, publicity or other legal rights.
         </p>
         <p>
-          <sup>[1]</sup> <small>Stanford Digital Repository Terms of Use: User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.</small>
+          <sup>[1]</sup> <small>Stanford Digital Repository Terms of Use: <%= Settings.access.use_and_reproduction_statement %></small>
         </p>
       </div>
     </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -49,3 +49,6 @@ notifications:
   first_draft_reminder:
     first_interval: 14 # delay before initial first draft reminder, in days
     subsequent_interval: 28 # delay between reminders after the initial, also in days
+
+access:
+  use_and_reproduction_statement: User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.

--- a/spec/services/access_generator_spec.rb
+++ b/spec/services/access_generator_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe AccessGenerator do
     let(:work_version) { build(:work_version, license: 'none') }
 
     it 'generates the model' do
-      expect(model).to eq(access: 'world', download: 'world')
+      expect(model).to eq(access: 'world',
+                          download: 'world',
+                          useAndReproductionStatement: Settings.access.use_and_reproduction_statement)
     end
   end
 
@@ -19,7 +21,10 @@ RSpec.describe AccessGenerator do
     let(:work_version) { build(:work_version) }
 
     it 'generates the model' do
-      expect(model).to eq(access: 'world', download: 'world', license: license_uri)
+      expect(model).to eq(access: 'world',
+                          download: 'world',
+                          license: license_uri,
+                          useAndReproductionStatement: Settings.access.use_and_reproduction_statement)
     end
   end
 
@@ -27,7 +32,10 @@ RSpec.describe AccessGenerator do
     let(:work_version) { build(:work_version, access: 'stanford') }
 
     it 'generates the model' do
-      expect(model).to eq(access: 'stanford', download: 'stanford', license: license_uri)
+      expect(model).to eq(access: 'stanford',
+                          download: 'stanford',
+                          license: license_uri,
+                          useAndReproductionStatement: Settings.access.use_and_reproduction_statement)
     end
   end
 
@@ -35,9 +43,11 @@ RSpec.describe AccessGenerator do
     let(:work_version) { build(:work_version, :embargoed, access: 'stanford') }
 
     it 'generates the model' do
-      expect(model).to eq(access: 'citation-only', download: 'none',
+      expect(model).to eq(access: 'citation-only',
+                          download: 'none',
                           embargo: { releaseDate: work_version.embargo_date.to_s, access: 'world', download: 'world' },
-                          license: license_uri)
+                          license: license_uri,
+                          useAndReproductionStatement: Settings.access.use_and_reproduction_statement)
     end
   end
 end

--- a/spec/services/request_generator_spec.rb
+++ b/spec/services/request_generator_spec.rb
@@ -68,7 +68,12 @@ RSpec.describe RequestGenerator do
           type: 'http://cocina.sul.stanford.edu/models/object.jsonld',
           label: 'Test title',
           version: 1,
-          access: { access: 'world', download: 'world', license: license_uri },
+          access: {
+            access: 'world',
+            download: 'world',
+            license: license_uri,
+            useAndReproductionStatement: Settings.access.use_and_reproduction_statement
+          },
           administrative: {
             hasAdminPolicy: 'druid:zx485kb6348',
             partOfProject: project_tag
@@ -118,7 +123,12 @@ RSpec.describe RequestGenerator do
           type: 'http://cocina.sul.stanford.edu/models/object.jsonld',
           label: 'Test title',
           version: 1,
-          access: { access: 'world', download: 'world', license: license_uri },
+          access: {
+            access: 'world',
+            download: 'world',
+            license: license_uri,
+            useAndReproductionStatement: Settings.access.use_and_reproduction_statement
+          },
           administrative: {
             hasAdminPolicy: 'druid:zx485kb6348',
             partOfProject: project_tag
@@ -190,7 +200,12 @@ RSpec.describe RequestGenerator do
           type: 'http://cocina.sul.stanford.edu/models/object.jsonld',
           label: 'Test title',
           version: 1,
-          access: { access: 'world', download: 'world', license: license_uri },
+          access: {
+            access: 'world',
+            download: 'world',
+            license: license_uri,
+            useAndReproductionStatement: Settings.access.use_and_reproduction_statement
+          },
           administrative: {
             hasAdminPolicy: 'druid:zx485kb6348',
             partOfProject: project_tag
@@ -262,7 +277,12 @@ RSpec.describe RequestGenerator do
           label: 'Test title',
           version: 1,
           externalIdentifier: 'druid:bk123gh4567',
-          access: { access: 'world', download: 'world', license: license_uri },
+          access: {
+            access: 'world',
+            download: 'world',
+            license: license_uri,
+            useAndReproductionStatement: Settings.access.use_and_reproduction_statement
+          },
           administrative: {
             hasAdminPolicy: 'druid:zx485kb6348',
             partOfProject: project_tag


### PR DESCRIPTION
## Why was this change made?

Fixes #1401  by adding a configuration setting for the use and reproduction statement and adding it to the access metadata. This also removes an unused method.

## How was this change tested?

Unit

## Which documentation and/or configurations were updated?

N/A

