### PR TITLE
Add draft label to collection name when needed on dashboard

### DIFF
--- a/app/components/dashboard/all_collections_component.html.erb
+++ b/app/components/dashboard/all_collections_component.html.erb
@@ -28,18 +28,9 @@
       </tr>
     </thead>
     <tbody>
-    <% stats.each do |collection, counts| %>
-      <tr>
-        <td><%= link_to collection.head.name, collection %></td>
-        <td><%= counts['total'] %></td>
-        <td><%= counts['deposited'] %></td>
-        <td><%= counts['first_draft'] %></td>
-        <td><%= counts['version_draft'] %></td>
-        <td><%= counts['pending_approval'] %></td>
-        <td><%= counts['rejected'] %></td>
-        <td><%= I18n.l(collection.updated_at.to_date, format: :abbr_month) %></td>
-      </tr>
-    <% end %>
+      <% stats.each do |collection, counts| %>
+        <%= render Dashboard::AllCollectionsRowComponent.new(collection: collection, counts: counts) %>
+      <% end %>
     </tbody>
   </table>
 </section>

--- a/app/components/dashboard/all_collections_row_component.html.erb
+++ b/app/components/dashboard/all_collections_row_component.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= link_to collection.head.name, collection %><strong><i><%= draft_label %></i></strong></td>
+  <td><%= link_to collection.head.name, collection %><% if draft? %><strong><i> <%= draft_label %></i></strong><% end %></td>
   <td><%= counts['total'] %></td>
   <td><%= counts['deposited'] %></td>
   <td><%= counts['first_draft'] %></td>

--- a/app/components/dashboard/all_collections_row_component.html.erb
+++ b/app/components/dashboard/all_collections_row_component.html.erb
@@ -1,0 +1,10 @@
+<tr>
+  <td><%= link_to collection.head.name, collection %><strong><i><%= draft_label %></i></strong></td>
+  <td><%= counts['total'] %></td>
+  <td><%= counts['deposited'] %></td>
+  <td><%= counts['first_draft'] %></td>
+  <td><%= counts['version_draft'] %></td>
+  <td><%= counts['pending_approval'] %></td>
+  <td><%= counts['rejected'] %></td>
+  <td><%= I18n.l(collection.updated_at.to_date, format: :abbr_month) %></td>
+</tr>

--- a/app/components/dashboard/all_collections_row_component.html.erb
+++ b/app/components/dashboard/all_collections_row_component.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= link_to collection.head.name, collection %><% if draft? %><strong><i> <%= draft_label %></i></strong><% end %></td>
+  <td><%= link_to collection.head.name, collection %><%= draft_label %></td>
   <td><%= counts['total'] %></td>
   <td><%= counts['deposited'] %></td>
   <td><%= counts['first_draft'] %></td>

--- a/app/components/dashboard/all_collections_row_component.rb
+++ b/app/components/dashboard/all_collections_row_component.rb
@@ -1,0 +1,26 @@
+# typed: true
+# frozen_string_literal: true
+
+module Dashboard
+  # Renders a list of all collections
+  class AllCollectionsRowComponent < ApplicationComponent
+    sig { params(collection: Collection, counts: Hash).void }
+    def initialize(collection:, counts:)
+      @collection = collection
+      @counts = counts
+    end
+
+    attr_reader :collection, :counts
+
+    def draft_label
+      case @collection.head.state
+      when 'first_draft'
+        return '- Draft'
+      when 'version_draft'
+        return '- Version Draft'
+      end
+
+      nil
+    end
+  end
+end

--- a/app/components/dashboard/all_collections_row_component.rb
+++ b/app/components/dashboard/all_collections_row_component.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: false
 # frozen_string_literal: true
 
 module Dashboard
@@ -12,21 +12,15 @@ module Dashboard
 
     attr_reader :collection, :counts
 
-    def draft?
-      return true if @collection.head&.state&.include? 'draft'
-
-      false
-    end
-
     def draft_label
+      return unless @collection.head&.state&.include? 'draft'
+
       case @collection.head&.state
       when 'first_draft'
-        return '- Draft'
+        tag.span ' - Draft', class: 'draft-tag'
       when 'version_draft'
-        return '- Version Draft'
+        tag.span ' - Version Draft', class: 'draft-tag'
       end
-
-      nil
     end
   end
 end

--- a/app/components/dashboard/all_collections_row_component.rb
+++ b/app/components/dashboard/all_collections_row_component.rb
@@ -13,7 +13,7 @@ module Dashboard
     attr_reader :collection, :counts
 
     def draft_label
-      case @collection.head.state
+      case @collection.head&.state
       when 'first_draft'
         return '- Draft'
       when 'version_draft'

--- a/app/components/dashboard/all_collections_row_component.rb
+++ b/app/components/dashboard/all_collections_row_component.rb
@@ -12,6 +12,12 @@ module Dashboard
 
     attr_reader :collection, :counts
 
+    def draft?
+      return true if @collection.head&.state&.include? 'draft'
+
+      false
+    end
+
     def draft_label
       case @collection.head&.state
       when 'first_draft'

--- a/app/components/related_link_row_component.html.erb
+++ b/app/components/related_link_row_component.html.erb
@@ -1,6 +1,6 @@
 <div class="inner-container">
   <div class="row mb-2">
