### PR TITLE
Add what's changing element to collections detail editing

### DIFF
--- a/app/components/collections/detail_component.rb
+++ b/app/components/collections/detail_component.rb
@@ -12,6 +12,6 @@ module Collections
     sig { returns(CollectionVersion) }
     attr_reader :collection_version
 
-    delegate :name, :description, :contact_emails, to: :collection_version
+    delegate :name, :description, :version_description, :contact_emails, to: :collection_version
   end
 end

--- a/app/components/collections/update/details_form_component.html.erb
+++ b/app/components/collections/update/details_form_component.html.erb
@@ -5,6 +5,8 @@
       action: 'change->unsaved-changes#changed beforeunload@window->unsaved-changes#leavingPage turbo:before-visit@window->unsaved-changes#leavingPage'
     },
     html: { class: 'needs-validation collection-editor', novalidate: true, multipart: true } do |form| %>
+
+  <%= render Collections::VersionDescriptionComponent.new(form: form) %>
   <%= render FirstDraftCollections::Create::DetailsComponent.new(form: form) %>
 
   <div class="row justify-content-between">

--- a/app/components/collections/update/details_form_component.rb
+++ b/app/components/collections/update/details_form_component.rb
@@ -8,7 +8,7 @@ module Collections
       attr_reader :collection_form
 
       delegate :model, to: :collection_form
-      delegate :version_draft?, :first_draft?, :name, :collection, to: :model
+      delegate :version_draft?, :first_draft?, :name, :collection, :version_description, to: :model
 
       sig { params(collection_form: DraftCollectionVersionForm).void }
       def initialize(collection_form:)

--- a/app/components/collections/version_description_component.html.erb
+++ b/app/components/collections/version_description_component.html.erb
@@ -1,0 +1,10 @@
+<section class="version">
+   <header>Version your work *</header>
+   <div class="mb-3 row">
+     <%= form.label :version_description, "What's changing? *", class: 'col-sm-2 col-form-label' %>
+     <div class="col-sm-10">
+       <%= form.text_field :version_description, class: "form-control", required: true %>
+     </div>
+   </div>
+ </section>
+ 

--- a/app/components/collections/version_description_component.rb
+++ b/app/components/collections/version_description_component.rb
@@ -1,0 +1,22 @@
+# typed: true
+# frozen_string_literal: true
+
+module Collections
+  # Renders a widget for entering a version description
+  class VersionDescriptionComponent < ApplicationComponent
+    def initialize(form:)
+      @form = form
+    end
+
+    attr_reader :form
+
+    def collection_version
+      form.object.model
+    end
+
+    sig { returns(T::Boolean) }
+    def render?
+      %w[deposited rejected version_draft].include? collection_version.state
+    end
+  end
+end

--- a/app/controllers/collection_versions_controller.rb
+++ b/app/controllers/collection_versions_controller.rb
@@ -79,7 +79,7 @@ class CollectionVersionsController < ObjectsController
   end
 
   def collection_params
