### PR TITLE
Refactor date components to use the forms param_key

### DIFF
--- a/app/components/works/dates_component.html.erb
+++ b/app/components/works/dates_component.html.erb
@@ -20,25 +20,29 @@
     </div>
     <div data-controller="date-validation" class="col-sm-10">
       <div class="year">
-        <label for="work_created_year" class="visually-hidden">Created year</label>
-        <%= number_field_tag 'work[created(1i)]', created_year,
+        <label for="<%= prefix %>_created_year" class="visually-hidden">Created year</label>
+        <%= number_field_tag "#{prefix}[created(1i)]", created_year,
             data: { date_validation_target: 'year', action: 'date-validation#change' },
-            id: 'work_created_year',
+            id: "#{prefix}_created_year",
             placeholder: 'year',
             class: "form-control", min: min_year, max: max_year %>
         <div class="invalid-feedback">Created year must be between <%= min_year %> and <%= max_year %></div>
       </div>
       <div class="month">
-        <label for="work_created_month" class="visually-hidden">Created month</label>
-        <%= select_month created_month, { prefix: 'work', field_name: 'created(2i)', prompt: 'month'}, data: { date_validation_target: 'month', action: 'date-validation#change' }, id: 'work_created_month', class: "form-control" %>
+        <label for="<%= prefix %>_created_month" class="visually-hidden">Created month</label>
+        <%= select_month created_month, { prefix: prefix, field_name: 'created(2i)', prompt: 'month'},
+                         data: { date_validation_target: 'month', action: 'date-validation#change' },
+                         id: "#{prefix}_created_month", class: "form-control" %>
       </div>
 
       <div class="day">
-        <label for="work_created_day" class="visually-hidden">Created day</label>
-        <%= select_day created_day, { prefix: 'work', field_name: 'created(3i)', prompt: 'day'}, data: { date_validation_target: 'day', action: 'date-validation#change' }, id: 'work_created_day', class: "form-control" %>
+        <label for="<%= prefix %>_created_day" class="visually-hidden">Created day</label>
+        <%= select_day created_day, { prefix: prefix, field_name: 'created(3i)', prompt: 'day'},
+                       data: { date_validation_target: 'day', action: 'date-validation#change' },
+                       id: "#{prefix}_created_day", class: "form-control" %>
       </div>
        <div>
-       <%= check_box_tag 'work[created(approx0)]', true, created_approximate?, class: 'form-check-input' %>
+       <%= check_box_tag "#{prefix}[created(approx0)]", true, created_approximate?, class: 'form-check-input' %>
        <%= form.label 'created(approx0)', 'Approximate' %>
       </div>
     </div>
@@ -54,29 +58,29 @@
     <div class="col-md-10 date-range" data-controller="date-range">
       <div class="start-date" data-controller="date-validation">
         <div class="year">
-          <label for="work_created_range_start_year" class="visually-hidden">Created range start year</label>
+          <label for="<%= prefix %>_created_range_start_year" class="visually-hidden">Created range start year</label>
           <%= date_range_start_year %>
           <div class="invalid-feedback">Created year must be between <%= min_year %> and <%= max_year %></div>
         </div>
         <div class="month">
-          <label for="work_created_range_start_month" class="visually-hidden">Created range start month</label>
+          <label for="<%= prefix %>_created_range_start_month" class="visually-hidden">Created range start month</label>
           <%= select_month created_range_start_month,
-              { prefix: 'work', field_name: 'created_range(2i)', prompt: 'month'},
+              { prefix: prefix, field_name: 'created_range(2i)', prompt: 'month'},
               data: { date_validation_target: 'month', action: 'date-validation#change' },
-              id: 'work_created_range_start_month',
+              id: "#{prefix}_created_range_start_month",
               class: "form-control" %>
         </div>
         <div class="day">
