### PR TITLE
Deposits that fail should automatically retry

### DIFF
--- a/app/jobs/deposit_job.rb
+++ b/app/jobs/deposit_job.rb
@@ -9,8 +9,6 @@ class DepositJob < BaseDepositJob
   def perform(work_version)
     deposit(request_dro: RequestGenerator.generate_model(work_version: work_version),
             blobs: work_version.attached_files.map { |af| af.file.attachment.blob })
-  rescue StandardError => e
-    Honeybadger.notify(e)
   end
 
   private

--- a/spec/jobs/deposit_job_spec.rb
+++ b/spec/jobs/deposit_job_spec.rb
@@ -61,13 +61,13 @@ RSpec.describe DepositJob do
   context 'when the deposit request is not successful' do
     before do
       allow(SdrClient::Deposit::UploadFiles).to receive(:upload)
+        .and_return([SdrClient::Deposit::Files::DirectUploadResponse.new(filename: 'sul.svg', signed_id: '9999999')])
       allow(SdrClient::Deposit::CreateResource).to receive(:run).and_raise('Deposit failed.')
     end
 
     it 'notifies' do
-      described_class.perform_now(work_version)
+      expect { described_class.perform_now(work_version) }.to raise_error(RuntimeError, 'Deposit failed.')
       expect(SdrClient::Deposit::UploadFiles).to have_received(:upload)
-      expect(Honeybadger).to have_received(:notify)
     end
   end
 end


### PR DESCRIPTION

## Why was this change made?
This can happen when the catalog is down (as it is everynight for a restart)

See:
https://app.honeybadger.io/projects/77112/faults/79787375
https://app.honeybadger.io/projects/67994/faults/64602885

Ref #1585


## How was this change tested?



## Which documentation and/or configurations were updated?



