### PR TITLE
Create a crontab entry when deploying in production

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -15,6 +15,7 @@ require 'capistrano/rails'
 require 'capistrano/honeybadger'
 require 'capistrano/passenger'
 require 'capistrano/maintenance'
+require 'whenever/capistrano'
 require 'dlss/capistrano'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -64,5 +64,8 @@ set :rails_env, 'production'
 set :passenger_restart_command, 'sudo systemctl restart passenger'
 set :passenger_restart_options, -> { '' }
 
+set :whenever_environment, fetch(:rails_env)
+set :whenever_roles, [:cron]
+
 # update shared_configs before restarting app (from dlss-capistrano gem)
 before 'deploy:restart', 'shared_configs:update'

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,6 +1,7 @@
 # typed: false
 # frozen_string_literal: true
 
+# TODO: add the 'cron' environment when we roll out in production
 server 'sul-h2-prod.stanford.edu', user: 'h2', roles: %w[web app db]
 
 Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
## Why was this change made?
So that we have a way of writing the crontab entry automatically.


## How was this change tested?



## Which documentation and/or configurations were updated?



