### PR TITLE
Set dropzone max file size to 10G

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -1,4 +1,4 @@
-<section data-controller="dropzone" data-dropzone-max-file-size="2000" data-dropzone-max-files="1000" id="file">
+<section data-controller="dropzone" data-dropzone-max-file-size="10000" data-dropzone-max-files="1000" id="file">
   <header>Add your files *</header>
   <p>All file types are accepted. If you have a deposit that is over 10GB, or
     have any trouble with adding your files,


### PR DESCRIPTION
## Why was this change made?

Fixes #1316 

Sets drops zone max file size to 10GB to match the text on the screen.

## How was this change tested?



## Which documentation and/or configurations were updated?