-    params.require(:collection_version).permit(:name, :description,
+    params.require(:collection_version).permit(:name, :description, :version_description,
                                                related_links_attributes: %i[_destroy id link_title url],
                                                contact_emails_attributes: %i[_destroy id email])
   end

--- a/app/forms/draft_collection_form.rb
+++ b/app/forms/draft_collection_form.rb
@@ -11,6 +11,7 @@ class DraftCollectionForm < Reform::Form
 
   property :name, on: :collection_version
   property :description, on: :collection_version
+  property :version_description, on: :collection_version
   property :access, default: 'world', on: :collection
   property :manager_sunets, virtual: true, on: :collection,
                             prepopulator: ->(_options) { self.manager_sunets = manager_sunets_from_model.join(', ') }

--- a/app/forms/draft_collection_version_form.rb
+++ b/app/forms/draft_collection_version_form.rb
@@ -8,6 +8,8 @@ class DraftCollectionVersionForm < Reform::Form
 
   property :name, on: :collection_version
   property :description, on: :collection_version
+  property :version_description, on: :collection_version
+
   collection :contact_emails, populator: ContactEmailsPopulator.new(:contact_emails, ContactEmail),
                               prepopulator: ->(*) { contact_emails << ContactEmail.new if contact_emails.blank? },
                               on: :collection_version do

--- a/db/migrate/20210520161846_add_version_description_to_collection_versions.rb
+++ b/db/migrate/20210520161846_add_version_description_to_collection_versions.rb
@@ -1,0 +1,5 @@
+class AddVersionDescriptionToCollectionVersions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :collection_versions, :version_description, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -257,8 +257,7 @@ CREATE TABLE public.collections (
     email_depositors_status_changed boolean,
     review_enabled boolean DEFAULT false,
     license_option character varying DEFAULT 'required'::character varying NOT NULL,
-    head_id bigint,
-    description character varying
+    head_id bigint
 );
 
 
@@ -1284,7 +1283,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210216220559'),
 ('20210218234733'),
 ('20210219142356'),
-('20210513210814'),
 ('20210520161846');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -214,7 +214,8 @@ CREATE TABLE public.collection_versions (
     description character varying,
     collection_id bigint,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    version_description character varying
 );
 
 
@@ -256,7 +257,8 @@ CREATE TABLE public.collections (
     email_depositors_status_changed boolean,
     review_enabled boolean DEFAULT false,
     license_option character varying DEFAULT 'required'::character varying NOT NULL,
-    head_id bigint
+    head_id bigint,
+    description character varying
 );
 
 
@@ -1281,6 +1283,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210211170008'),
 ('20210216220559'),
 ('20210218234733'),
-('20210219142356');
+('20210219142356'),
+('20210513210814'),
+('20210520161846');
 
 

--- a/spec/components/collections/version_description_component_spec.rb
+++ b/spec/components/collections/version_description_component_spec.rb
@@ -1,0 +1,19 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Collections::VersionDescriptionComponent do
+  let(:form) { ActionView::Helpers::FormBuilder.new(nil, collection_form, controller.view_context, {}) }
+  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:collection) { build_stubbed(:collection, head: collection_version) }
+  let(:collection_form) { CreateCollectionForm.new(collection: collection, collection_version: collection_version) }
+
+  context 'with a first draft' do
+    let(:collection_version) { build_stubbed(:collection_version) }
+
+    it 'does not renders the component' do
+      expect(rendered.to_html).not_to include('Version your work')
+    end
+  end
+end

--- a/spec/components/collections/version_description_component_spec.rb
+++ b/spec/components/collections/version_description_component_spec.rb
@@ -7,13 +7,21 @@ RSpec.describe Collections::VersionDescriptionComponent do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, collection_form, controller.view_context, {}) }
   let(:rendered) { render_inline(described_class.new(form: form)) }
   let(:collection) { build_stubbed(:collection, head: collection_version) }
-  let(:collection_form) { CreateCollectionForm.new(collection: collection, collection_version: collection_version) }
+  let(:collection_form) { DraftCollectionVersionForm.new(collection_version) }
 
   context 'with a first draft' do
     let(:collection_version) { build_stubbed(:collection_version) }
 
     it 'does not renders the component' do
       expect(rendered.to_html).not_to include('Version your work')
+    end
+  end
+
+  context 'with a deposited collection' do
+    let(:collection_version) { build_stubbed(:collection_version, state: :deposited) }
+
+    it 'renders the component' do
+      expect(rendered.to_html).to include('Version your work')
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #968 

Creating a collection or editing a draft the what's changing element is not displayed:

<img width="1192" alt="Screen Shot 2021-05-25 at 2 38 21 PM" src="https://user-images.githubusercontent.com/2294288/119572061-0b12e180-bd67-11eb-8ea9-f4df9d532419.png">

The What's Changing element is displayed when editing a deposited or version_draft collection:

<img width="1211" alt="Screen Shot 2021-05-25 at 2 36 57 PM" src="https://user-images.githubusercontent.com/2294288/119572089-17973a00-bd67-11eb-8806-8e2cb060a95b.png">


## How was this change tested?

Unit

## Which documentation and/or configurations were updated?



