### PR TITLE
Add missing anchor, which is linked to from the show page

### DIFF
--- a/app/components/works/authors_and_contributors_component.html.erb
+++ b/app/components/works/authors_and_contributors_component.html.erb
@@ -1,4 +1,4 @@
-<section data-controller="nested-form">
+<section data-controller="nested-form" id="author">
   <header>List authors and contributors *</header>
   <p>Enter the name(s) of people, organizations or events responsible for producing the deposit.</p>
 


### PR DESCRIPTION
## Why was this change made?

The show page doesn't link to the right part of the page.

## How was this change tested?



## Which documentation and/or configurations were updated?



