### PR TITLE
Update the keyword entry to be a single text box with "add another" button

### DIFF
--- a/app/components/works/description_component.html.erb
+++ b/app/components/works/description_component.html.erb
@@ -1,4 +1,4 @@
-<section id="description" data-controller="nested-form" data-nested-form-select-value=".inner-container">
+<section id="description">
   <header>Describe your deposit</header>
   <p>Enter a summary statement about the deposit (600 words max) to help others
     discover your deposits in SearchWorks and on the internet. Add at least one

--- a/app/components/works/description_component.html.erb
+++ b/app/components/works/description_component.html.erb
@@ -21,7 +21,7 @@
       <%= render PopoverComponent.new key: 'work.keywords' %>
     </div>
     <div class="col-sm-10">
-      <%= render Works::KeywordsComponent.new(form: form) %>
+      <%= render Works::KeywordsComponent.new(form: form, key: 'work.keywords') %>
     </div>
   </div>
 

--- a/app/components/works/description_component.html.erb
+++ b/app/components/works/description_component.html.erb
@@ -21,7 +21,7 @@
       <%= render PopoverComponent.new key: 'work.keywords' %>
     </div>
     <div class="col-sm-10">
-      <%= render Works::KeywordsComponent.new(form: form, key: 'work.keywords') %>
+      <%= render Works::KeywordsComponent.new(form: form) %>
     </div>
   </div>
 

--- a/app/components/works/description_component.html.erb
+++ b/app/components/works/description_component.html.erb
@@ -1,4 +1,4 @@
-<section id="description">
+<section id="description" data-controller="nested-form" data-nested-form-select-value=".inner-container">
   <header>Describe your deposit</header>
   <p>Enter a summary statement about the deposit (600 words max) to help others
     discover your deposits in SearchWorks and on the internet. Add at least one

--- a/app/components/works/keywords_component.html.erb
+++ b/app/components/works/keywords_component.html.erb
@@ -1,15 +1,18 @@
-<div class="mb-3" data-controller="nested-form" data-nested-form-selector-value=".plain-container">
-  <template data-nested-form-target='template'>
-    <%= form.fields_for :keywords, Keyword.new, child_index: 'TEMPLATE_RECORD' do |keyword_form| %>
+
+<div class="mb-3" data-controller="keywords" data-action="focusout->keywords#close" data-edit-deposit-target="keywordsField" data-nested-form-selector-value=".plain-container">
+  <div class="keywords-container<%= ' is-invalid' if error? %>" data-keywords-target="container" data-action="click->keywords#open">
+    <template data-nested-form-target='template'>
+      <%= form.fields_for :keywords, Keyword.new, child_index: 'TEMPLATE_RECORD' do |keyword_form| %>
+        <%= row(keyword_form) %>
+      <% end %>
+    </template>
+
+    <%= form.fields_for :keywords do |keyword_form| %>
       <%= row(keyword_form) %>
     <% end %>
-  </template>
 
-  <%= form.fields_for :keywords do |keyword_form| %>
-    <%= row(keyword_form) %>
-  <% end %>
-
-  <div data-nested-form-target="add_item">
-    <%= button_tag '+ Add another keyword', type: 'button', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
+    <div data-nested-form-target="add_item">
+      <%= button_tag '+ Add another keyword', type: 'button', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
+    </div>
   </div>
 </div>

--- a/app/components/works/keywords_component.html.erb
+++ b/app/components/works/keywords_component.html.erb
@@ -1,7 +1,6 @@
-
-<div class="mb-3" data-controller="keywords" data-action="focusout->keywords#close" data-edit-deposit-target="keywordsField" data-nested-form-selector-value=".plain-container">
-  <div class="keywords-container<%= ' is-invalid' if error? %>" data-keywords-target="container" data-action="click->keywords#open">
-    <template data-nested-form-target='template'>
+<div class="mb-3" data-controller="nested-form" data-nested-form-selector-value=".plain-container">
+  <div class="keywords-container<%= ' is-invalid' if error? %>" data-keywords-target="container" data-action="click->keywords#open" data-keywords-target="addItem">
+    <template data-nested-form-target='template' data-keywords-target="selectedTemplate">
       <%= form.fields_for :keywords, Keyword.new, child_index: 'TEMPLATE_RECORD' do |keyword_form| %>
         <%= row(keyword_form) %>
       <% end %>
