### PR TITLE
Disable comments that show what template is rendered

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,7 +62,8 @@ Rails.application.configure do
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
 
-  config.action_view.annotate_rendered_view_with_filenames = true
+  # This is nice for debugging, but we found that it breaks dropzone
+  config.action_view.annotate_rendered_view_with_filenames = false
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.


### PR DESCRIPTION

## Why was this change made?

Because this breaks dropzone in development

Fixes #1506


## How was this change tested?



## Which documentation and/or configurations were updated?



