### PR TITLE
Add invalid feedback for collection version description

### DIFF
--- a/app/components/collections/version_description_component.html.erb
+++ b/app/components/collections/version_description_component.html.erb
@@ -4,7 +4,7 @@
      <%= form.label :version_description, "What's changing? *", class: 'col-sm-2 col-form-label' %>
      <div class="col-sm-10">
        <%= form.text_field :version_description, class: "form-control", required: true %>
+       <div class="invalid-feedback">You must describe your changes.</div>
      </div>
    </div>
  </section>
- 


### PR DESCRIPTION
## Why was this change made?

Fixes #1574

## How was this change tested?


<img width="1123" alt="Screen Shot 2021-06-03 at 7 22 12 PM" src="https://user-images.githubusercontent.com/92044/120727819-1e2d5c00-c4a1-11eb-87bb-f8b4190c89a0.png">

## Which documentation and/or configurations were updated?