@@ -10,9 +9,9 @@
     <%= form.fields_for :keywords do |keyword_form| %>
       <%= row(keyword_form) %>
     <% end %>
+  </div>
 
-    <div data-nested-form-target="add_item">
-      <%= button_tag '+ Add another keyword', type: 'button', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
-    </div>
+  <div data-nested-form-target="add_item">
+    <%= button_tag '+ Add another keyword', type: 'button', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
   </div>
 </div>

--- a/app/components/works/keywords_component.html.erb
+++ b/app/components/works/keywords_component.html.erb
@@ -1,46 +1,15 @@
-<div class="keywords" data-controller="keywords" data-action="focusout->keywords#close" data-edit-deposit-target="keywordsField">
-  <div class="keywords-container<%= ' is-invalid' if error? %>" data-keywords-target="container" data-action="click->keywords#open">
-    <span class="selection" role="combobox" aria-haspopup="true" aria-expanded="true" tabindex="-1"
-      aria-disabled="false" aria-owns="keyword-results">
-      <ul class="rendered" id="keyword-container" data-keywords-target="addItem">
-        <%= form.fields_for :keywords do |keyword_form| %>
-          <%= render Works::SelectedKeywordComponent.new(form: keyword_form) %>
-        <% end %>
-      </ul>
+<div class="mb-3" data-controller="nested-form" data-nested-form-selector-value=".plain-container">
+  <template data-nested-form-target='template'>
+    <%= form.fields_for :keywords, Keyword.new, child_index: 'TEMPLATE_RECORD' do |keyword_form| %>
+      <%= row(keyword_form) %>
+    <% end %>
+  </template>
 
-      <template data-keywords-target='selectedTemplate'>
-        <%= form.fields_for :keywords, Keyword.new(label: 'TEMPLATE_LABEL'), child_index: 'TEMPLATE_RECORD' do |file_form| %>
-          <%= render Works::SelectedKeywordComponent.new(form: file_form) %>
-        <% end %>
-      </template>
+  <%= form.fields_for :keywords do |keyword_form| %>
+    <%= row(keyword_form) %>
+  <% end %>
 
-      <!-- THIS IS THE BLOCK FOR THE ACTUAL ENTRY -->
-      <span class="search">
-        <input class="search-field" type="text" tabindex="0" autocorrect="off"
-               data-keywords-target="search" autocapitalize="none" spellcheck="false"
-               role="searchbox" aria-autocomplete="list" autocomplete="off"
-               id="work_keywords"
-               aria-describedby="keyword-container"
-               data-action="change->keywords#add keypress->keywords#checkForEnter"
-               aria-controls="keyword-results">
-      </span>
-      <!-- THIS IS THE BLOCK FOR THE ACTUAL ENTRY -->
-    </span>
-      </div>
-      <div data-nested-form-target="add_item">
-      <%= button_tag '+ Add another keyword', type: 'button', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
-      </div>
-    <div data-keywords-target="error" class="invalid-feedback"><%= error_message %></div>
-<%# -- TODO for autocomplete
-  <div class="keywords-container keywords-container-open" data-keywords-target="container">
-    <span class="keywords-dropdown select2-dropdown--above">
-      <span class="keywords-results">
-        <ul class="select2-results__options" role="listbox" aria-multiselectable="true" id="keyword-results" aria-expanded="true" aria-hidden="false">
-          <li class="select2-results__option select2-results__option--selectable select2-results__option--highlighted select2-results__option--selected" id="select2-1ndb-result-wggo-AK" role="option" data-select2-id="select2-data-select2-1ndb-result-wggo-AK" aria-selected="true">Alaska</li>
-          <li class="select2-results__option select2-results__option--selectable" id="select2-1ndb-result-ltnw-HI" role="option" data-select2-id="select2-data-select2-1ndb-result-ltnw-HI" aria-selected="false">Hawaii</li>
-        </ul>
-      </span>
-    </span>
+  <div data-nested-form-target="add_item">
+    <%= button_tag '+ Add another keyword', type: 'button', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
   </div>
