### PR TITLE
Alpha sort collections on the dashboard

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -15,10 +15,14 @@ class DashboardsController < ApplicationController
 
   private
 
+  # rubocop:disable Metrics/AbcSize
   def build_presenter
     DashboardPresenter.new(
       just_signed_in: session.delete(:just_signed_in),
-      collections: authorized_scope(Collection.all, as: :deposit),
+      collections: authorized_scope(Collection
+                                      .all
+                                      .includes('collection_versions')
+                                      .order('collection_versions.name'), as: :deposit),
       approvals: WorkVersion.awaiting_review_by(current_user),
       in_progress: WorkVersion.with_state(:first_draft, :version_draft, :rejected)
                      .joins(:work)
@@ -28,4 +32,5 @@ class DashboardsController < ApplicationController
                                          .where('managers.user_id' => current_user)
     )
   end
+  # rubocop:enable Metrics/AbcSize
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #1376 

<img width="782" alt="Screen Shot 2021-06-08 at 3 36 24 PM" src="https://user-images.githubusercontent.com/2294288/121266429-57821500-c86f-11eb-9bc4-3133e4b469bf.png">



## How was this change tested?



## Which documentation and/or configurations were updated?



