### PR TITLE
Use a default scope to order events chronologically

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,8 +1,9 @@
-# typed: strict
+# typed: false
 # frozen_string_literal: true
 
 # Records events in the lifecycle of a deposit
 class Event < ApplicationRecord
+  default_scope { order(created_at: :desc) }
   belongs_to :eventable, polymorphic: true
   belongs_to :user, optional: true
 


### PR DESCRIPTION
## Why was this change made?

Fixes #1619 by ordering the event data in descending chronological order

Works:

<img width="966" alt="Screen Shot 2021-06-10 at 10 14 30 AM" src="https://user-images.githubusercontent.com/2294288/121575370-28d57d00-c9dc-11eb-9bd8-52511f778f64.png">

Collection:

<img width="1160" alt="Screen Shot 2021-06-10 at 10 14 43 AM" src="https://user-images.githubusercontent.com/2294288/121575382-2d019a80-c9dc-11eb-83de-39b4244ae107.png">



## How was this change tested?



## Which documentation and/or configurations were updated?



