### PR TITLE
[Refactor] Extract WorkTitlePresenter

### DIFF
--- a/app/components/collections/work_row_component.html.erb
+++ b/app/components/collections/work_row_component.html.erb
@@ -2,7 +2,7 @@
   <%= render Works::LinkToShowComponent.new(work_version: work_version) %>
   <td>
     <% if allowed_to? :edit?, work_version %>
-      <%= link_to [:edit, work], aria: { label: "Edit #{Works::DetailComponent.new(work_version: work_version).title}" } do %>
+      <%= link_to [:edit, work], aria: { label: "Edit #{WorkTitlePresenter.show(work_version)}" } do %>
         <span class="fas fa-pencil-alt" aria-hidden="true"></span>
       <% end %>
     <% end %>

--- a/app/components/dashboard/continue_work_modal_component.rb
+++ b/app/components/dashboard/continue_work_modal_component.rb
@@ -19,7 +19,7 @@ module Dashboard
     delegate :work, to: :work_version
 
     def title
-      @title ||= Works::DetailComponent.new(work_version: work_version).title
+      @title ||= WorkTitlePresenter.show(work_version)
     end
   end
 end

--- a/app/components/dashboard/in_progress_row_component.rb
+++ b/app/components/dashboard/in_progress_row_component.rb
@@ -19,7 +19,7 @@ module Dashboard
     end
 
     def title
-      @title ||= Works::DetailComponent.new(work_version: work_version).title
+      @title ||= WorkTitlePresenter.show(work_version)
     end
 
     def work_link

--- a/app/components/purl_check_link_component.rb
+++ b/app/components/purl_check_link_component.rb
@@ -27,6 +27,6 @@ class PurlCheckLinkComponent < ApplicationComponent
   private
 
   def title
-    Works::DetailComponent.new(work_version: work_version).title
+    WorkTitlePresenter.show(work_version)
   end
 end

--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -41,7 +41,7 @@ module Works
 
     sig { returns(String) }
     def title
-      work_version.title.presence || 'No title'
+      WorkTitlePresenter.show(work_version)
     end
 
     sig { returns(String) }

--- a/app/components/works/link_to_show_component.rb
+++ b/app/components/works/link_to_show_component.rb
@@ -13,7 +13,7 @@ module Works
     end
 
     def title
-      @title ||= Works::DetailComponent.new(work_version: work_version).title
+      @title ||= WorkTitlePresenter.show(work_version)
     end
 
     attr_reader :work_version

--- a/app/presenters/work_title_presenter.rb
+++ b/app/presenters/work_title_presenter.rb
@@ -1,0 +1,12 @@
+# typed: true
+# frozen_string_literal: true
+
+# A helper for displaying a title for a Work
+class WorkTitlePresenter
+  extend T::Sig
+
+  sig { params(work_version: WorkVersion).returns(String) }
+  def self.show(work_version)
+    work_version.title.presence || 'No title'
+  end
+end

--- a/app/views/works/_edit_button.html.erb
+++ b/app/views/works/_edit_button.html.erb
@@ -9,11 +9,11 @@
               bs_target: '#workTypeModal',
               action: "work-type#set_collection"
             },
-            aria: { label: "Choose Type and Edit #{Works::DetailComponent.new(work_version: work.head).title}" } do %>
+            aria: { label: "Choose Type and Edit #{WorkTitlePresenter.show(work.head)}" } do %>
         <span class="fas fa-pencil-alt" aria-hidden="true"></span>
       <% end %>
     <% else %>
-      <%= link_to [:edit, work], aria: { label: "Edit #{Works::DetailComponent.new(work_version: work.head).title}" } do %>
+      <%= link_to [:edit, work], aria: { label: "Edit #{WorkTitlePresenter.show(work.head)}" } do %>
         <span class="fas fa-pencil-alt" aria-hidden="true"></span>
       <% end %>
     <% end %>


### PR DESCRIPTION


## Why was this change made?

We have been abusing the Works::DetailComponent just to format a title value.  This extracts that functionality to it's own class.

## How was this change tested?



## Which documentation and/or configurations were updated?



