### PR TITLE
Hide dataTable searching on the collection works tab

### DIFF
--- a/app/packs/stylesheets/collection.scss
+++ b/app/packs/stylesheets/collection.scss
@@ -31,6 +31,12 @@
     }
   }
 
+  .dataTable-wrapper {
+    .dataTable-search {
+      visibility: hidden;
+    }
+  }
+
   // The pencil icon
   .edit {
     margin-left: 10px;


### PR DESCRIPTION
## Why was this change made?

Note, as in a prior PR, the configuration option in dataTables to disable searching does not seem to be working and we've had to hide via CSS. 

I'm happy to investigate that further, but for now, this removes the search.

<img width="1151" alt="Screen Shot 2021-06-10 at 10 01 19 AM" src="https://user-images.githubusercontent.com/2294288/121567233-34707600-c9d3-11eb-98c3-909775a5ea4f.png">


## How was this change tested?



## Which documentation and/or configurations were updated?



