### PR TITLE
Make the reserve a purl style have valid bootstrap markup

### DIFF
--- a/app/components/works/purl_reservation_modal_component.html.erb
+++ b/app/components/works/purl_reservation_modal_component.html.erb
@@ -1,33 +1,30 @@
 <div class="modal fade" id="purlReservationModal" tabindex="-1" aria-labelledby="content-type-prompt" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-sm">
+  <div class="modal-dialog modal-dialog-centered modal">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="content-type-prompt"><label for="purl-reservation-title">Enter a title for this deposit</label></h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
-      <div class="modal-header">
-        <h6><em>(You can update this later.)</em></h6>
-      </div>
-      <div class="modal-body">
-        <form method="post" action="" data-purl-reservation-target="form">
-          <div class="container-fluid">
-            <div>
-              <input type="text" name="work[title]" data-purl-reservation-target="title" id="purl-reservation-title">
-              <input type="hidden" name="purl_reservation" value="true">
-            </div>
-            <div class="modal-footer">
-              <%= button_tag 'Submit', class: 'btn btn-primary' %>
-              <%= button_tag 'Cancel',
-                    data: {
-                      bs_dismiss: 'modal',
-                      bs_target: '#purlReservationModal',
-                      action: "purl-reservation#cancel"
-                    },
-                    class: 'btn btn-secondary' %>
-            </div>
+      <form method="post" action="" data-purl-reservation-target="form">
+        <div class="modal-body">
+          <div class="form-group">
+            <input type="text" name="work[title]" data-purl-reservation-target="title" class="form-control" id="purl-reservation-title">
+            <small class="form-text">You can update this later.</small>
+            <input type="hidden" name="purl_reservation" value="true">
           </div>
-        </form>
-      </div>
+        </div>
+
+        <div class="modal-footer">
+          <%= button_tag 'Submit', class: 'btn btn-primary' %>
+          <%= button_tag 'Cancel',
+                data: {
+                  bs_dismiss: 'modal',
+                  bs_target: '#purlReservationModal',
+                  action: "purl-reservation#cancel"
+                },
+                class: 'btn btn-secondary' %>
+        </div>
+      </form>
     </div>
   </div>
 </div>

--- a/spec/components/works/purl_reservation_modal_component_spec.rb
+++ b/spec/components/works/purl_reservation_modal_component_spec.rb
@@ -7,6 +7,6 @@ RSpec.describe Works::PurlReservationModalComponent, type: :component do
   it 'renders the component' do
     rendered_html = render_inline(described_class.new).to_html
     expect(rendered_html).to include('Enter a title for this deposit')
-    expect(rendered_html).to include('(You can update this later.)')
+    expect(rendered_html).to include('You can update this later.')
   end
 end


### PR DESCRIPTION
(e.g. don't nest footer inside the body)

## Why was this change made?

Before:
<img width="336" alt="Screen Shot 2021-05-13 at 12 17 54 PM" src="https://user-images.githubusercontent.com/92044/118161769-97c3b400-b3e5-11eb-8f49-5f9cb53ad386.png">

After:
<img width="522" alt="Screen Shot 2021-05-13 at 12 18 11 PM" src="https://user-images.githubusercontent.com/92044/118161784-9befd180-b3e5-11eb-9ca7-572ef49f13d2.png">


## How was this change tested?



## Which documentation and/or configurations were updated?



