### PR TITLE
Land on the terms area when the terms pencil edit icon is clicked

### DIFF
--- a/app/components/collections/edit_license_component.html.erb
+++ b/app/components/collections/edit_license_component.html.erb
@@ -1,4 +1,4 @@
-  <section id="terms-and-license" data-controller="complex-radio">
+  <section id="terms" data-controller="complex-radio">
     <header>Terms of use and license * <%= render PopoverComponent.new key: 'collection.terms' %></header>
 
     <p>


### PR DESCRIPTION
## Why was this change made?

Fixes #1342 

When the pencil icon for terms and license is clicked, that section is now at the top of the window.

<img width="1285" alt="Screen Shot 2021-06-08 at 3 56 31 PM" src="https://user-images.githubusercontent.com/2294288/121268111-23f4ba00-c872-11eb-964f-d1f7c301815a.png">



## How was this change tested?



## Which documentation and/or configurations were updated?



