### PR TITLE
Fix footnote marker to be superscript on terms-of-service modal

### DIFF
--- a/app/views/shared/_terms_of_deposit.html.erb
+++ b/app/views/shared/_terms_of_deposit.html.erb
@@ -28,7 +28,7 @@
           formats as may be in existence now or developed in the future, to sublicense others to do the
           same, and to preserve and store the Work, subject to any third-party release or display
           restrictions chosen by Depositor through Stanford Libraries’ deposit submission application.
-          Stanford Libraries may make the Work available to users, subject to the applicable Terms of Use1
+          Stanford Libraries may make the Work available to users, subject to the applicable Terms of Use<sup>[1]</sup>
           and to any license applied by Depositor through Stanford Libraries’ deposit submission
           application. These Terms of Use are subject to change by Stanford Libraries; Stanford Libraries
           will make a reasonable effort to notify the Depositor when changes occur. More information is


### PR DESCRIPTION
## Why was this change made?

Fixes #1422 

<img width="208" alt="Screen Shot 2021-05-12 at 3 53 56 PM" src="https://user-images.githubusercontent.com/2294288/118054069-75289100-b33a-11eb-8984-77a34569a2ef.png">

cc: @amyehodge 

## How was this change tested?



## Which documentation and/or configurations were updated?



