### PR TITLE
Remove unwanted spacing before garbage icon

### DIFF
--- a/app/components/works/keywords_row_component.html.erb
+++ b/app/components/works/keywords_row_component.html.erb
@@ -1,4 +1,4 @@
-<div class="mb-3 row plain-container">
+<div class="mb-3 row plain-container g-0">
   <div class="col-sm-6">
     <%= form.label :label, 'Keyword', class: 'col-form-label sr-only' %>
     <%= form.text_field :label, class: "form-control#{ 'is-invalid' if error?}", required: true %>
@@ -6,7 +6,7 @@
   </div>
   <% if not_first_keyword? %>
     <div class="col-sm-1">
-      <%= button_tag type: 'button', class: 'btn btn-sm float-end', aria: { label: 'Remove' },
+      <%= button_tag type: 'button', class: 'btn btn-sm', aria: { label: 'Remove' },
       data: { action: "click->nested-form#removeAssociation",
               plain: true } do %>
         <span class="far fa-trash-alt"></span>


### PR DESCRIPTION


## Why was this change made?

Fixes #1518

## How was this change tested?
<img width="809" alt="Screen Shot 2021-06-09 at 1 55 13 PM" src="https://user-images.githubusercontent.com/92044/121412430-5235d080-c92a-11eb-9d7b-33ad24fa9de7.png">



## Which documentation and/or configurations were updated?



