### PR TITLE
If providing a create date interval, requires start and finish year.

### DIFF
--- a/app/components/works/buttons_component.html.erb
+++ b/app/components/works/buttons_component.html.erb
@@ -1,6 +1,6 @@
 <div class="row justify-content-between">
   <div class="col-auto">
-    <% if first_draft? %>
+    <% if show_first_draft_cancel? %>
       <%= link_to model, method: :delete, aria: { label: "Delete #{title}" },
             data: {
                confirm: "Are you sure you want to delete this draft work? It cannot be undone.",
@@ -8,7 +8,7 @@
             } do %>
         <span class="btn btn-primary"><span class="far fa-trash-alt"></span> Discard draft</span>
       <% end %>
-    <% elsif version_draft? %>
+    <% elsif show_version_draft_cancel? %>
       <%= link_to work_version, method: :delete, aria: { label: "Delete #{title}" },
             data: {
               confirm: "Are you sure you want to revert to the previously published version? It cannot be undone.",

--- a/app/components/works/buttons_component.rb
+++ b/app/components/works/buttons_component.rb
@@ -18,7 +18,7 @@ module Works
     private
 
     delegate :object, to: :form
-    delegate :first_draft?, :version_draft?, :title, to: :work_version
+    delegate :title, to: :work_version
     delegate :collection, to: :model
 
     def work_version
@@ -32,6 +32,16 @@ module Works
     sig { returns(T.nilable(T::Boolean)) }
     def work_in_reviewed_coll?
       collection.review_enabled?
+    end
+
+    sig { returns(T::Boolean) }
+    def show_version_draft_cancel?
+      work_version.version_draft? && work_version.persisted?
+    end
+
+    sig { returns(T::Boolean) }
+    def show_first_draft_cancel?
+      work_version.first_draft?
     end
   end
 end

--- a/app/components/works/dates_component.html.erb
+++ b/app/components/works/dates_component.html.erb
@@ -26,7 +26,7 @@
             id: "#{prefix}_created_year",
             placeholder: 'year',
             class: "form-control", min: min_year, max: max_year %>
-        <div class="invalid-feedback">Created year must be between <%= min_year %> and <%= max_year %></div>
+        <div class="invalid-feedback" data-date-validation-target="error"></div>
       </div>
       <div class="month">
         <label for="<%= prefix %>_created_month" class="visually-hidden">Created month</label>
@@ -60,13 +60,14 @@
         <div class="year">
           <label for="<%= prefix %>_created_range_start_year" class="visually-hidden">Created range start year</label>
           <%= date_range_start_year %>
-          <div class="invalid-feedback">Created year must be between <%= min_year %> and <%= max_year %></div>
+          <div class="invalid-feedback" data-date-validation-target="error"></div>
+          <div class="invalid-feedback" data-date-range-target="startError"></div>
         </div>
         <div class="month">
           <label for="<%= prefix %>_created_range_start_month" class="visually-hidden">Created range start month</label>
           <%= select_month created_range_start_month,
               { prefix: prefix, field_name: 'created_range(2i)', prompt: 'month'},
-              data: { date_validation_target: 'month', action: 'date-validation#change' },
+              data: { date_validation_target: 'month', date_range_target: 'startMonth', action: 'date-range#change' },
               id: "#{prefix}_created_range_start_month",
               class: "form-control" %>
         </div>
@@ -74,7 +75,7 @@
           <label for="<%= prefix %>_created_range_start_day" class="visually-hidden">Created range start day</label>
           <%= select_day created_range_start_day,
               { prefix: prefix, field_name: 'created_range(3i)', prompt: 'day'},
-              data: { date_validation_target: 'day', action: 'date-validation#change' },
+              data: { date_validation_target: 'day', date_range_target: 'startDay', action: 'date-range#change' },
               id: "#{prefix}_created_range_start_day",
               class: "form-control" %>
         </div>
@@ -92,13 +93,14 @@
         <div class="year">
           <label for="<%= prefix %>_created_range_end_year" class="visually-hidden">Created range end year</label>
           <%= date_range_end_year %>
-          <div class="invalid-feedback">Created year must be between <%= min_year %> and <%= max_year %></div>
+          <div class="invalid-feedback" data-date-validation-target="error"></div>
+          <div class="invalid-feedback" data-date-range-target="endError"></div>
         </div>
         <div class="month">
           <label for="<%= prefix %>_created_range_end_month" class="visually-hidden">Created range end month</label>
           <%= select_month created_range_end_month,
               { prefix: prefix, field_name: 'created_range(5i)', prompt: 'month' },
-              data: { date_validation_target: 'month', action: 'date-validation#change' },
+              data: { date_validation_target: 'month', date_range_target: 'endMonth', action: 'date-range#change' },
               id: "#{prefix}_created_range_end_month", class: "form-control" %>
         </div>
 
@@ -106,7 +108,7 @@
           <label for="<%= prefix %>_created_range_end_day" class="visually-hidden">Created range end day</label>
           <%= select_day created_range_end_day,
               { prefix: prefix, field_name: 'created_range(6i)', prompt: 'day' },
-              data: { date_validation_target: 'day', action: 'date-validation#change' },
+              data: { date_validation_target: 'day', date_range_target: 'endDay', action: 'date-range#change' },
               id: "#{prefix}_created_range_end_day", class: "form-control" %>
         </div>
         <div>

--- a/app/components/works/dates_component.rb
+++ b/app/components/works/dates_component.rb
@@ -16,8 +16,9 @@ module Works
       number_field_tag "#{prefix}[created_range(1i)]", created_range_start_year,
                        data: {
                          date_validation_target: 'year',
-                         date_range_target: 'year',
-                         action: 'date-validation#change date-range#change'
+                         date_range_target: 'startYear',
+                         action: 'date-range#change clear->date-validation#clearValidations ' \
+                                    'validate->date-validation#validate'
                        },
                        id: 'work_created_range_start_year',
                        placeholder: 'year',
@@ -28,8 +29,9 @@ module Works
       number_field_tag "#{prefix}[created_range(4i)]", created_range_end_year,
                        data: {
                          date_validation_target: 'year',
-                         date_range_target: 'year',
-                         action: 'date-validation#change date-range#change'
+                         date_range_target: 'endYear',
+                         action: 'date-range#change clear->date-validation#clearValidations ' \
+                                    'validate->date-validation#validate'
                        },
                        id: 'work_created_range_end_year',
                        placeholder: 'year',
@@ -56,16 +58,19 @@ module Works
 
     delegate :published_edtf, to: :reform
 
+    # In getters below, reform.send is used to return the original submitted values are returned when an EDTF
+    # couldn't be created.
+
     def created_range_start_year
-      created_range_start&.year
+      created_range_start&.year || reform.send(:'created_range(1i)').presence&.to_i
     end
 
     def created_range_start_month
-      resolve_month(created_range_start)
+      resolve_month(created_range_start) || reform.send(:'created_range(2i)').presence&.to_i
     end
 
     def created_range_start_day
-      resolve_day(created_range_start)
+      resolve_day(created_range_start) || reform.send(:'created_range(3i)').presence&.to_i
     end
 
     def created_range_start_approximate?
@@ -75,15 +80,15 @@ module Works
     end
 
     def created_range_end_year
-      created_range_end&.year
+      created_range_end&.year || reform.send(:'created_range(4i)').presence&.to_i
     end
 
     def created_range_end_month
-      resolve_month(created_range_end)
+      resolve_month(created_range_end) || reform.send(:'created_range(5i)').presence&.to_i
     end
 
     def created_range_end_day
-      resolve_day(created_range_end)
+      resolve_day(created_range_end) || reform.send(:'created_range(6i)').presence&.to_i
     end
 
     def created_range_end_approximate?
@@ -94,12 +99,12 @@ module Works
 
     sig { returns(T.nilable(Date)) }
     def created_range_start
-      created_interval&.begin
+      created_interval&.from
     end
 
     sig { returns(T.nilable(Date)) }
     def created_range_end
-      created_interval&.end
+      created_interval&.to
     end
 
     sig { returns(T.nilable(EDTF::Interval)) }

--- a/app/components/works/publication_date_component.html.erb
+++ b/app/components/works/publication_date_component.html.erb
@@ -7,8 +7,9 @@
     <div class="year">
       <label for="work_published_year" class="visually-hidden">Publication year</label>
       <%= year_field %>
+      <div class="invalid-feedback" data-date-validation-target="error"></div>
       <% unless error? # This is only used before the form is submitted %>
-        <div class="invalid-feedback">Publication year must be between <%= min_year %> and <%= max_year %></div>
+        <div class="invalid-feedback" data-date-validation-target="error"></div>
       <% end %>
     </div>
     <div class="month">

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -23,7 +23,7 @@ class DraftWorkForm < Reform::Form
   property :license, on: :work_version
   property :agree_to_terms, on: :work_version
   property :created_type, virtual: true, prepopulator: (proc do |*|
-    self.created_type = created_edtf.is_a?(EDTF::Interval) ? 'range' : 'single'
+    self.created_type = created_edtf.is_a?(EDTF::Interval) ? 'range' : 'single' unless created_type
   end)
   property :created_edtf, edtf: true, range: true, on: :work_version
   property :published_edtf, edtf: true, on: :work_version
@@ -34,6 +34,9 @@ class DraftWorkForm < Reform::Form
 
   validates_with EmbargoDateParts,
                  if: proc { |form| form.user_can_set_availability? && form.release == 'embargo' }
+
+  validates_with CreatedDateParts,
+                 if: proc { |form| form.created_type == 'range' }
 
   delegate :user_can_set_availability?, to: :collection
 

--- a/app/forms/edtf_params_filter.rb
+++ b/app/forms/edtf_params_filter.rb
@@ -12,7 +12,6 @@ class EdtfParamsFilter
 
       date_attributes[dfn[:name]] = deserialize(params, name, dfn[:range] && params["#{name}_type"] == 'range')
     end
-
     params.merge(date_attributes)
   end
 
@@ -21,10 +20,10 @@ class EdtfParamsFilter
   end
 
   def deserialize_edtf(params, date_attribute, offset = 0)
-    year = params.delete("#{date_attribute}(#{1 + offset}i)")
-    month = params.delete("#{date_attribute}(#{2 + offset}i)")
-    day = params.delete("#{date_attribute}(#{3 + offset}i)")
-    uncertain = params.delete("#{date_attribute}(approx#{offset})")
+    year = params["#{date_attribute}(#{1 + offset}i)"]
+    month = params["#{date_attribute}(#{2 + offset}i)"]
+    day = params["#{date_attribute}(#{3 + offset}i)"]
+    uncertain = params["#{date_attribute}(approx#{offset})"]
 
     deserialize_edtf_date(year, month, day, uncertain)
   end

--- a/app/packs/controllers/date_range_controller.js
+++ b/app/packs/controllers/date_range_controller.js
@@ -1,11 +1,107 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  static targets = ["year"]
+    static targets = ["startYear", "startMonth", "startDay", "endYear", "endMonth", "endDay", "startError", "endError"]
 
-  // If any of the years are filled in, then make both required.
-  change(_event) {
-   const filledIn = this.yearTargets.find((target) => target.value !== '')
-   this.yearTargets.forEach((target) => target.required = filledIn)
-  }
+    connect() {
+        this.change()
+    }
+
+    // This invokes Date Validation controller as necessary for start and end dates.
+    change() {
+        this.clearValidationMessages()
+        this.validate()
+    }
+
+    validate() {
+        this.startYearTarget.dispatchEvent(new Event('validate'))
+        this.endYearTarget.dispatchEvent(new Event('validate'))
+        const filled = this.dateFilled()
+        if(filled) this.dateOrder()
+    }
+
+    clearValidationMessages() {
+        this.startYearTarget.dispatchEvent(new Event('clear'))
+        this.endYearTarget.dispatchEvent(new Event('clear'))
+    }
+
+    // If any of the years are filled in, then make both required.
+    dateFilled() {
+        if (!this.filledIn(this.startYearTarget) && !this.filledIn(this.endYearTarget)) return
+        if (!this.filledIn(this.startYearTarget)) {
+          this.startYearTarget.required = true
+          this.startYearTarget.classList.add('is-invalid')
+          this.startErrorTarget.textContent = "start must be provided"
+          return false
+        }
+        if (!this.filledIn(this.endYearTarget)) {
+          this.endYearTarget.required = true
+          this.endYearTarget.classList.add('is-invalid')
+          this.endErrorTarget.textContent = "end must be provided"
+          return false
+        }
+        return true
+    }
+
+    dateOrder() {
+        const startYear = this.toInt(this.startYearTarget)
+        const startMonth = this.toInt(this.startMonthTarget)
+        const startDay = this.toInt(this.startDayTarget)
+        const endYear = this.toInt(this.endYearTarget)
+        const endMonth = this.toInt(this.endMonthTarget)
+        const endDay = this.toInt(this.endDayTarget)
+
+        if(startYear == endYear && startMonth == endMonth && startDay === endDay) {
+            this.startErrorTarget.textContent = 'start must be before end'
+            this.startYearTarget.classList.add('is-invalid')
+            this.startYearTarget.setCustomValidity('invalid')
+            if(startMonth != 0) {
+                this.startMonthTarget.classList.add('is-invalid')
+                this.startMonthTarget.setCustomValidity('invalid')
+            }
+            if(startDay != 0) {
+                this.startDayTarget.classList.add('is-invalid')
+                this.startDayTarget.setCustomValidity('invalid')
+            }
+            return
+        }
+
+        if(startYear > endYear) {
+            this.startErrorTarget.textContent = 'start must be before end'
+            this.startYearTarget.classList.add('is-invalid')
+            this.startYearTarget.setCustomValidity('invalid')
+            return
+        }
+        if(startYear < endYear) return
+
+        if(startMonth > endMonth) {
+            this.startErrorTarget.textContent = 'start must be before end'
+            this.startYearTarget.classList.add('is-invalid')
+            this.startYearTarget.setCustomValidity('invalid')
+            this.startMonthTarget.classList.add('is-invalid')
+            this.startMonthTarget.setCustomValidity('invalid')
+            return
+        }
+
+        if(startMonth < endMonth) return
+
+        if(startDay > endDay) {
+            this.startErrorTarget.textContent = 'start must be before end'
+            this.startYearTarget.classList.add('is-invalid')
+            this.startYearTarget.setCustomValidity('invalid')
+            this.startMonthTarget.classList.add('is-invalid')
+            this.startMonthTarget.setCustomValidity('invalid')
+            this.startDayTarget.classList.add('is-invalid')
+            this.startDayTarget.setCustomValidity('invalid')
+            return
+        }
+    }
+
+    filledIn(target) {
+        return target.value !== ''
+    }
+
+    toInt(target) {
+        return parseInt(target.value) || 0
+    }
 }

