### PR TITLE
rubocop: add new cops from 1.16

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -307,3 +307,12 @@ Rails/EnvironmentVariableAccess: # (new in 2.10)
   Enabled: true
 Rails/TimeZoneAssignment: # (new in 2.10)
   Enabled: true
+
+Lint/EmptyInPattern: # (new in 1.16)
+  Enabled: true
+Style/InPatternThen: # (new in 1.16)
+  Enabled: true
+Style/MultilineInPatternThen: # (new in 1.16)
+  Enabled: true
+Style/QuotedSymbols: # (new in 1.16)
+  Enabled: true

--- a/app/components/works/available_date_component.rb
+++ b/app/components/works/available_date_component.rb
@@ -80,15 +80,15 @@ module Works
     end
 
     def embargo_year
-      embargo_date&.year || reform.send(:"embargo_date(1i)").to_i
+      embargo_date&.year || reform.send(:'embargo_date(1i)').to_i
     end
 
     def embargo_month
-      embargo_date&.month || reform.send(:"embargo_date(2i)").to_i
+      embargo_date&.month || reform.send(:'embargo_date(2i)').to_i
     end
 
     def embargo_day
-      embargo_date&.day || reform.send(:"embargo_date(3i)").to_i
+      embargo_date&.day || reform.send(:'embargo_date(3i)').to_i
     end
   end
 end

--- a/spec/components/works/available_date_component_spec.rb
+++ b/spec/components/works/available_date_component_spec.rb
@@ -54,9 +54,9 @@ RSpec.describe Works::AvailableDateComponent, type: :component do
     before do
       work_form.validate({
                            release: 'embargo',
-                           "embargo_date(1i)": '2022',
-                           "embargo_date(2i)": '2',
-                           "embargo_date(3i)": '3'
+                           'embargo_date(1i)': '2022',
+                           'embargo_date(2i)': '2',
+                           'embargo_date(3i)': '3'
                          })
     end
 

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe WorkForm do
     it 'validates with a correct contact email' do
       form.validate(contact_emails: valid_email)
       expect(form.contact_emails.size).to eq 2
-      expect(form.errors.messages).not_to include({ "contact_emails.email": ['is invalid'] })
+      expect(form.errors.messages).not_to include({ 'contact_emails.email': ['is invalid'] })
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Up to date cops gives us less noise when running specs.

## How was this change tested?

rubocop passes without the noise.

## Which documentation and/or configurations were updated?



