### PR TITLE
Don't render "Edit or Deposit" button when item is deposited

### DIFF
--- a/app/components/works/edit_button_component.rb
+++ b/app/components/works/edit_button_component.rb
@@ -14,7 +14,7 @@ module Works
 
     sig { returns(T::Boolean) }
     def render?
-      work_version.updatable?
+      work_version.draft?
     end
 
     def call

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -94,6 +94,10 @@ class WorkVersion < ApplicationRecord
     can_update_metadata? || deposited?
   end
 
+  def draft?
+    version_draft? || first_draft?
+  end
+
   sig { void }
   def add_purl_to_citation
     return unless citation

--- a/spec/components/works/edit_button_component_spec.rb
+++ b/spec/components/works/edit_button_component_spec.rb
@@ -1,0 +1,32 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Works::EditButtonComponent, type: :component do
+  let(:rendered) { render_inline(described_class.new(work_version: work_version)) }
+
+  context 'when the work is a draft' do
+    let(:work_version) { build_stubbed(:work_version, :first_draft) }
+
+    it 'renders the link' do
+      expect(rendered.css('a').text).to eq 'Edit or Deposit'
+    end
+  end
+
+  context 'when the work is deposited' do
+    let(:work_version) { build_stubbed(:work_version, :deposited) }
+
+    it 'does not render the link' do
+      expect(rendered.css('a')).to be_empty
+    end
+  end
+
+  context 'when the work is being reviewed' do
+    let(:work_version) { build_stubbed(:work_version, :pending_approval) }
+
+    it 'does not render the link' do
+      expect(rendered.css('a')).to be_empty
+    end
+  end
+end


### PR DESCRIPTION


## Why was this change made?
Fixes #1474


## How was this change tested?



## Which documentation and/or configurations were updated?



