### PR TITLE
Fix missing capitalization in help text

### DIFF
--- a/app/components/first_draft_collections/create/settings_component.html.erb
+++ b/app/components/first_draft_collections/create/settings_component.html.erb
@@ -82,7 +82,7 @@
       <div class="col-sm-10 col-xl-8 offset-sm-2">
          <%= form.check_box :email_when_participants_changed, { class: "form-check-input" }, 'true', 'false' %>
          <%= form.label :email_when_participants_changed,
-         "Send email to collection Managers and Reviewers when participants are added/removed.",
+         "Send email to Collection Managers and Reviewers when participants are added/removed.",
          class: 'form-check-label' %>
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,7 +83,7 @@ en:
   hints:
     collection:
       review_enabled: >
-        A reviewer checks a deposit for clarity, accuracy, and completeness before
+        A Reviewer checks a deposit for clarity, accuracy, and completeness before
         approving the publication. Only one Reviewer is required to review each
         deposit. A Reviewer can edit a deposit or return it to the Depositor with
         a request for changes. The Depositor will receive a notification when

--- a/spec/features/create_new_collection_spec.rb
+++ b/spec/features/create_new_collection_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Create a new collection', js: true do
       fill_in 'Collection name', with: name
       fill_in 'Description', with: collection_version_attrs.fetch(:description)
       fill_in 'Contact email', with: 'test@example.edu'
-      check 'Send email to collection Managers and Reviewers when participants are added/removed.'
+      check 'Send email to Collection Managers and Reviewers when participants are added/removed.'
 
       select 'Apache-2.0', from: 'collection_required_license'
 


### PR DESCRIPTION
## Why was this change made?

Fixes #1343 
Fixes #1344 

1343:

<img width="995" alt="Screen Shot 2021-06-09 at 10 18 36 AM" src="https://user-images.githubusercontent.com/2294288/121400226-31f71900-c90c-11eb-8993-cb28343d04eb.png">

1344:

<img width="986" alt="Screen Shot 2021-06-09 at 10 18 43 AM" src="https://user-images.githubusercontent.com/2294288/121400267-3fac9e80-c90c-11eb-8859-4c74bfcd7090.png">



## How was this change tested?

Unit test updated

## Which documentation and/or configurations were updated?



