### PR TITLE
Don't render "Edit or Deposit" button for a deposited collection

### DIFF
--- a/app/components/collections/show/settings_header_component.rb
+++ b/app/components/collections/show/settings_header_component.rb
@@ -13,7 +13,7 @@ module Collections
       sig { returns(CollectionVersion) }
       attr_reader :collection_version
 
-      delegate :depositing?, :updatable?, :collection, to: :collection_version
+      delegate :depositing?, :draft?, :collection, to: :collection_version
 
       sig { returns(String) }
       def name
@@ -30,7 +30,7 @@ module Collections
       end
 
       def edit_button
-        return unless updatable?
+        return unless draft?
 
         link_to 'Edit or Deposit', edit_collection_path(collection),
                 class: 'btn btn-outline-primary float-end me-2'

--- a/app/models/collection_version.rb
+++ b/app/models/collection_version.rb
@@ -56,6 +56,10 @@ class CollectionVersion < ApplicationRecord
     can_update_metadata? || (deposited? && head?)
   end
 
+  def draft?
+    version_draft? || first_draft?
+  end
+
   sig { returns(T::Boolean) }
   def head?
     collection.head == self

--- a/spec/components/collections/show/settings_header_component_spec.rb
+++ b/spec/components/collections/show/settings_header_component_spec.rb
@@ -9,8 +9,9 @@ RSpec.describe Collections::Show::SettingsHeaderComponent, type: :component do
   context 'with a new, first draft collection' do
     let(:collection_version) { build_stubbed(:collection_version, :first_draft) }
 
-    it 'does not render the spinner' do
+    it 'does not render the spinner and renders the edit link' do
       expect(rendered.to_html).not_to include 'fa-spinner'
+      expect(rendered.css('a.btn').text).to eq 'Edit or Deposit'
     end
   end
 
@@ -20,6 +21,15 @@ RSpec.describe Collections::Show::SettingsHeaderComponent, type: :component do
     it 'does not render the spinner' do
       expect(rendered.to_html).to include 'Depositing'
       expect(rendered.to_html).to include 'fas fa-spinner fa-pulse'
+      expect(rendered.css('a.btn')).to be_empty
+    end
+  end
+
+  context 'when the collection is deposited' do
+    let(:collection_version) { build_stubbed(:collection_version, :deposited) }
+
+    it 'does not render the link' do
+      expect(rendered.css('a.btn')).to be_empty
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #1473

## How was this change tested?



## Which documentation and/or configurations were updated?



