### PR TITLE
Fix deposit button alignment.

### DIFF
--- a/app/components/collections/show/details_header_component.html.erb
+++ b/app/components/collections/show/details_header_component.html.erb
@@ -1,25 +1,30 @@
 <header class="title">
+  <% if depositing? %>
+    <span class="state">Depositing <%= spinner %></span>
+  <% end %>
+  <div class="row">
+    <div class="col"> </div>
+    <div class="col-4">
+      <%= edit_button %>
+      <% if can_create_work? %>
+        <span class="deposit-button" data-controller="work-type">
+          <%= button_tag '+ Deposit to this collection',
+                data: {
+                  destination: new_collection_work_path(collection),
+                  bs_toggle: 'modal',
+                  bs_target: '#workTypeModal',
+                  action: "work-type#set_collection"
+                },
+                class: "btn btn-primary" %>
+
+          <%= render Works::WorkTypeModalComponent.new %>
+          <%= render CitationModalComponent.new %>
+        </span>
+      <% end %>
+    </div>
+  </div>
   <span class="header-text"><%= name %></span>
   <%= helpers.turbo_frame_tag dom_id(collection_version, :edit),
                               src: edit_link_collection_version_path(collection_version),
                               target: '_top' %>
-  <% if depositing? %>
-    <span class="state">Depositing <%= spinner %></span>
-  <% end %>
-  <% if can_create_work? %>
-    <span class="deposit-button float-end" data-controller="work-type">
-      <%= button_tag '+ Deposit to this collection',
-            data: {
-              destination: new_collection_work_path(collection),
-              bs_toggle: 'modal',
-              bs_target: '#workTypeModal',
-              action: "work-type#set_collection"
-            },
-            class: "btn btn-primary" %>
-
-      <%= render Works::WorkTypeModalComponent.new %>
-      <%= render CitationModalComponent.new %>
-    </span>
-  <% end %>
-  <%= edit_button %>
 </header>

--- a/app/components/collections/show/settings_header_component.html.erb
+++ b/app/components/collections/show/settings_header_component.html.erb
@@ -1,25 +1,30 @@
 <header class="title">
+  <% if depositing? %>
+    <span class="state">Depositing <%= spinner %></span>
+  <% end %>
+  <div class="row">
+    <div class="col"> </div>
+    <div class="col-4">
+      <%= edit_button %>
+      <% if can_create_work? %>
+        <span class="deposit-button" data-controller="work-type">
+          <%= button_tag '+ Deposit to this collection',
+                data: {
+                  destination: new_collection_work_path(collection),
+                  bs_toggle: 'modal',
+                  bs_target: '#workTypeModal',
+                  action: "work-type#set_collection"
+                },
+                class: "btn btn-primary" %>
+
+          <%= render Works::WorkTypeModalComponent.new %>
+          <%= render CitationModalComponent.new %>
+        </span>
+      <% end %>
+    </div>
+  </div>
   <span class="header-text"><%= name %></span>
   <%= helpers.turbo_frame_tag dom_id(collection, :edit),
                               src: edit_link_collection_path(collection),
                               target: '_top' %>
-  <% if depositing? %>
-    <span class="state">Depositing <%= spinner %></span>
-  <% end %>
-  <% if can_create_work? %>
-    <span class="deposit-button float-end" data-controller="work-type">
-      <%= button_tag '+ Deposit to this collection',
-            data: {
-              destination: new_collection_work_path(collection),
-              bs_toggle: 'modal',
-              bs_target: '#workTypeModal',
-              action: "work-type#set_collection"
-            },
-            class: "btn btn-primary" %>
-
-      <%= render Works::WorkTypeModalComponent.new %>
-      <%= render CitationModalComponent.new %>
-    </span>
-  <% end %>
-  <%= edit_button %>
 </header>

--- a/app/components/collections/show/settings_header_component.rb
+++ b/app/components/collections/show/settings_header_component.rb
@@ -33,7 +33,7 @@ module Collections
         return unless draft?
 
         link_to 'Edit or Deposit', edit_collection_path(collection),
-                class: 'btn btn-outline-primary float-end me-2'
+                class: 'btn btn-outline-primary me-2'
       end
     end
   end


### PR DESCRIPTION
closes #1476

## Why was this change made?
Fix alignment when collection name is long.


## How was this change tested?
Locally


## Which documentation and/or configurations were updated?
NA