-          <label for="work_created_range_start_day" class="visually-hidden">Created range start day</label>
+          <label for="<%= prefix %>_created_range_start_day" class="visually-hidden">Created range start day</label>
           <%= select_day created_range_start_day,
-              { prefix: 'work', field_name: 'created_range(3i)', prompt: 'day'},
+              { prefix: prefix, field_name: 'created_range(3i)', prompt: 'day'},
               data: { date_validation_target: 'day', action: 'date-validation#change' },
-              id: 'work_created_range_start_day',
+              id: "#{prefix}_created_range_start_day",
               class: "form-control" %>
         </div>
         <div>
-         <%= check_box_tag 'work[created_range(approx0)]', true, created_range_start_approximate?, class: 'form-check-input' %>
-         <label for='work_created_range_start_approx'>Approximate</label>
+         <%= check_box_tag "#{prefix}[created_range(approx0)]", true, created_range_start_approximate?, class: 'form-check-input' %>
+         <label for="<%= prefix %>_created_range_start_approx">Approximate</label>
         </div>
       </div>
 
@@ -86,28 +90,28 @@
 
       <div class="end-date" data-controller="date-validation">
         <div class="year">
-          <label for="work_created_range_end_year" class="visually-hidden">Created range end year</label>
+          <label for="<%= prefix %>_created_range_end_year" class="visually-hidden">Created range end year</label>
           <%= date_range_end_year %>
           <div class="invalid-feedback">Created year must be between <%= min_year %> and <%= max_year %></div>
         </div>
         <div class="month">
-          <label for="work_created_range_end_month" class="visually-hidden">Created range end month</label>
+          <label for="<%= prefix %>_created_range_end_month" class="visually-hidden">Created range end month</label>
           <%= select_month created_range_end_month,
-              { prefix: 'work', field_name: 'created_range(5i)', prompt: 'month' },
+              { prefix: prefix, field_name: 'created_range(5i)', prompt: 'month' },
               data: { date_validation_target: 'month', action: 'date-validation#change' },
-              id: 'work_created_range_end_month', class: "form-control" %>
+              id: "#{prefix}_created_range_end_month", class: "form-control" %>
         </div>
 
         <div class="day">
-          <label for="work_created_range_end_day" class="visually-hidden">Created range end day</label>
+          <label for="<%= prefix %>_created_range_end_day" class="visually-hidden">Created range end day</label>
           <%= select_day created_range_end_day,
-              { prefix: 'work', field_name: 'created_range(6i)', prompt: 'day' },
+              { prefix: prefix, field_name: 'created_range(6i)', prompt: 'day' },
               data: { date_validation_target: 'day', action: 'date-validation#change' },
-              id: 'work_created_range_end_day', class: "form-control" %>
+              id: "#{prefix}_created_range_end_day", class: "form-control" %>
         </div>
         <div>
-         <%= check_box_tag 'work[created_range(approx3)]', true, created_range_end_approximate?, class: 'form-check-input' %>
-         <label for='work_created_range_end_approx'>Approximate</label>
+         <%= check_box_tag "#{prefix}[created_range(approx3)]", true, created_range_end_approximate?, class: 'form-check-input' %>
+         <label for="<%= prefix %>_created_range_end_approx">Approximate</label>
         </div>
       </div>
     </div>

--- a/app/components/works/dates_component.rb
+++ b/app/components/works/dates_component.rb
@@ -13,7 +13,7 @@ module Works
     attr_reader :form, :min_year, :max_year
 
     def date_range_start_year