-    <%= form.label :link_title, 'Link text', class: 'form-label col-md-2' %>
+    <%= form.label :link_title, 'Link title', class: 'form-label col-md-2' %>
 
     <div class="col-md-9">
       <%= form.text_field :link_title, class: 'form-control' %>

--- a/app/components/related_link_row_component.html.erb
+++ b/app/components/related_link_row_component.html.erb
@@ -1,6 +1,6 @@
 <div class="inner-container">
   <div class="row mb-2">
-    <%= form.label :link_title, 'Link title', class: 'form-label col-md-2' %>
+    <%= form.label :link_title, 'Link text', class: 'form-label col-md-2' %>
 
     <div class="col-md-9">
       <%= form.text_field :link_title, class: 'form-control' %>

--- a/app/packs/stylesheets/dashboard.scss
+++ b/app/packs/stylesheets/dashboard.scss
@@ -27,6 +27,11 @@
     }
   }
 
+  .draft-tag {
+    font-weight: bold;
+    font-style: italic;
+  }
+
   margin-top: 1rem;
   max-width: 1140px;
 }

--- a/spec/components/dashboard/all_collections_row_component_spec.rb
+++ b/spec/components/dashboard/all_collections_row_component_spec.rb
@@ -1,0 +1,37 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Dashboard::AllCollectionsRowComponent, type: :component do
+  let(:rendered) { render_inline(described_class.new(collection: collection, counts: counts)) }
+  let(:collection) { build_stubbed(:collection, head: collection_version) }
+  let(:collection_version) { build_stubbed(:collection_version) }
+  let(:counts) { {} }
+
+  context 'with a new, first draft collection' do
+    let(:collection_version) { build_stubbed(:collection_version, :first_draft) }
+
+    it 'adds the Draft to the label' do
+      expect(rendered.to_html).to include 'Draft'
+      expect(rendered.to_html).not_to include 'Version Draft'
+    end
+  end
+
+  context 'with a version draft collection' do
+    let(:collection_version) { build_stubbed(:collection_version, :version_draft) }
+
+    it 'adds the Version Draft to the label' do
+      expect(rendered.to_html).to include 'Version Draft'
+    end
+  end
+
+  context 'with a deposited collection' do
+    let(:collection_version) { build_stubbed(:collection_version, :deposited) }
+
+    it 'does not change the label' do
+      expect(rendered.to_html).not_to include 'Version Draft'
+      expect(rendered.to_html).not_to include 'Draft'
+    end
+  end
+end

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe 'Dashboard requests' do
       expect(response.body).to include 'Your collections'
       expect(response.body).to include '+ Create a new collection'
       expect(response.body).to include <<-HTML
-  <td><a href=\"#{collection_path(workful_collection)}\">MyString</a><strong><i></i></strong></td>
+  <td><a href=\"#{collection_path(workful_collection)}\">MyString</a></td>
   <td>5</td>
   <td>1</td>
   <td>1</td>
@@ -187,7 +187,7 @@ RSpec.describe 'Dashboard requests' do
   <td>Dec 02, 2020</td>
       HTML
       expect(response.body).to include <<-HTML
-  <td><a href=\"#{collection_path(workless_collection)}\">MyString</a><strong><i></i></strong></td>
+  <td><a href=\"#{collection_path(workless_collection)}\">MyString</a></td>
   <td>0</td>
   <td></td>
   <td></td>

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -177,28 +177,24 @@ RSpec.describe 'Dashboard requests' do
       expect(response.body).to include 'Your collections'
       expect(response.body).to include '+ Create a new collection'
       expect(response.body).to include <<-HTML
-      <tr>
-        <td><a href=\"#{collection_path(workful_collection)}\">MyString</a></td>
-        <td>5</td>
-        <td>1</td>
-        <td>1</td>
-        <td>1</td>
-        <td>1</td>
-        <td>1</td>
-        <td>Dec 02, 2020</td>
-      </tr>
+  <td><a href=\"#{collection_path(workful_collection)}\">MyString</a><strong><i></i></strong></td>
+  <td>5</td>
+  <td>1</td>
+  <td>1</td>
+  <td>1</td>
+  <td>1</td>
+  <td>1</td>
+  <td>Dec 02, 2020</td>
       HTML
       expect(response.body).to include <<-HTML
-      <tr>
-        <td><a href=\"#{collection_path(workless_collection)}\">MyString</a></td>
-        <td>0</td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td>Dec 03, 2020</td>
-      </tr>
+  <td><a href=\"#{collection_path(workless_collection)}\">MyString</a><strong><i></i></strong></td>
+  <td>0</td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td></td>
+  <td>Dec 03, 2020</td>
       HTML
     end
   end


### PR DESCRIPTION
## Why was this change made?

Fixes #1049 

<img width="647" alt="Screen Shot 2021-05-14 at 3 59 03 PM" src="https://user-images.githubusercontent.com/2294288/118339518-e9476e00-b4cd-11eb-849e-99bfa2dd1987.png">

Note: This is draft pending updated test(s).

## How was this change tested?



## Which documentation and/or configurations were updated?



