### PR TITLE
Refactor reserve a PURL to use a form object

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -25,12 +25,6 @@ class WorksController < ObjectsController
 
     authorize! work_version
 
-    if purl_reservation?
-      work_version.abstract = ''
-      work_version.license = 'none'
-      work_version.work_type = WorkType.purl_reservation_type.id
-    end
-
     @form = work_form(work_version)
     if @form.validate(work_params) && @form.save
       work.event_context = { user: current_user }
@@ -146,11 +140,13 @@ class WorksController < ObjectsController
 
   sig { params(work_version: WorkVersion).returns(Reform::Form) }
   def work_form(work_version)
-    if deposit_button_pushed? && !purl_reservation?
-      return WorkForm.new(work_version: work_version, work: work_version.work)
+    if purl_reservation?
+      ReservationForm.new(work_version: work_version, work: work_version.work)
+    elsif deposit_button_pushed?
+      WorkForm.new(work_version: work_version, work: work_version.work)
+    else
+      DraftWorkForm.new(work_version: work_version, work: work_version.work)
     end
-
-    DraftWorkForm.new(work_version: work_version, work: work_version.work)
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/app/forms/reservation_form.rb
+++ b/app/forms/reservation_form.rb
@@ -1,0 +1,20 @@
+# typed: false
+# frozen_string_literal: true
+
+# The form for reserving a PURL
+class ReservationForm < Reform::Form
+  include Composition
+
+  property :work_type, on: :work_version, default: WorkType.purl_reservation_type.id
+  property :abstract, on: :work_version, default: ''
+  property :license, on: :work_version, default: 'none'
+  property :title, on: :work_version
+
+  # Ensure that this work version is now the head of the work versions for this work
+  def save_model
+    Work.transaction do
+      super
+      model.fetch(:work).update(head: model.fetch(:work_version))
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

Keep the form stuff in the form.

## How was this change tested?



## Which documentation and/or configurations were updated?



