### PR TITLE
Require the search parameter

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -4,7 +4,7 @@
 # When a user searches for a druid, direct them to the correct path.
 class SearchesController < ApplicationController
   def show
-    druid = params[:q]
+    druid = params.require(:q)
     druid = "druid:#{druid}" unless druid.start_with?('druid:')
     result = Work.find_by(druid: druid) || Collection.find_by(druid: druid)
     return render js: "window.location='#{polymorphic_path(result)}'" if result

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -25,5 +25,11 @@ RSpec.describe 'Searches', type: :request do
         expect(response).to be_not_found
       end
     end
+
+    context "when the client doesn't send a 'q' parameter" do
+      it 'raises ParameterMissing error' do
+        expect { get '/search?foo=bar', xhr: true }.to raise_error ActionController::ParameterMissing
+      end
+    end
   end
 end


### PR DESCRIPTION

## Why was this change made?
The UIT security scanning software tries to fuzz this which triggers a Nil pointer error.  This change instead raises ActionController::ParameterMissing which is handled by ActionDispatch::ExceptionWrapper: https://github.com/rails/rails/blob/f95c0b7e96eb36bc3efc0c5beffbb9e84ea664e4/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb#L21

Fixes #1491


## How was this change tested?



## Which documentation and/or configurations were updated?



