### PR TITLE
DraftWorkForm should have the same model name as WorkForm

### DIFF
--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -175,4 +175,9 @@ class DraftWorkForm < Reform::Form
   def to_param
     model.fetch(:work).to_param
   end
+
+  # Override reform so that this looks just like a Work
+  def model_name
+    Work.model_name
+  end
 end

--- a/spec/components/works/dates_component_spec.rb
+++ b/spec/components/works/dates_component_spec.rb
@@ -97,7 +97,9 @@ RSpec.describe Works::DatesComponent do
   end
 
   context 'with a different type of form' do
-    let(:work_form) { DraftWorkForm.new(work_version: work_version, work: work) }
+    before do
+      allow(work_form.model_name).to receive(:param_key).and_return('draft_work')
+    end
 
     it 'uses the param_key from the form' do
       expect(rendered.css('#draft_work_created_year')).to be_present

--- a/spec/components/works/publication_date_component_spec.rb
+++ b/spec/components/works/publication_date_component_spec.rb
@@ -46,7 +46,9 @@ RSpec.describe Works::PublicationDateComponent, type: :component do
   end
 
   context 'with a different type of form' do
-    let(:work_form) { DraftWorkForm.new(work_version: work_version, work: work) }
+    before do
+      allow(work_form.model_name).to receive(:param_key).and_return('draft_work')
+    end
 
     it 'uses the param_key from the form' do
       expect(rendered.css('#draft_work_published_year')).to be_present

--- a/spec/forms/draft_work_form_spec.rb
+++ b/spec/forms/draft_work_form_spec.rb
@@ -1,0 +1,17 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DraftWorkForm do
+  subject(:form) { described_class.new(work_version: work_version, work: work) }
+
+  let(:work) { work_version.work }
+  let(:work_version) { build(:work_version) }
+
+  describe 'param_key' do
+    it 'is the same as work' do
+      expect(form.model_name.param_key).to eq 'work'
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?
So the parameters are always named 'work' regardless of whether this is a draft or not.
This can occur here: https://github.com/sul-dlss/happy-heron/blob/main/app/controllers/works_controller.rb#L83
when the draft fails to save, then it re-renders the form with a DraftWorkForm and all the parameters are prefixed with `draft_work` rather than the expected: `work`

Fixes #1578 

## How was this change tested?



## Which documentation and/or configurations were updated?



