### PR TITLE
Don't allow blank contact emails

### DIFF
--- a/app/components/works/contact_email_row_component.html.erb
+++ b/app/components/works/contact_email_row_component.html.erb
@@ -3,7 +3,8 @@
     <%= form.label :email, 'Contact email *', class: 'col-form-label' %> <%= tooltip %>
   </div>
   <div class="<%= bootstrap_classes %>">
-    <%= form.email_field :email, class: "form-control#{' is-invalid' if error?}", pattern: Devise.email_regexp.source %>
+    <%= form.email_field :email, class: "form-control#{' is-invalid' if error?}",
+                         pattern: Devise.email_regexp.source, required: true %>
     <div class="invalid-feedback">You must provide a valid email address</div>
   </div>
   <% if not_first_email? %>

--- a/app/controllers/collection_versions_controller.rb
+++ b/app/controllers/collection_versions_controller.rb
@@ -48,10 +48,10 @@ class CollectionVersionsController < ObjectsController
 
     authorize! collection_version
     @form = collection_form(collection_version)
-
     if @form.validate(clean_params) && @form.save
       after_save(collection: collection_version.collection, collection_version: collection_version)
     else
+      @form.prepopulate!
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -30,6 +30,7 @@ class WorksController < ObjectsController
       work.event_context = { user: current_user }
       after_save(work_version: work_version, work: work)
     else
+      @form.prepopulate!
       render :new, status: :unprocessable_entity
     end
   end
@@ -78,6 +79,7 @@ class WorksController < ObjectsController
     if @form.validate(clean_params) && @form.save
       after_save(work_version: work_version, work: work)
     else
+      @form.prepopulate!
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/forms/contact_emails_populator.rb
+++ b/app/forms/contact_emails_populator.rb
@@ -10,6 +10,8 @@ class ContactEmailsPopulator < ApplicationPopulator
     if fragment['_destroy'] == '1'
       form.contact_emails.delete(item)
       return skip!
+    elsif fragment['email'].blank?
+      return skip!
     end
     item || form.contact_emails.append(ContactEmail.new)
   end

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -101,23 +101,24 @@ RSpec.describe WorkForm do
   describe 'populator on contact email' do
     let(:emails) do
       [
-        { _destroy: 'false', email: 'avalidemail@test.com' },
-        { _destroy: 'false', email: 'anothervalid@test.com' },
-        { _destroy: 'false', email: 'third@example.com' }
+        { '_destroy' => 'false', 'email' => 'avalidemail@test.com' },
+        { '_destroy' => 'false', 'email' => 'anothervalid@test.com' },
+        { '_destroy' => '1', 'email' => 'remove@test.com' },
+        { '_destroy' => 'false', 'email' => '' }
       ]
     end
 
     it 'populates contact emails' do
       form.validate(contact_emails: emails)
-      expect(form.contact_emails.size).to be 3
+      expect(form.contact_emails.map(&:email)).to eq ['avalidemail@test.com', 'anothervalid@test.com']
     end
   end
 
   describe 'email validation' do
     let(:valid_email) do
       [
-        { _destroy: 'false', email: 'avalidemail@test.com' },
-        { _destroy: 'false', email: 'anothervalid@test.com' }
+        { '_destroy' => 'false', 'email' => 'avalidemail@test.com' },
+        { '_destroy' => 'false', 'email' => 'anothervalid@test.com' }
       ]
     end
 

--- a/spec/requests/edit_collection_version_spec.rb
+++ b/spec/requests/edit_collection_version_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Updating an existing collection version' do
       context 'when collection fails to save' do
         let(:collection_params) do
           {
-            contact_emails_attributes: { '0' => { 'email' => '', 'id' => '' } }
+            contact_emails_attributes: { '0' => { 'email' => 'notvalid', 'id' => '' } }
           }
         end
 

--- a/spec/requests/edit_work_spec.rb
+++ b/spec/requests/edit_work_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe 'Updating an existing work' do
           {
             title: 'New title',
             work_type: 'text',
-            contact_email: 'io@io.io',
             abstract: 'test abstract',
             attached_files_attributes: {
               '0' => { 'label' => 'two', '_destroy' => '', 'hide' => '0', 'id' => work_version.attached_files.first.id }
@@ -92,7 +91,6 @@ RSpec.describe 'Updating an existing work' do
           {
             title: '',
             work_type: 'text',
-            contact_email: 'io@io.io',
             abstract: 'test abstract',
             keywords_attributes: {
               '0' => { '_destroy' => 'false', 'label' => 'Feminism', 'uri' => 'http://id.worldcat.org/fast/922671' }


### PR DESCRIPTION


## Why was this change made?

Previously leaving the contact email blank was enabling validations to pass.
Fixes #1362

## How was this change tested?



## Which documentation and/or configurations were updated?