-   %>
 </div>

--- a/app/components/works/keywords_component.html.erb
+++ b/app/components/works/keywords_component.html.erb
@@ -14,8 +14,9 @@
         <% end %>
       </template>
 
+      <!-- THIS IS THE BLOCK FOR THE ACTUAL ENTRY -->
       <span class="search">
-        <input class="search-field" type="search" tabindex="0" autocorrect="off"
+        <input class="search-field" type="text" tabindex="0" autocorrect="off"
                data-keywords-target="search" autocapitalize="none" spellcheck="false"
                role="searchbox" aria-autocomplete="list" autocomplete="off"
                id="work_keywords"
@@ -23,9 +24,13 @@
                data-action="change->keywords#add keypress->keywords#checkForEnter"
                aria-controls="keyword-results">
       </span>
+      <!-- THIS IS THE BLOCK FOR THE ACTUAL ENTRY -->
     </span>
-  </div>
-  <div data-keywords-target="error" class="invalid-feedback"><%= error_message %></div>
+      </div>
+      <div data-nested-form-target="add_item">
+      <%= button_tag '+ Add another keyword', type: 'button', class: "btn btn-outline-primary", data: { action: "nested-form#addAssociation" } %>
+      </div>
+    <div data-keywords-target="error" class="invalid-feedback"><%= error_message %></div>
 <%# -- TODO for autocomplete
   <div class="keywords-container keywords-container-open" data-keywords-target="container">
     <span class="keywords-dropdown select2-dropdown--above">

--- a/app/components/works/keywords_component.rb
+++ b/app/components/works/keywords_component.rb
@@ -4,12 +4,11 @@
 module Works
   # Allows the user to search for keywords or provide freetext keywords
   class KeywordsComponent < ApplicationComponent
-    def initialize(form:, key:)
+    def initialize(form:)
       @form = form
-      @key = key
     end
 
-    attr_reader :form, :key
+    attr_reader :form
 
     def error?
       errors.present?
@@ -24,7 +23,7 @@ module Works
     end
 
     def row(keyword_form)
-      render Works::KeywordsRowComponent.new(form: keyword_form, key: key)
+      render Works::KeywordsRowComponent.new(form: keyword_form)
     end
   end
 end

--- a/app/components/works/keywords_row_component.html.erb
+++ b/app/components/works/keywords_row_component.html.erb
@@ -1,14 +1,8 @@
 <div class="mb-3 row plain-container">
   <div class="col-sm-6">
-    <span class="search">
-    <input class="search-field form-control" type="search" tabindex="0" autocorrect="off"
-      data-keywords-target="search" autocapitalize="none" spellcheck="false"
-      role="searchbox" aria-autocomplete="list" autocomplete="off"
-      id="work_keywords"
-      aria-describedby="keyword-container"
-      data-action="change->keywords#add keypress->keywords#checkForEnter"
-      aria-controls="keyword-results">
-      </span>
+    <%= form.label :label, 'Keyword', class: 'col-form-label sr-only' %>
+    <%= form.text_field :label, class: "form-control", required: true %>
+    <div class="invalid-feedback">You must provide a valid keyword</div>
   </div>
   <% if not_first_keyword? %>
     <div class="col-sm-1">

--- a/app/components/works/keywords_row_component.html.erb
+++ b/app/components/works/keywords_row_component.html.erb
@@ -1,5 +1,5 @@
 <div class="mb-3 row plain-container">
-  <div class="col-sm-9">
+  <div class="col-sm-6">
     <input class="search-field form-control" type="search" tabindex="0" autocorrect="off"
       data-keywords-target="search" autocapitalize="none" spellcheck="false"
       role="searchbox" aria-autocomplete="list" autocomplete="off"
@@ -7,14 +7,15 @@
       aria-describedby="keyword-container"
       data-action="change->keywords#add keypress->keywords#checkForEnter"
       aria-controls="keyword-results">
