### PR TITLE
Add error message when the change description is not provided

### DIFF
--- a/app/components/works/version_description_component.html.erb
+++ b/app/components/works/version_description_component.html.erb
@@ -4,6 +4,7 @@
      <%= form.label :description, "What's changing?", class: 'col-sm-2 col-form-label' %>
      <div class="col-sm-10">
        <%= form.text_field :description, class: "form-control", required: true %>
+       <div class="invalid-feedback">You must describe your changes.</div>
      </div>
    </div>
  </section>


### PR DESCRIPTION


## Why was this change made?

Fixes #1379

## How was this change tested?

<img width="1308" alt="Screen Shot 2021-05-17 at 1 55 01 PM" src="https://user-images.githubusercontent.com/92044/118541729-a8db3080-b717-11eb-8199-1a5d2d722448.png">


## Which documentation and/or configurations were updated?



