### PR TITLE
Ignore fileTargets if parent display is none

### DIFF
--- a/app/packs/controllers/dropzone_controller.js
+++ b/app/packs/controllers/dropzone_controller.js
@@ -34,8 +34,8 @@ export default class extends Controller {
   }
 
   checkForDuplicates(fileName) {
-    // Extract all filenames
-    const fileNames = this.fileNameTargets.map(target => { return target.innerText.trim() })
+    // Extract all filenames that are visible
+    const fileNames = this.fileNameTargets.map(target => { if (target.offsetParent !== null) return target.innerText.trim() })
 
     // Remove current fileName
     fileNames.splice(fileNames.indexOf(fileName), 1)


### PR DESCRIPTION
## Why was this change made?
Fixes #1579, only checks for duplicate file names for those FileRowComponts that are visible. Uses `.offsetParent` property on the element, `nil` if the enclosing parent display is set to none (which we set in order to remove this file when the user submits the form). See https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent


## How was this change tested?
Test suite


## Which documentation and/or configurations were updated?
n/a