-
-      <div class="col-sm-1">
+  </div>
+  <% if not_first_keyword? %>
+    <div class="col-sm-1">
       <%= button_tag type: 'button', class: 'btn btn-sm float-end', aria: { label: 'Remove' },
-       data: { action: "click->nested-form#removeAssociation",
-               plain: true } do %>
+      data: { action: "click->nested-form#removeAssociation",
+              plain: true } do %>
         <span class="far fa-trash-alt"></span>
       <% end %>
       <%= form.hidden_field :_destroy %>
-    </div>  
-  <div>
+    </div>
+  <% end %>
 </div>

--- a/app/components/works/keywords_row_component.html.erb
+++ b/app/components/works/keywords_row_component.html.erb
@@ -1,0 +1,20 @@
+<div class="mb-3 row plain-container">
+  <div class="col-sm-9">
+    <input class="search-field form-control" type="search" tabindex="0" autocorrect="off"
+      data-keywords-target="search" autocapitalize="none" spellcheck="false"
+      role="searchbox" aria-autocomplete="list" autocomplete="off"
+      id="work_keywords"
+      aria-describedby="keyword-container"
+      data-action="change->keywords#add keypress->keywords#checkForEnter"
+      aria-controls="keyword-results">
+
+      <div class="col-sm-1">
+      <%= button_tag type: 'button', class: 'btn btn-sm float-end', aria: { label: 'Remove' },
+       data: { action: "click->nested-form#removeAssociation",
+               plain: true } do %>
+        <span class="far fa-trash-alt"></span>
+      <% end %>
+      <%= form.hidden_field :_destroy %>
+    </div>  
+  <div>
+</div>

--- a/app/components/works/keywords_row_component.html.erb
+++ b/app/components/works/keywords_row_component.html.erb
@@ -1,5 +1,6 @@
 <div class="mb-3 row plain-container">
   <div class="col-sm-6">
+    <span class="search">
     <input class="search-field form-control" type="search" tabindex="0" autocorrect="off"
       data-keywords-target="search" autocapitalize="none" spellcheck="false"
       role="searchbox" aria-autocomplete="list" autocomplete="off"
@@ -7,6 +8,7 @@
       aria-describedby="keyword-container"
       data-action="change->keywords#add keypress->keywords#checkForEnter"
       aria-controls="keyword-results">
+      </span>
   </div>
   <% if not_first_keyword? %>
     <div class="col-sm-1">

--- a/app/components/works/keywords_row_component.html.erb
+++ b/app/components/works/keywords_row_component.html.erb
@@ -1,8 +1,8 @@
 <div class="mb-3 row plain-container">
   <div class="col-sm-6">
     <%= form.label :label, 'Keyword', class: 'col-form-label sr-only' %>
-    <%= form.text_field :label, class: "form-control", required: true %>
-    <div class="invalid-feedback">You must provide a valid keyword</div>
+    <%= form.text_field :label, class: "form-control#{ 'is-invalid' if error?}", required: true %>
+    <div class="invalid-feedback">Please add at least one keyword</div>
   </div>
   <% if not_first_keyword? %>
     <div class="col-sm-1">

--- a/app/components/works/keywords_row_component.rb
+++ b/app/components/works/keywords_row_component.rb
@@ -4,9 +4,8 @@
 module Works
   # Allows the user to search for keywords or provide freetext keywords
   class KeywordsRowComponent < ApplicationComponent
-    def initialize(form:, key:)
+    def initialize(form:)
       @form = form
-      @key = key
     end
 
     attr_reader :form, :key

--- a/app/components/works/keywords_row_component.rb
+++ b/app/components/works/keywords_row_component.rb
@@ -3,7 +3,7 @@
 
 module Works
   # Allows the user to search for keywords or provide freetext keywords
-  class KeywordsComponent < ApplicationComponent
+  class KeywordsRowComponent < ApplicationComponent
     def initialize(form:, key:)
       @form = form
       @key = key
@@ -21,10 +21,6 @@ module Works
 
     def errors
       form.object.errors.where(:keywords)
-    end
-
-    def row(keyword_form)
-      render Works::KeywordsRowComponent.new(form: keyword_form, key: key)
     end
   end
 end

