### PR TITLE
Embargo date

### DIFF
--- a/app/components/works/available_date_component.html.erb
+++ b/app/components/works/available_date_component.html.erb
@@ -3,7 +3,7 @@
     <div class="col-sm-10 release-option" data-complex-radio-target="selection">
       <%= form.radio_button :release, 'immediate', class: 'form-check-input',
                             data: {
-                              action: 'complex-radio#disableUnselectedInputs change->auto-citation#updateDisplay'
+                              action: 'complex-radio#disableUnselectedInputs change->auto-citation#updateDisplay available-date#clearError'
                             } %>
       <%= form.label :release_immediate, 'Immediately once deposit is completed' %>
     </div>
@@ -14,7 +14,7 @@
       <div class="col-sm-10 release-option" data-complex-radio-target="selection">
         <%= form.radio_button :release, 'embargo', class: 'form-check-input',
                               data: {
-                                action: 'complex-radio#disableUnselectedInputs change->auto-citation#updateDisplay',
+                                action: 'complex-radio#disableUnselectedInputs change->auto-citation#updateDisplay available-date#validate',
                                 auto_citation_target: 'embargo'
                               } %>
         <%= form.label :release_embargo, 'On this date' %>

--- a/app/components/works/available_date_component.rb
+++ b/app/components/works/available_date_component.rb
@@ -34,7 +34,7 @@ module Works
     def year_field
       select_year embargo_year,
                   {
-                    prefix: 'work',
+                    prefix: reform.model_name.param_key,
                     field_name: 'embargo_date(1i)',
                     start_year: Time.zone.today.year,
                     end_year: 3.years.from_now.year
@@ -54,7 +54,7 @@ module Works
     # required is not applied. This is the desired behavior.
     def month_field
       select_month embargo_month,
-                   { prefix: 'work', field_name: 'embargo_date(2i)', prompt: 'month' },
+                   { prefix: reform.model_name.param_key, field_name: 'embargo_date(2i)', prompt: 'month' },
                    data: {
                      available_date_target: 'month',
                      action: 'available-date#validate'
@@ -69,7 +69,7 @@ module Works
     # required is not applied. This is the desired behavior.
     def day_field
       select_day embargo_day,
-                 { prefix: 'work', field_name: 'embargo_date(3i)', prompt: 'day' },
+                 { prefix: reform.model_name.param_key, field_name: 'embargo_date(3i)', prompt: 'day' },
                  data: {
                    available_date_target: 'day',
                    action: 'available-date#validate'
@@ -80,15 +80,15 @@ module Works
     end
 
     def embargo_year
-      embargo_date&.year || Time.zone.today.year
+      embargo_date&.year || reform.send(:"embargo_date(1i)").to_i
     end
 
     def embargo_month
-      embargo_date&.month
+      embargo_date&.month || reform.send(:"embargo_date(2i)").to_i
     end
 
     def embargo_day
-      embargo_date&.day
+      embargo_date&.day || reform.send(:"embargo_date(3i)").to_i
     end
   end
 end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -74,8 +74,8 @@ class WorksController < ObjectsController
     end
 
     authorize! work_version
-    @form = work_form(work_version)
 
+    @form = work_form(work_version)
     if @form.validate(clean_params) && @form.save
       after_save(work_version: work_version, work: work)
     else

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -27,14 +27,9 @@ class DraftWorkForm < Reform::Form
   property :created_edtf, edtf: true, range: true, on: :work_version
   property :published_edtf, edtf: true, on: :work_version
   property :release, virtual: true, prepopulator: (proc do |*|
-    self.release = embargo_date.present? ? 'embargo' : 'immediate'
+    self.release = embargo_date.present? ? 'embargo' : 'immediate' if release.blank?
   end)
-  property :embargo_date, embargo_date: true, on: :work_version, prepopulator: (proc do |*|
-    if embargo_date.present? && embargo_date <= Time.zone.today
-      self.embargo_date = nil
-      self.release = 'immediate'
-    end
-  end)
+  property :embargo_date, embargo_date: true, on: :work_version
 
   validates_with EmbargoDateParts,
                  if: proc { |form| form.user_can_set_availability? && form.release == 'embargo' }

--- a/app/forms/embargo_date.rb
+++ b/app/forms/embargo_date.rb
@@ -7,7 +7,7 @@ module EmbargoDate
   module ClassMethods
     def property(prop_name, options = {}, &block)
       if options[:embargo_date]
-        property "#{prop_name}(1i)", virtual: true
+        property "#{prop_name}(1i)", virtual: true, default: Time.zone.today.year
         property "#{prop_name}(2i)", virtual: true
         property "#{prop_name}(3i)", virtual: true
       end

--- a/app/forms/embargo_date_params_filter.rb
+++ b/app/forms/embargo_date_params_filter.rb
@@ -20,9 +20,9 @@ class EmbargoDateParamsFilter
   end
 
   def deserialize(params, date_attribute)
-    year = params.delete("#{date_attribute}(1i)").to_i
-    month = params.delete("#{date_attribute}(2i)").to_i
-    day = params.delete("#{date_attribute}(3i)").to_i
+    year = params["#{date_attribute}(1i)"].to_i
+    month = params["#{date_attribute}(2i)"].to_i
+    day = params["#{date_attribute}(3i)"].to_i
     Date.new(year, month, day) if Date.valid_date?(year, month, day)
   end
 

--- a/app/packs/controllers/available_date_controller.js
+++ b/app/packs/controllers/available_date_controller.js
@@ -5,8 +5,8 @@ export default class extends Controller {
 
   validate() {
     this.errors = {}
-    this.allPartsPresent()
     this.dateInFuture()
+    this.allPartsPresent()
     this.displayErrors()
   }
 
@@ -21,6 +21,11 @@ export default class extends Controller {
 
   hideError() {
     this.errorTarget.style.display = 'none'
+  }
+
+  clearError() {
+    this.errors = {}
+    this.displayErrors()
   }
 
   displayErrors () {

--- a/spec/components/works/available_date_component_spec.rb
+++ b/spec/components/works/available_date_component_spec.rb
@@ -50,6 +50,37 @@ RSpec.describe Works::AvailableDateComponent, type: :component do
     end
   end
 
+  context 'when the embargo date is provided by embargo fields' do
+    before do
+      work_form.validate({
+                           release: 'embargo',
+                           "embargo_date(1i)": '2022',
+                           "embargo_date(2i)": '2',
+                           "embargo_date(3i)": '3'
+                         })
+    end
+
+    it 'checks the embargo release radio button' do
+      expect(rendered.css('#release_embargo[@checked]')).to be_present
+      expect(rendered.css('#release_immediate[@checked]')).not_to be_present
+    end
+
+    it 'renders the year' do
+      expect(rendered.css('#work_embargo_year option[@selected]').first['value'])
+        .to eq '2022'
+    end
+
+    it 'renders the month' do
+      expect(rendered.css('#work_embargo_month option[@selected]').first['value'])
+        .to eq '2'
+    end
+
+    it 'renders the day' do
+      expect(rendered.css('#work_embargo_day option[@selected]').first['value'])
+        .to eq '3'
+    end
+  end
+
   context 'when there is an error' do
     let(:work_version) { build(:work_version, :embargoed) }
 

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -54,17 +54,6 @@ RSpec.describe WorkForm do
     end
   end
 
-  describe 'populator on embargo_date' do
-    before do
-      work_version.embargo_date = Time.zone.today - 1
-    end
-
-    it 'removes old embargo date' do
-      form.prepopulate!
-      expect(form.embargo_date).to be_nil
-    end
-  end
-
   describe 'authors validation' do
     let(:author_error) { 'Please add at least one author.' }
 


### PR DESCRIPTION

closes #1527

## Why was this change made?
So that the embargo date is correctly retained, populated, and validated.


## How was this change tested?
Local


## Which documentation and/or configurations were updated?
NA