-      number_field_tag 'work[created_range(1i)]', created_range_start_year,
+      number_field_tag "#{prefix}[created_range(1i)]", created_range_start_year,
                        data: {
                          date_validation_target: 'year',
                          date_range_target: 'year',
@@ -25,7 +25,7 @@ module Works
     end
 
     def date_range_end_year
-      number_field_tag 'work[created_range(4i)]', created_range_end_year,
+      number_field_tag "#{prefix}[created_range(4i)]", created_range_end_year,
                        data: {
                          date_validation_target: 'year',
                          date_range_target: 'year',
@@ -121,6 +121,11 @@ module Works
     sig { returns(DraftWorkForm) }
     def reform
       form.object
+    end
+
+    sig { returns(String) }
+    def prefix
+      reform.model_name.param_key
     end
 
     private

--- a/app/components/works/publication_date_component.rb
+++ b/app/components/works/publication_date_component.rb
@@ -18,6 +18,11 @@ module Works
       form.object
     end
 
+    sig { returns(String) }
+    def prefix
+      reform.model_name.param_key
+    end
+
     def error?
       errors.present?
     end
@@ -50,13 +55,13 @@ module Works
     end
 
     def year_field
-      number_field_tag 'work[published(1i)]', published_year,
+      number_field_tag "#{prefix}[published(1i)]", published_year,
                        data: {
                          auto_citation_target: 'year',
                          date_validation_target: 'year',
                          action: 'change->auto-citation#updateDisplay date-validation#change'
                        },
-                       id: 'work_published_year',
+                       id: "#{prefix}_published_year",
                        placeholder: 'year',
                        class: "form-control#{' is-invalid' if error?}",
                        min: min_year,
@@ -65,23 +70,23 @@ module Works
 
     def month_field
       select_month published_month,
-                   { prefix: 'work', field_name: 'published(2i)', prompt: 'month' },
+                   { prefix: prefix, field_name: 'published(2i)', prompt: 'month' },
                    data: {
                      date_validation_target: 'month',
                      action: 'date-validation#change'
                    },
-                   id: 'work_published_month',
+                   id: "#{prefix}_published_month",
                    class: "form-control#{' is-invalid' if error?}"
     end
 
     def day_field
       select_day published_day,
-                 { prefix: 'work', field_name: 'published(3i)', prompt: 'day' },
+                 { prefix: prefix, field_name: 'published(3i)', prompt: 'day' },
                  data: {
                    date_validation_target: 'day',
                    action: 'date-validation#change'
                  },
-                 id: 'work_published_day',
+                 id: "#{prefix}_published_day",
                  class: "form-control#{' is-invalid' if error?}"
     end
   end

--- a/spec/components/works/dates_component_spec.rb
+++ b/spec/components/works/dates_component_spec.rb
@@ -95,4 +95,14 @@ RSpec.describe Works::DatesComponent do
       expect(rendered.css('#work_created_approx0_').first.attribute('checked').value).to eq 'checked'
     end
   end
+
+  context 'with a different type of form' do
+    let(:work_form) { DraftWorkForm.new(work_version: work_version, work: work) }
+
+    it 'uses the param_key from the form' do
+      expect(rendered.css('#draft_work_created_year')).to be_present
+      expect(rendered.css('#draft_work_created_month')).to be_present
+      expect(rendered.css('#draft_work_created_day')).to be_present
+    end
+  end
 end

--- a/spec/components/works/publication_date_component_spec.rb
+++ b/spec/components/works/publication_date_component_spec.rb
@@ -44,4 +44,14 @@ RSpec.describe Works::PublicationDateComponent, type: :component do
       expect(rendered.css('#work_published_day option[@selected="selected"]')).to be_empty
     end
   end
+
+  context 'with a different type of form' do
+    let(:work_form) { DraftWorkForm.new(work_version: work_version, work: work) }
+
+    it 'uses the param_key from the form' do
+      expect(rendered.css('#draft_work_published_year')).to be_present
+      expect(rendered.css('#draft_work_published_month')).to be_present
+      expect(rendered.css('#draft_work_published_day')).to be_present
+    end
+  end
 end


### PR DESCRIPTION


## Why was this change made?

Previously 'work' was hardcoded everwhere.

Fixes #1587

## How was this change tested?



## Which documentation and/or configurations were updated?



