### PR TITLE
Extract more-types controller from edit-deposit controller

### DIFF
--- a/app/components/works/available_date_component.html.erb
+++ b/app/components/works/available_date_component.html.erb
@@ -6,7 +6,7 @@
     </div>
   </div>
 
-  <div class="embargo-date mb-5" data-edit-deposit-target="embargo-dateField">
+  <div class="embargo-date mb-5">
     <div class="row<%= ' is-invalid' if error? %>">
       <div class="col-sm-10 release-option" data-complex-radio-target="selection">
         <%= form.radio_button :release, 'embargo', class: 'form-check-input', data: { action: 'complex-radio#disableUnselectedInputs' } %>

--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -1,4 +1,4 @@
-<div class="row inner-container" data-controller="contributors" data-contributors-required-value="<%= required? %>" data-edit-deposit-target="contributorsField">
+<div class="row inner-container" data-controller="contributors" data-contributors-required-value="<%= required? %>"">
   <div class="contributors-container col-md-12" data-contributors-target="container">
     <% if not_first_contributor? %>
       <%= button_tag type: 'button', class: 'btn btn-sm float-end', aria: { label: 'Remove' },

--- a/app/components/works/subtypes_component.html.erb
+++ b/app/components/works/subtypes_component.html.erb
@@ -5,7 +5,7 @@
   </div>
 </div>
 
-<div class="mb-5 row work-types">
+<div class="mb-5 row work-types" data-controller="more-types">
   <% if other_type? %>
     <%= form.label :subtype, 'Other', class: 'col-sm-2 col-form-label' %>
     <div class="col-sm-10">
@@ -28,11 +28,11 @@
       </div>
     <% end %>
 
-    <a href="#" class="mt-4 more-options collapsed" data-action="edit-deposit#toggleMoreTypes" data-edit-deposit-target="moreTypesLink">
+    <a href="#" class="mt-4 more-options collapsed" data-action="more-types#toggleMoreTypes" data-more-types-target="moreTypesLink">
       See more options
     </a>
 
-    <div class="row" data-edit-deposit-target="moreTypes" hidden>
+    <div class="row" data-more-types-target="moreTypes" hidden>
       <% more_types.each do |more_type| %>
         <div class="col-sm-4">
           <div class="form-check">

--- a/app/packs/controllers/edit_deposit_controller.js
+++ b/app/packs/controllers/edit_deposit_controller.js
@@ -1,9 +1,7 @@
 import { Controller } from "stimulus";
 
 export default class extends Controller {
-  static targets = ["moreTypesLink",
-                    "moreTypes",
-                    "frame"]
+  static targets = ["frame"]
   static values = { endpoint: String }
 
   connect() {
@@ -11,6 +9,7 @@ export default class extends Controller {
     this.element.addEventListener('change', () => this.check())
   }
 
+  // Trigger the progress component to re-render on each change
   check(e) {
     const form = this.element
     const data = new FormData(form)
@@ -24,25 +23,5 @@ export default class extends Controller {
 
     const queryString = new URLSearchParams(data).toString();
     this.frameTarget.src = `${this.endpointValue}?${queryString}`
-  }
-
-  toggleMoreTypes(event) {
-    event.preventDefault()
-
-    this.moreTypesTarget.hidden ?
-      this.showMoreTypes() :
-      this.hideMoreTypes()
-  }
-
-  showMoreTypes() {
-    this.moreTypesTarget.hidden = false
-    this.moreTypesLinkTarget.innerHTML = 'See fewer options'
-    this.moreTypesLinkTarget.classList.toggle('collapsed', false)
-  }
-
-  hideMoreTypes() {
-    this.moreTypesTarget.hidden = true
-    this.moreTypesLinkTarget.innerHTML = 'See more options'
-    this.moreTypesLinkTarget.classList.toggle('collapsed', true)
   }
 }

--- a/app/packs/controllers/more_types_controller.js
+++ b/app/packs/controllers/more_types_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "stimulus";
+
+export default class extends Controller {
+  static targets = ["moreTypesLink", "moreTypes"]
+
+  toggleMoreTypes(event) {
+    event.preventDefault()
+
+    this.moreTypesTarget.hidden ?
+      this.showMoreTypes() :
+      this.hideMoreTypes()
+  }
+
+  showMoreTypes() {
+    this.moreTypesTarget.hidden = false
+    this.moreTypesLinkTarget.innerHTML = 'See fewer options'
+    this.moreTypesLinkTarget.classList.toggle('collapsed', false)
+  }
+
+  hideMoreTypes() {
+    this.moreTypesTarget.hidden = true
+    this.moreTypesLinkTarget.innerHTML = 'See more options'
+    this.moreTypesLinkTarget.classList.toggle('collapsed', true)
+  }
+}


### PR DESCRIPTION


## Why was this change made?
This keeps the function of each controller clear.


## How was this change tested?



## Which documentation and/or configurations were updated?



