### PR TITLE
remove inoperative code

### DIFF
--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -1,5 +1,5 @@
 <div class="row inner-container" data-controller="contributors" data-contributors-required-value="<%= required? %>"">
-  <div class="contributors-container col-md-12" data-contributors-target="container">
+  <div class="col-md-12">
     <% if not_first_contributor? %>
       <%= button_tag type: 'button', class: 'btn btn-sm float-end', aria: { label: 'Remove' },
                      data: { action: "click->nested-form#removeAssociation" } do %>
@@ -33,5 +33,4 @@
     <%= form.text_field :full_name, html_options('organizationNameInput', 'contributorOrg') %>
     <div class="invalid-feedback">You must provide a name</div>
   </div>
-  <div data-contributors-target="error" class="invalid-feedback"></div>
 </div>

--- a/app/components/works/contributor_row_component.rb
+++ b/app/components/works/contributor_row_component.rb
@@ -55,13 +55,12 @@ module Works
       options = {
         class: 'form-control',
         data: {
-          action: 'change->contributors#inputChanged',
           contributors_target: contributors_target
         },
         required: required?
       }
       if citation?
-        options[:data][:action] += ' change->auto-citation#updateDisplay'
+        options[:data][:action] = 'change->auto-citation#updateDisplay'
         options[:data][:auto_citation_target] = auto_citation_target
       end
 

--- a/app/packs/controllers/contributors_controller.js
+++ b/app/packs/controllers/contributors_controller.js
@@ -1,15 +1,11 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  static targets = ["personName", "organizationName", "role", "personNameInput", "organizationNameInput", "container", "error"]
+  static targets = ["personName", "organizationName", "role", "personNameInput", "organizationNameInput"]
   static values = { required: Boolean }
 
   connect() {
     this.updateDisplay()
-  }
-
-  inputChanged() {
-    this.containerTarget.classList.remove('is-invalid')
   }
 
   typeChanged() {

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
           # This is the div that contains the contributor remove button. The button
           # should NOT be rendered since there's one and only one author at
           # this point, which is not removable.
-          within '.contributors-container' do
+          within '.inner-container' do
             expect(page).not_to have_selector('button')
           end
 


### PR DESCRIPTION

## Why was this change made?
This stopped doing anything useful back when https://github.com/sul-dlss/happy-heron/commit/7f7adb02c2b85866cbeab353978eb82b617a4124#diff-480d3ee3cd54681b7cc0549457979474ae723cd1dcb64352c9467b2680b3171e was changed



## How was this change tested?



## Which documentation and/or configurations were updated?