--- a/app/components/works/keywords_row_component.rb
+++ b/app/components/works/keywords_row_component.rb
@@ -8,7 +8,7 @@ module Works
       @form = form
     end
 
-    attr_reader :form, :key
+    attr_reader :form
 
     sig { returns(T::Boolean) }
     def not_first_keyword?

--- a/app/components/works/keywords_row_component.rb
+++ b/app/components/works/keywords_row_component.rb
@@ -20,10 +20,6 @@ module Works
       errors.present?
     end
 
-    def error_message
-      safe_join(errors.map(&:message), tag.br)
-    end
-
     def errors
       form.object.errors.where(:keywords)
     end

--- a/app/components/works/keywords_row_component.rb
+++ b/app/components/works/keywords_row_component.rb
@@ -11,6 +11,11 @@ module Works
 
     attr_reader :form, :key
 
+    sig { returns(T::Boolean) }
+    def not_first_keyword?
+      form.index != 0
+    end
+
     def error?
       errors.present?
     end

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -122,7 +122,9 @@ class DraftWorkForm < Reform::Form
     property :_destroy, virtual: true
   end
 
-  collection :keywords, populator: KeywordsPopulator.new(:keywords, Keyword), on: :work_version do
+  collection :keywords, populator: KeywordsPopulator.new(:keywords, Keyword),
+             prepopulator: ->(*) { keywords << Keyword.new if keywords.blank? },
+             on: :work_version do
     property :id
     property :label
     property :uri

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -122,7 +122,8 @@ class DraftWorkForm < Reform::Form
     property :_destroy, virtual: true
   end
 
-  collection :keywords, populator: KeywordsPopulator.new(:keywords, Keyword),
+  collection :keywords,
+             populator: KeywordsPopulator.new(:keywords, Keyword),
              prepopulator: ->(*) { keywords << Keyword.new if keywords.blank? },
              on: :work_version do
     property :id

--- a/spec/components/works/contact_email_component_spec.rb
+++ b/spec/components/works/contact_email_component_spec.rb
@@ -12,5 +12,6 @@ RSpec.describe Works::ContactEmailComponent, type: :component do
 
   it 'renders the component' do
     expect(rendered.to_html).to include('Contact email')
+    expect(rendered.to_html).to include('+ Add another email')
   end
 end

--- a/spec/components/works/keywords_component_spec.rb
+++ b/spec/components/works/keywords_component_spec.rb
@@ -8,11 +8,9 @@ RSpec.describe Works::KeywordsComponent do
   let(:work) { work_version.work }
   let(:work_version) { build_stubbed(:work_version) }
   let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
-  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:rendered) { render_inline(described_class.new(form: form, key: 'work.keywords')) }
 
   it 'renders the component' do
-    expect(rendered.css('.keywords').to_html)
-      .to be_present
-    expect(rendered.css('.keywords-container.is-invalid')).not_to be_present
+    expect(rendered.to_html).to include('Keyword')
   end
 end

--- a/spec/components/works/keywords_component_spec.rb
+++ b/spec/components/works/keywords_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Works::KeywordsComponent do
   let(:work) { work_version.work }
   let(:work_version) { build_stubbed(:work_version) }
   let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
-  let(:rendered) { render_inline(described_class.new(form: form, key: 'work.keywords')) }
+  let(:rendered) { render_inline(described_class.new(form: form)) }
 
   it 'renders the component' do
     expect(rendered.to_html).to include('Keyword')

--- a/spec/components/works/keywords_component_spec.rb
+++ b/spec/components/works/keywords_component_spec.rb
@@ -12,5 +12,6 @@ RSpec.describe Works::KeywordsComponent do
 
   it 'renders the component' do
     expect(rendered.to_html).to include('Keyword')
+    expect(rendered.to_html).to include('+ Add another keyword')
   end
 end

--- a/spec/components/works/keywords_row_component_spec.rb
+++ b/spec/components/works/keywords_row_component_spec.rb
@@ -19,5 +19,6 @@ RSpec.describe Works::KeywordsRowComponent do
 
   it 'renders the component' do
     expect(rendered.to_html).to include('Keyword')
