### PR TITLE
rubocop.yml gets newly created cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -316,3 +316,8 @@ Style/MultilineInPatternThen: # (new in 1.16)
   Enabled: true
 Style/QuotedSymbols: # (new in 1.16)
   Enabled: true
+
+RSpec/IdenticalEqualityAssertion: # (new in 2.4)
+  Enabled: true
+RSpec/Rails/AvoidSetupHook: # (new in 2.4)
+  Enabled: true


### PR DESCRIPTION
## Why was this change made?

we must appease our rubocop masters or bad things will happen.

## How was this change tested?



## Which documentation and/or configurations were updated?



