### PR TITLE
Add pencil icon to in progress collections

### DIFF
--- a/app/components/dashboard/in_progress_collection_row_component.html.erb
+++ b/app/components/dashboard/in_progress_collection_row_component.html.erb
@@ -1,9 +1,11 @@
 <div class="row">
   <div class="col-4">
-    <%= show_collection_link %>
+    <%= show_collection_link %> <%= helpers.turbo_frame_tag dom_id(collection, :edit),
+    src: edit_link_collection_path(collection),
+    target: '_top' %>
   </div>
   <div class="col-3">
-    <%= link_to 'Complete draft', edit_collection_version_path(collection.head), class: "mb-2 btn btn-primary" %>
+    <%= link_to 'Edit or Deposit', edit_collection_version_path(collection.head), class: "mb-2 btn btn-outline-primary" %>
   </div>
   <div class="col-5">
     <%= helpers.turbo_frame_tag dom_id(collection, :delete), src: delete_button_collection_path(collection) if collection_version.first_draft?%>


### PR DESCRIPTION
## Why was this change made?

Fixes #1386 

<img width="810" alt="Screen Shot 2021-06-08 at 3 41 35 PM" src="https://user-images.githubusercontent.com/2294288/121266840-10e0ea80-c870-11eb-8684-b7ec443e087b.png">



## How was this change tested?



## Which documentation and/or configurations were updated?



