### PR TITLE
version_description_component for work and collection behave analogously

### DIFF
--- a/app/components/collections/version_description_component.html.erb
+++ b/app/components/collections/version_description_component.html.erb
@@ -1,10 +1,10 @@
 <section class="version">
-   <header>Version your work *</header>
+   <header>Version your collection *</header>
    <div class="mb-3 row">
      <%= form.label :version_description, "What's changing? *", class: 'col-sm-2 col-form-label' %>
      <div class="col-sm-10">
        <%= form.text_field :version_description, class: "form-control", required: true %>
+       <div class="invalid-feedback">You must describe your changes.</div>
      </div>
    </div>
  </section>
- 

--- a/app/components/works/version_description_component.html.erb
+++ b/app/components/works/version_description_component.html.erb
@@ -1,5 +1,5 @@
 <section class="version">
-   <header>Version your work</header>
+   <header>Version your work *</header>
    <div class="mb-3 row">
      <%= form.label :description, "What's changing?", class: 'col-sm-2 col-form-label' %>
      <div class="col-sm-10">

--- a/spec/components/collections/version_description_component_spec.rb
+++ b/spec/components/collections/version_description_component_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Collections::VersionDescriptionComponent do
   context 'with a first draft' do
     let(:collection_version) { build_stubbed(:collection_version) }
 
-    it 'does not renders the component' do
-      expect(rendered.to_html).not_to include('Version your work')
+    it 'does not render the component' do
+      expect(rendered.to_html).not_to include('Version your collection *')
     end
   end
 
@@ -21,7 +21,7 @@ RSpec.describe Collections::VersionDescriptionComponent do
     let(:collection_version) { build_stubbed(:collection_version, state: :deposited) }
 
     it 'renders the component' do
-      expect(rendered.to_html).to include('Version your work')
+      expect(rendered.to_html).to include('Version your collection *')
     end
   end
 end

--- a/spec/components/works/version_description_component_spec.rb
+++ b/spec/components/works/version_description_component_spec.rb
@@ -12,16 +12,16 @@ RSpec.describe Works::VersionDescriptionComponent do
   context 'with a first draft' do
     let(:work_version) { build(:work_version, work: work) }
 
-    it 'does not renders the component' do
-      expect(rendered.to_html).not_to include('Version your work')
+    it 'does not render the component' do
+      expect(rendered.to_html).not_to include('Version your work *')
     end
   end
 
   context 'with a deposited work' do
     let(:work_version) { build(:work_version, work: work, state: 'deposited') }
 
-    it 'does not renders the component' do
-      expect(rendered.to_html).to include('Version your work')
+    it 'renders the component' do
+      expect(rendered.to_html).to include('Version your work *')
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Makes text and error behavior of the version description component analogous between work and collection

Fixes #1574

### Before

![image](https://user-images.githubusercontent.com/96775/120823356-34bccd00-c50c-11eb-9226-69f89fb81c11.png)

![image](https://user-images.githubusercontent.com/96775/120823431-48683380-c50c-11eb-8af9-27126a30e540.png)


### After

![image](https://user-images.githubusercontent.com/96775/120823154-fde6b700-c50b-11eb-9997-2586413f29ec.png)

![image](https://user-images.githubusercontent.com/96775/120823237-16ef6800-c50c-11eb-9009-eda840400c1c.png)


## How was this change tested?

updated unit test code;  tested in situ locally and had Amy test on stage


## Which documentation and/or configurations were updated?



