### PR TITLE
Use correct key for embargo date

### DIFF
--- a/app/validators/embargo_date_parts.rb
+++ b/app/validators/embargo_date_parts.rb
@@ -8,6 +8,6 @@ class EmbargoDateParts < ActiveModel::Validator
     return if record.embargo_date.instance_of?(Date)
 
     # Adds error because embargo date is nil (may be missing month and day values in form)
-    record.errors.add('embargo-date', 'Must provide all parts')
+    record.errors.add(:embargo_date, 'must provide all parts')
   end
 end

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe WorkForm do
 
   describe 'embargo validation' do
     context 'with a collection that allows depositor to select embargo' do
-      let(:errors) { form.errors.where(:'embargo-date') }
+      let(:errors) { form.errors.where(:embargo_date) }
       let(:messages) { errors.map(&:message) }
 
       before do
@@ -223,7 +223,7 @@ RSpec.describe WorkForm do
       context 'when release is embargo and a date is not provided' do
         it 'has an error' do
           form.validate(release: 'embargo', 'embargo_date(1i)' => '2040', 'embargo_date(2i)' => '2')
-          expect(messages).to eq ['Must provide all parts']
+          expect(messages).to eq ['must provide all parts']
         end
       end
     end

--- a/spec/validators/embargo_date_parts_spec.rb
+++ b/spec/validators/embargo_date_parts_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe EmbargoDateParts do
     end
 
     it 'has errors' do
-      expect(record.errors.full_messages).to eq ['Embargo-date Must provide all parts']
+      expect(record.errors.full_messages).to eq ['Embargo date must provide all parts']
     end
   end
 end


### PR DESCRIPTION


## Why was this change made?
Previously the validator was setting an error on :'embargo-date', but the AvailableDateComponent was looking for :embargo_date


## How was this change tested?



## Which documentation and/or configurations were updated?



