### PR TITLE
Add required field marker and remove optional text for collections

### DIFF
--- a/app/components/collections/edit_license_component.html.erb
+++ b/app/components/collections/edit_license_component.html.erb
@@ -1,5 +1,5 @@
   <section id="terms-and-license" data-controller="complex-radio">
-    <header>Terms of use and license <%= render PopoverComponent.new key: 'collection.terms' %></header>
+    <header>Terms of use and license * <%= render PopoverComponent.new key: 'collection.terms' %></header>
 
     <p>
       We highly recommend every deposit be assigned a license when possible. A

--- a/app/components/collections/update/details_form_component.html.erb
+++ b/app/components/collections/update/details_form_component.html.erb
@@ -1,4 +1,4 @@
-<header>All fields are required, unless otherwise noted.</header>
+<header><strong>* REQUIRED FIELDS</strong></header>
 <%= form_with model: collection_form,
     data: {
       controller: 'unsaved-changes',

--- a/app/components/collections/update/settings_form_component.html.erb
+++ b/app/components/collections/update/settings_form_component.html.erb
@@ -1,4 +1,4 @@
-<header>All fields are required, unless otherwise noted.</header>
+<header><strong>* REQUIRED FIELDS</strong></header>
 <%= form_with model: collection_form,
     data: {
       controller: 'unsaved-changes',

--- a/app/components/first_draft_collections/create/details_component.html.erb
+++ b/app/components/first_draft_collections/create/details_component.html.erb
@@ -1,8 +1,8 @@
 <section id="details">
-  <header>Details</header>
+  <header>Details *</header>
   <div class="mb-3 row">
     <div class="col-sm-2">
-      <%= form.label :name, 'Collection name', class: 'col-form-label' %>
+      <%= form.label :name, 'Collection name *', class: 'col-form-label' %>
       <%= render PopoverComponent.new key: 'collection.name' %>
     </div>
     <div class="col-sm-10 col-xl-8">
@@ -12,7 +12,7 @@
   </div>
   <div class="mb-3 row">
     <div class="col-sm-2">
-      <%= form.label :description, 'Description', class: 'col-form-label' %>
+      <%= form.label :description, 'Description *', class: 'col-form-label' %>
       <%= render PopoverComponent.new key: 'collection.description' %>
     </div>
     <div class="col-sm-10 col-xl-8">

--- a/app/components/first_draft_collections/create/form_component.html.erb
+++ b/app/components/first_draft_collections/create/form_component.html.erb
@@ -1,4 +1,4 @@
-<header>All fields are required, unless otherwise noted.</header>
+<header><strong>* REQUIRED FIELDS</strong></header>
 <%= form_with model: collection_form,
     data: {
       controller: 'unsaved-changes',

--- a/app/components/first_draft_collections/create/settings_component.html.erb
+++ b/app/components/first_draft_collections/create/settings_component.html.erb
@@ -1,9 +1,9 @@
 
   <section id="release_details">
-    <header>Manage release of deposits for discovery and download</header>
+    <header>Manage release of deposits for discovery and download *</header>
 
     <fieldset class="mb-5 release-option" data-controller="complex-radio">
-      <legend class="h5">When will files on deposits to this collection be downloadable? <%= render PopoverComponent.new key: 'collection.release' %></legend>
+      <legend class="h5">When will files on deposits to this collection be downloadable? * <%= render PopoverComponent.new key: 'collection.release' %></legend>
       <div class="form-check" data-complex-radio-target="selection">
         <%= form.radio_button :release_option, 'immediate', class: "form-check-input", data: { action: 'complex-radio#disableUnselectedInputs' } %>
         <%= form.label 'release_option_immediate', t('options.collection.release.immediate'), class: "form-check-label" %>
@@ -33,7 +33,7 @@
     </fieldset>
 
     <fieldset>
-      <legend class="h5">Who will have permission to download files for deposits to this collection? <%= render PopoverComponent.new key: 'collection.access' %></legend>
+      <legend class="h5">Who will have permission to download files for deposits to this collection? * <%= render PopoverComponent.new key: 'collection.access' %></legend>
       <div class="form-check">
         <%= form.radio_button :access, 'world', class: "form-check-input" %>
         <%= form.label 'access_world', t('options.collection.access.world'), class: "form-check-label" %>
@@ -52,14 +52,14 @@
   <%= render Collections::EditLicenseComponent.new(form: form) %>
 
   <section id="participants">
-    <header>Collection participants</header>
+    <header>Collection participants *</header>
     <div class="mb-3 row">
       <p class="col-sm-12">Enter SUNet IDs of participants. Separate each one with a comma and a space. (e.g. janelath, lelandst)</p>
     </div>
 
     <div class="mb-3 row">
       <div class="col-sm-2">
-        <%= form.label :manager_sunets, 'Managers', class: 'col-form-label' %>
+        <%= form.label :manager_sunets, 'Managers *', class: 'col-form-label' %>
         <%= render PopoverComponent.new key: 'collection.managers' %>
       </div>
       <div class="col-sm-10 col-xl-8">

--- a/app/components/first_draft_collections/update/form_component.html.erb
+++ b/app/components/first_draft_collections/update/form_component.html.erb
@@ -1,4 +1,4 @@
-<header>All fields are required, unless otherwise noted.</header>
+<header><strong>* REQUIRED FIELDS</header>
 <%= form_with model: collection_form,
     data: {
       controller: 'unsaved-changes',

--- a/app/components/related_link_component.html.erb
+++ b/app/components/related_link_component.html.erb
@@ -1,5 +1,5 @@
 <fieldset>
-  <legend class="h5">Links to related content (optional) <%= tooltip %></legend>
+  <legend class="h5">Links to related content <%= tooltip %></legend>
 
   <div class="mb-3" data-controller="nested-form" data-nested-form-selector-value=".inner-container">
     <template data-nested-form-target='template'>

--- a/app/components/works/contact_email_row_component.html.erb
+++ b/app/components/works/contact_email_row_component.html.erb
@@ -1,6 +1,6 @@
 <div class="mb-3 row plain-container">
   <div class="col-sm-2">
-    <%= form.label :email, 'Contact email', class: 'col-form-label' %> <%= tooltip %>
+    <%= form.label :email, 'Contact email *', class: 'col-form-label' %> <%= tooltip %>
   </div>
   <div class="<%= bootstrap_classes %>">
     <%= form.email_field :email, class: "form-control#{' is-invalid' if error?}", pattern: Devise.email_regexp.source %>

--- a/app/components/works/contributors_component.html.erb
+++ b/app/components/works/contributors_component.html.erb
@@ -1,5 +1,5 @@
 <section data-controller="nested-form" data-nested-form-selector-value=".inner-container">
-  <header>Additional contributors (optional)
+  <header>Additional contributors
    <%= render PopoverComponent.new key: 'work.contributor' %>
   </header>
   <p>Names will be listed in the order shown below.</p>

--- a/app/components/works/dates_component.html.erb
+++ b/app/components/works/dates_component.html.erb
@@ -1,5 +1,5 @@
 <section id="dates" data-controller="complex-radio">
-  <header>Enter dates related to your deposit (optional)
+  <header>Enter dates related to your deposit
     <%= render PopoverComponent.new key: 'work.date' %>
   </header>
   <%= render Works::PublicationDateComponent.new(form: form,

--- a/app/components/works/description_component.html.erb
+++ b/app/components/works/description_component.html.erb
@@ -29,7 +29,7 @@
 
   <fieldset class="mb-5">
     <legend class='h5'>
-      Citation for this deposit (optional)
+      Citation for this deposit
       <%= render PopoverComponent.new key: 'work.citation' %>
     </legend>
 

--- a/app/components/works/related_work_component.html.erb
+++ b/app/components/works/related_work_component.html.erb
@@ -1,6 +1,6 @@
 <fieldset class="mb-5">
   <legend class="h5">
-    Related works (optional)
+    Related works
     <%= render PopoverComponent.new key: 'work.related_work' %>
   </legend>
 

--- a/spec/components/works/contributors_component_spec.rb
+++ b/spec/components/works/contributors_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Works::ContributorsComponent do
   let(:rendered) { render_inline(described_class.new(form: form)) }
 
   it 'renders the component' do
-    expect(rendered.to_html).to include 'Additional contributors (optional)'
+    expect(rendered.to_html).to include 'Additional contributors'
   end
 
   context 'with an existing organizational contributor' do


### PR DESCRIPTION
## Why was this change made?

Fixes #1400 

<img width="1129" alt="Screen Shot 2021-05-13 at 3 01 14 PM" src="https://user-images.githubusercontent.com/2294288/118193177-23e0d600-b3fc-11eb-987b-1241c9963bf3.png">

- Updates text under title to "* REQUIRED FIELDS" for collections
- Adds "*" to required fields
- Removes "(optional)"

## How was this change tested?

Updated tests that checked for "optional"

## Which documentation and/or configurations were updated?



