### PR TITLE
Route the pid assigned by project name

### DIFF
--- a/app/jobs/assign_pid_job.rb
+++ b/app/jobs/assign_pid_job.rb
@@ -13,11 +13,7 @@ class AssignPidJob
   sig { params(msg: String).returns(Symbol) }
   def work(msg)
     model = build_cocina_model_from_json_str(msg)
-
-    source_id = model.identification&.sourceId
-    Honeybadger.context(source_id: source_id)
-    return ack! unless source_id&.start_with?('hydrus:')
-
+    source_id = model.identification.sourceId
     assign_druid(source_id, model.externalIdentifier)
     ack!
   end

--- a/lib/tasks/rabbitmq.rake
+++ b/lib/tasks/rabbitmq.rake
@@ -20,8 +20,7 @@ namespace :rabbitmq do
 
     exchange = channel.topic('sdr.objects.created')
     queue = channel.queue('h2.druid_assigned', durable: true)
-    # TODO: if we set partOfProject when we register, then update this routing key to match
-    queue.bind(exchange, routing_key: '#')
+    queue.bind(exchange, routing_key: Settings.h2.project_tag)
 
     conn.close
   end


### PR DESCRIPTION


## Why was this change made?
This means we don't have to process every registration to see if it's an h2 object


## How was this change tested?



## Which documentation and/or configurations were updated?



