### PR TITLE
update text for authors section

### DIFF
--- a/app/components/works/authors_component.html.erb
+++ b/app/components/works/authors_component.html.erb
@@ -3,7 +3,7 @@
     Authors to include in citation
     <%= render PopoverComponent.new key: 'work.author' %>
   </header>
-  <p>Reorder authors so they are in the correct order</p>
+  <p>When there are multiple authors, list them in the order they should appear in the citation. If you need to change the order of the authors, click the arrows to move individual authors up or down in the list.</p>
 
   <template data-ordered-nested-form-target='template'>
     <%= form.fields_for :authors, Author.new, child_index: 'TEMPLATE_RECORD' do |contributor_form| %>


### PR DESCRIPTION
## Why was this change made?

Fixes #1639 

### Before

![image](https://user-images.githubusercontent.com/96775/121755912-48989e00-cacd-11eb-8163-256f0382641a.png)

### After

![image](https://user-images.githubusercontent.com/96775/121755889-39b1eb80-cacd-11eb-8d1c-84d854940ff9.png)


## How was this change tested?

locally

## Which documentation and/or configurations were updated?



