### PR TITLE
style 'version your collection' like 'version your work'

### DIFF
--- a/app/packs/stylesheets/collectionEditor.scss
+++ b/app/packs/stylesheets/collectionEditor.scss
@@ -29,4 +29,10 @@
     font-style: italic;
     margin-left: 2.5rem;
   }
+
+  .version {
+    background-color: $ibis-white;
+    border-color: $stanford-cardinal;
+    border-width: 3px;
+  }
 }


### PR DESCRIPTION
## Why was this change made?

Fixes #1573

### Before

![image](https://user-images.githubusercontent.com/96775/121755226-83013b80-cacb-11eb-9e4f-126c8d7a2dcd.png)

### After

![image](https://user-images.githubusercontent.com/96775/121755213-78df3d00-cacb-11eb-90c1-42b97d18a3ea.png)


### Version your work

![image](https://user-images.githubusercontent.com/96775/121755241-8d233a00-cacb-11eb-8e58-783bf69b6e1f.png)


## How was this change tested?

locally

## Which documentation and/or configurations were updated?



