### PR TITLE
Only validate embargo parts when the user has selected 'embargo'

### DIFF
--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -37,7 +37,7 @@ class DraftWorkForm < Reform::Form
   end)
 
   validates_with EmbargoDateParts,
-                 if: proc { |form| form.user_can_set_availability? && form.release != 'immediate' }
+                 if: proc { |form| form.user_can_set_availability? && form.release == 'embargo' }
 
   delegate :user_can_set_availability?, to: :collection
 

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -187,4 +187,44 @@ RSpec.describe WorkForm do
       expect(messages).to be_empty
     end
   end
+
+  describe 'embargo validation' do
+    context 'with a collection that allows depositor to select embargo' do
+      let(:errors) { form.errors.where(:'embargo-date') }
+      let(:messages) { errors.map(&:message) }
+
+      before do
+        work.collection = build(:collection, release_option: 'depositor-selects')
+      end
+
+      context 'when release is nil' do
+        it 'validates' do
+          form.validate(release: nil)
+          expect(messages).to be_empty
+        end
+      end
+
+      context 'when release is immediate' do
+        it 'validates' do
+          form.validate(release: 'immediate')
+          expect(messages).to be_empty
+        end
+      end
+
+      context 'when release is embargo and a date is provided' do
+        it 'validates' do
+          form.validate(release: 'embargo', 'embargo_date(1i)' => '2040', 'embargo_date(2i)' => '2',
+                        'embargo_date(3i)' => '19')
+          expect(messages).to be_empty
+        end
+      end
+
+      context 'when release is embargo and a date is not provided' do
+        it 'has an error' do
+          form.validate(release: 'embargo', 'embargo_date(1i)' => '2040', 'embargo_date(2i)' => '2')
+          expect(messages).to eq ['Must provide all parts']
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -594,34 +594,6 @@ RSpec.describe 'Create a new work' do
         end
       end
 
-      context 'with a collection that allows depositor to select embargo but missing embargo month and day' do
-        let(:collection) do
-          create(:collection, depositors: [user], release_option: 'depositor-selects')
-        end
-        let(:work_params) do
-          {
-            title: 'A title of great import',
-            contact_email: '',
-            abstract: 'A work',
-            license: License.license_list.first,
-            work_type: 'text',
-            release: 'embargo',
-            'embargo(1i)': 2020,
-            'embargo(2i)': '',
-            'embargo(3i)': ''
-          }
-        end
-
-        before { create(:collection_version_with_collection, collection: collection) }
-
-        it 'returns an error' do
-          post "/collections/#{collection.id}/works", params: { work: work_params,
-                                                                commit: 'Deposit' }
-          expect(response).to have_http_status(:unprocessable_entity)
-          expect(response.body).to include 'Must provide all parts'
-        end
-      end
-
       context 'with a collection that dictates a license but a license is provided' do
         let(:collection) do
           create(:collection, :with_required_license, depositors: [user])


### PR DESCRIPTION

## Why was this change made?

Otherwise, this validation gets triggered when registering a purl in a collection that allows the user to choose whether to embargo.

Fixes #1394

## How was this change tested?



## Which documentation and/or configurations were updated?