+    expect(rendered.css('.plain-container')).to be_present
   end
 end

--- a/spec/components/works/keywords_row_component_spec.rb
+++ b/spec/components/works/keywords_row_component_spec.rb
@@ -4,7 +4,7 @@
 require 'rails_helper'
 
 RSpec.describe Works::KeywordsRowComponent do
-  subject(:rendered) { render_inline(described_class.new(form: form_builder, key: 'collection.contact_email')) }
+  subject(:rendered) { render_inline(described_class.new(form: form_builder)) }
 
   let(:work) { work_version.work }
   let(:work_version) { build_stubbed(:work_version) }

--- a/spec/components/works/keywords_row_component_spec.rb
+++ b/spec/components/works/keywords_row_component_spec.rb
@@ -1,0 +1,23 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Works::KeywordsRowComponent do
+  subject(:rendered) { render_inline(described_class.new(form: form_builder, key: 'collection.contact_email')) }
+
+  let(:work) { work_version.work }
+  let(:work_version) { build_stubbed(:work_version) }
+  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
+  let(:keyword_form) do
+    work_form.prepopulate!
+    work_form.keywords.first
+  end
+  let(:form_builder) do
+    ActionView::Helpers::FormBuilder.new('work', keyword_form, controller.view_context, {})
+  end
+
+  it 'renders the component' do
+    expect(rendered.to_html).to include('Keyword')
+  end
+end

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -106,19 +106,11 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
 
         check 'I agree to the SDR Terms of Deposit'
 
-        # Test remote form validation which only happens once client-side validation passes
-        expect(page).not_to have_content('Please add at least one keyword')
-        expect(page).not_to have_css('.keywords-container.is-invalid')
-        expect(page).not_to have_css('.keywords-container.is-invalid ~ .invalid-feedback')
-
         click_button 'Deposit'
 
         expect(page).to have_content('Please add at least one keyword')
-        expect(page).to have_css('.keywords-container.is-invalid')
-        expect(page).to have_css('.keywords-container.is-invalid ~ .invalid-feedback')
 
-        fill_in 'Keywords', with: 'Springs'
-        blur_from 'work_keywords'
+        fill_in 'Keyword', with: 'Springs'
 
         uncheck 'Use default citation'
         fill_in 'Provided citation', with: 'Citation from user input'
@@ -187,8 +179,7 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
 
         fill_in 'Abstract', with: 'User provided abstract'
 
-        fill_in 'Keywords', with: 'Springs'
-        blur_from 'work_keywords'
+        fill_in 'Keyword', with: 'Springs'
 
         check 'I agree to the SDR Terms of Deposit'
         click_button 'Deposit'


### PR DESCRIPTION
## Why was this change made?

Fixes #1377

1. Single entry:

<img width="963" alt="Screen Shot 2021-05-13 at 10 35 45 AM" src="https://user-images.githubusercontent.com/2294288/118163710-2c72e580-b3d7-11eb-938c-af5e479e47a9.png">

2. When another keyword is added:

<img width="865" alt="Screen Shot 2021-05-13 at 10 35 55 AM" src="https://user-images.githubusercontent.com/2294288/118163785-414f7900-b3d7-11eb-8760-abbbd7027ceb.png">

3. Error message if blank:

<img width="781" alt="Screen Shot 2021-05-13 at 10 36 11 AM" src="https://user-images.githubusercontent.com/2294288/118163873-54624900-b3d7-11eb-99f4-ac86c53e213d.png">

4. Entering multiple values:

<img width="804" alt="Screen Shot 2021-05-13 at 10 36 34 AM" src="https://user-images.githubusercontent.com/2294288/118163904-5e844780-b3d7-11eb-892e-6e704cd1a8bb.png">

5. Showing the values saves as draft:

<img width="571" alt="Screen Shot 2021-05-13 at 10 36 42 AM" src="https://user-images.githubusercontent.com/2294288/118163957-6ba13680-b3d7-11eb-9afe-1e190e013fb1.png">

## How was this change tested?

Updated feature tests

## Which documentation and/or configurations were updated?



