### PR TITLE
Switch to using white text on the header to follow the identity guide

### DIFF
--- a/app/packs/stylesheets/frontpage.scss
+++ b/app/packs/stylesheets/frontpage.scss
@@ -1,7 +1,7 @@
 
 .stanford-masthead {
   background-color: black;
-  color: $alabaster;
+  color: $white;
   height: 500px;  padding: 1rem 0;
   position: relative;
 
@@ -33,7 +33,7 @@
 
   .credit {
     bottom: 10px;
-    color: $alabaster;
+    color: $white;
     font-size: 0.8rem;
     font-style: italic;
     position: absolute;
@@ -43,7 +43,7 @@
 
 .benefits {
   background-color: $stanford-cardinal;
-  color: $alabaster;
+  color: $white;
   ol {
     padding-left: 1rem;
   }

--- a/app/packs/stylesheets/palette.scss
+++ b/app/packs/stylesheets/palette.scss
@@ -1,4 +1,3 @@
-$alabaster: #f2f1eb;
 $ibis-white: #f3e7e7; // light pinkish hue used in what's changing box
 
 // https://identity.stanford.edu/design-elements/color/primary-colors/

--- a/app/packs/stylesheets/suNavbar.scss
+++ b/app/packs/stylesheets/suNavbar.scss
@@ -15,14 +15,14 @@
     background-color: rgba(255, 255, 255, 0.7);
   }
   .sdr-header {
-    color: $alabaster;
+    color: $white;
 
     .stanford {
       @extend h3;
       line-height: 2.2  ;
       font-family: Palatino, ‘Palatino Linotype’, ‘Hoefler Text’, Times, ‘Times New Roman’, serif;
       padding-right: 1rem;
-      border-right: 1px solid $alabaster;
+      border-right: 1px solid $white;
     }
 
     .digital-repo {

--- a/app/packs/stylesheets/sulFooter.scss
+++ b/app/packs/stylesheets/sulFooter.scss
@@ -12,7 +12,7 @@ $sul-footer-height: 80px;
 }
 
 #sul-footer-container {
-  background-color: $alabaster;
+  background-color: $white;
   -webkit-box-shadow: 0 4px 8px -8px rgba(0, 0, 0, .2) inset;
   box-shadow: 0 4px 8px -8px rgba(0, 0, 0, .2) inset;
   clear: both;


### PR DESCRIPTION
## Why was this change made?

Because "alabaster" is not a color permitted by the identity guide.

## How was this change tested?



## Which documentation and/or configurations were updated?