--- a/app/packs/controllers/date_validation_controller.js
+++ b/app/packs/controllers/date_validation_controller.js
@@ -1,71 +1,82 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  static targets = ["year", "month", "day"]
+  static targets = ["year", "month", "day", "error"]
+
+  connect() {
+    this.validate()
+  }
 
   change() {
-    this.errors = {}
-    this.mostSignifcantPartsPresent()
-    this.dateInPast()
-    this.displayErrors()
+    this.clearValidations()
+    this.validate()
   }
 
-  displayErrors () {
-    if (this.errors.year) {
-      this.yearTarget.classList.add('is-invalid')
-      this.yearTarget.setCustomValidity(this.errors.year)
-    } else {
-      this.yearTarget.classList.remove('is-invalid')
-      this.yearTarget.setCustomValidity('')
-    }
-
-    if (this.errors.month) {
-      this.monthTarget.classList.add('is-invalid')
-      this.monthTarget.setCustomValidity(this.errors.month)
-    } else {
-      this.monthTarget.classList.remove('is-invalid')
-      this.monthTarget.setCustomValidity('')
-    }
-
-    if (this.errors.day) {
-      this.dayTarget.classList.add('is-invalid')
-      this.dayTarget.setCustomValidity(this.errors.day)
-    } else {
-      this.dayTarget.classList.remove('is-invalid')
-      this.dayTarget.setCustomValidity('')
-    }
+  validate() {
+    this.mostSignificantPartsPresent()
+    this.validDateRange()
   }
 
-  dateInPast() {
+  clearValidations() {
+    this.yearTarget.classList.remove('is-invalid')
+    this.yearTarget.setCustomValidity('')
+    this.yearTarget.required = false
+    this.monthTarget.classList.remove('is-invalid')
+    this.monthTarget.setCustomValidity('')
+    this.monthTarget.required = false
+    this.dayTarget.classList.remove('is-invalid')
+    this.dayTarget.setCustomValidity('')
+    this.errorTarget.textContent = ''
+  }
+
+  validDateRange() {
     const currentTime = new Date()
     const currentMonth = currentTime.getMonth() + 1
     const currentDay = currentTime.getDate()
     const currentYear = currentTime.getFullYear()
-    const day = this.dayTarget.value
-    const month = this.monthTarget.value
-    const year = this.yearTarget.value
+    const day = this.toInt(this.dayTarget)
+    const month = this.toInt(this.monthTarget)
+    const year = this.toInt(this.yearTarget)
 
-    if (year > currentYear) {
-      this.errors.year = 'must be in the past'
+    if (year != 0 && year < this.yearTarget.min) {
+      this.yearTarget.classList.add('is-invalid')
+      this.yearTarget.setCustomValidity('invalid')
+      this.errorTarget.textContent = 'must be after ' + this.yearTarget.min
+    } else if (year > currentYear) {
+      this.yearTarget.classList.add('is-invalid')
+      this.yearTarget.setCustomValidity('invalid')
+      this.errorTarget.textContent = 'must be in the past'
     } else if (year == currentYear) {
       if (month > currentMonth) {
-        this.errors.month = 'must be in the past'
+        this.monthTarget.classList.add('is-invalid')
+        this.monthTarget.setCustomValidity('invalid')
+        this.errorTarget.textContent = 'must be in the past'
       } else if (month == currentMonth && day > currentDay) {
-        this.errors.day = 'must be in the past'
+        this.dayTarget.classList.add('is-invalid')
+        this.dayTarget.setCustomValidity('invalid')
+        this.errorTarget.textContent = 'must be in the past'
       }
     }
   }
 
   // Validate that the most signifcant parts are provided when a less significant part is provided.
-  mostSignifcantPartsPresent() {
+  // Draft cannot be saved unless this is satisfied so should be displayed immediately.
+  mostSignificantPartsPresent() {
     const day = this.dayTarget.value
     const month = this.monthTarget.value
     const year = this.yearTarget.value
 
     if ((day || month) && !year) {
-      this.errors.year = 'must be provided'
-    } else if (day && !month) {
-      this.errors.month = 'must be provided'
+      this.yearTarget.classList.add('is-invalid')
+      this.yearTarget.required = true
     }
+    if (day && !month) {
+      this.monthTarget.classList.add('is-invalid')
+      this.monthTarget.required = true
+    }
+  }
+
+  toInt(target) {
+    return parseInt(target.value) || 0
   }
 }

--- a/app/validators/created_date_parts.rb
+++ b/app/validators/created_date_parts.rb
@@ -1,0 +1,16 @@
+# typed: true
+# frozen_string_literal: true
+
+# Validates created date interval
+class CreatedDateParts < ActiveModel::Validator
+  def validate(record)
+    start_year = record.send(:'created_range(1i)')
+    finish_year = record.send(:'created_range(4i)')
+
+    return if start_year.blank? && finish_year.blank?
+    return if start_year.present? && finish_year.present?
+
+    record.errors.add(:created_date_range_start, 'must be provided') if start_year.blank?
+    record.errors.add(:created_date_range_end, 'must be provided') if finish_year.blank?
+  end
+end

--- a/app/validators/created_in_past_validator.rb
+++ b/app/validators/created_in_past_validator.rb
@@ -12,6 +12,7 @@ class CreatedInPastValidator < ActiveModel::EachValidator
     when EDTF::Interval
       validate_date(record, attribute, value.from, 'start')
       validate_date(record, attribute, value.to, 'end')
+      validate_interval_order(record, value)
     end
   end
 
@@ -21,5 +22,11 @@ class CreatedInPastValidator < ActiveModel::EachValidator
     prefix &&= "#{prefix} "
     record.errors.add(attribute, "#{prefix}must have a four digit year") if Settings.earliest_year > value.year
     record.errors.add(attribute, "#{prefix}must be in the past") if Time.zone.today < value
+  end
+
+  def validate_interval_order(record, value)
+    return if value.from < value.to
+
+    record.errors.add(:created_date_range_start, 'must be before end')
   end
 end

--- a/spec/components/works/dates_component_spec.rb
+++ b/spec/components/works/dates_component_spec.rb
@@ -45,8 +45,25 @@ RSpec.describe Works::DatesComponent do
 
     it 'renders the component with both start and end approximate checkbox selected' do
       expect(rendered.css('#work_created_range_start_year').first['value']).to eq '2019'
+      expect(rendered.css('#work_created_range_start_month option[@selected="selected"]').first['value']).to eq '5'
       expect(rendered.css('#work_created_range_approx0_').first.attribute('checked').value).to eq 'checked'
       expect(rendered.css('#work_created_range_end_year').first['value']).to eq '2020'
+      expect(rendered.css('#work_created_range_end_month option[@selected="selected"]').first['value']).to eq '7'
+      expect(rendered.css('#work_created_range_approx3_').first.attribute('checked').value).to eq 'checked'
+    end
+  end
+
+  context 'with a populated form with an approximate backwards date range' do
+    # Testing this due to how EDTF handles to < from
+    let(:approx_date_range) { EDTF.parse('2020-07?/2019-05?') }
+    let(:work_version) { build(:work_version, created_edtf: approx_date_range) }
+
+    it 'renders the component with both start and end approximate checkbox selected' do
+      expect(rendered.css('#work_created_range_start_year').first['value']).to eq '2020'
+      expect(rendered.css('#work_created_range_start_month option[@selected="selected"]').first['value']).to eq '7'
+      expect(rendered.css('#work_created_range_approx0_').first.attribute('checked').value).to eq 'checked'
+      expect(rendered.css('#work_created_range_end_year').first['value']).to eq '2019'
+      expect(rendered.css('#work_created_range_end_month option[@selected="selected"]').first['value']).to eq '5'
       expect(rendered.css('#work_created_range_approx3_').first.attribute('checked').value).to eq 'checked'
     end
   end

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -55,10 +55,10 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
         fill_in 'Created year', with: '999'
         click_button 'Deposit'
         expect(page).to have_content(
-          "Publication year must be between #{Settings.earliest_year} and #{Time.zone.today.year}"
+          'must be after 1000'
         )
         expect(page).to have_content(
-          "Created year must be between #{Settings.earliest_year} and #{Time.zone.today.year}"
+          'must be in the past'
         )
         expect(page).to have_content('You must provide an abstract')
 

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -659,6 +659,30 @@ RSpec.describe 'Create a new work' do
           expect(DepositJob).to have_received(:perform_later)
         end
       end
+
+      context 'with a partial create date range' do
+        let(:collection_version) { create(:collection_version_with_collection, depositors: [user]) }
+
+        let(:work_params) do
+          {
+            title: '',
+            abstract: '',
+            license: License.license_list.first,
+            work_type: 'text',
+            release: 'immediate',
+            created_type: 'range',
+            'created_range(1i)' => '2020', 'created_range(2i)' => '3', 'created_range(3i)' => '4',
+            'created_range(4i)' => '', 'created_range(5i)' => '', 'created_range(6i)' => ''
+          }
+        end
+
+        it 'displays the draft work with a validation error' do
+          post "/collections/#{collection.id}/works", params: { work: work_params,
+                                                                commit: 'Save as draft' }
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.body).to include 'end must be provided'
+        end
+      end
     end
   end
 end

--- a/spec/validators/created_in_past_validator_spec.rb
+++ b/spec/validators/created_in_past_validator_spec.rb
@@ -98,5 +98,14 @@ RSpec.describe CreatedInPastValidator do
                                                    'Created edtf end must be in the past']
       end
     end
+
+    context 'with dates out of order' do
+      let(:attribute) { :created_edtf }
+      let(:value) { EDTF.parse('2000-01-01/1900-01-01') }
+
+      it 'has errors' do
+        expect(record.errors.full_messages).to eq ['Created date range start must be before end']
+      end
+    end
   end
 end


### PR DESCRIPTION
closes #914

## Why was this change made?
* Validate date intervals.
* Do not discard interval dates that the user has entered.

## How was this change tested?
Unit, local


## Which documentation and/or configurations were updated?
NA


