### PR TITLE
Redirect to collection details page after collection details save.

### DIFF
--- a/app/controllers/collection_versions_controller.rb
+++ b/app/controllers/collection_versions_controller.rb
@@ -85,7 +85,7 @@ class CollectionVersionsController < ObjectsController
       collection_version.begin_deposit!
       redirect_to dashboard_path
     else
-      redirect_to collection_path(collection_version.collection)
+      redirect_to collection_version_path(collection_version)
     end
   end
 

--- a/spec/requests/edit_collection_version_spec.rb
+++ b/spec/requests/edit_collection_version_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Updating an existing collection version' do
             patch "/collection_versions/#{collection_version.id}",
                   params: { collection_version: collection_params, commit: save_draft_button }
             expect(response).to have_http_status(:found)
-            expect(response).to redirect_to(collection_path(collection))
+            expect(response).to redirect_to(collection_version_path(collection_version))
             collection_version.reload
             expect(collection_version.name).to eq 'My Test Collection'
           end


### PR DESCRIPTION
closes #1516

## Why was this change made?
Redirect to correct page.


## How was this change tested?
Local, unit


## Which documentation and/or configurations were updated?
NA


