### PR TITLE
item deposit has corrected header for work subtypes

### DIFF
--- a/app/components/works/subtypes_component.html.erb
+++ b/app/components/works/subtypes_component.html.erb
@@ -1,6 +1,6 @@
 <div class="mb-3 row">
   <div class="col-sm-12 h5">
-    Work types <%= '*' unless optional? %>
+    Work subtypes <%= '*' unless optional? %>
     <%= tooltip %>
   </div>
 </div>

--- a/spec/components/works/subtypes_component_spec.rb
+++ b/spec/components/works/subtypes_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Works::SubtypesComponent do
     let(:work_version) { build_stubbed(:work_version, work_type: 'other', subtype: ['femur']) }
 
     it 'does not label subtypes as optional' do
-      expect(rendered.to_html).to include('Work types *')
+      expect(rendered.to_html).to include('Work subtypes *')
       expect(rendered.to_html).to include('Specify "Other" type')
       expect(rendered.css('a[data-bs-content^="Enter a word or short phrase to describe"]')).to be_present
     end
@@ -23,7 +23,7 @@ RSpec.describe Works::SubtypesComponent do
     let(:work_version) { build_stubbed(:work_version, work_type: 'music', subtype: ['Data']) }
 
     it 'does not label subtypes as optional' do
-      expect(rendered.to_html).to include('Work types *')
+      expect(rendered.to_html).to include('Work subtypes *')
       expect(rendered.css('a[data-bs-content^="You must select at least one term from the shorter list"]'))
         .to be_present
     end
@@ -37,7 +37,7 @@ RSpec.describe Works::SubtypesComponent do
     let(:work_version) { build_stubbed(:work_version, work_type: 'mixed material', subtype: %w[Data Sound]) }
 
     it 'does not label subtypes as optional' do
-      expect(rendered.to_html).to include('Work types *')
+      expect(rendered.to_html).to include('Work subtypes *')
       expect(rendered.css('a[data-bs-content^="You must choose at least two of the terms below"]'))
         .to be_present
     end
@@ -49,7 +49,7 @@ RSpec.describe Works::SubtypesComponent do
 
   context 'when work type is anything else' do
     it 'does not label subtypes as required' do
-      expect(rendered.to_html).to include('Work types')
+      expect(rendered.to_html).to include('Work subtypes')
       expect(rendered.css('a[data-bs-content^="You have the option to choose one or more of the following terms"]'))
         .to be_present
     end

--- a/spec/features/edit_draft_work_spec.rb
+++ b/spec/features/edit_draft_work_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe 'Edit a draft work', js: true do
         expect(nav).to have_content('Edit')
       end
 
-      expect(page).to have_content('Work types')
-      expect(page).not_to have_content('Work types (optional)')
+      expect(page).to have_content('Work subtypes')
+      expect(page).not_to have_content('Work subtypes (optional)')
 
       fill_in "What's changing?", with: 'Fixing title per request'
 
@@ -105,7 +105,7 @@ RSpec.describe 'Edit a draft work', js: true do
       click_link 'Yes!'
 
       expect(page).to have_content work_version.title
-      expect(page).to have_content('Work types')
+      expect(page).to have_content('Work subtypes')
       expect(page).to have_content('Select at least one term below')
       expect(find('#work_subtype_preprint', visible: :all)).not_to be_visible
       expect(find('#work_subtype_data')).to be_visible


### PR DESCRIPTION
## Why was this change made?

Fixes #1643

## How was this change tested?

running locally and unit test changes

## Which documentation and/or configurations were updated?



