### PR TITLE
Makes title and related works into text areas.

### DIFF
--- a/app/components/works/description_component.html.erb
+++ b/app/components/works/description_component.html.erb
@@ -57,7 +57,8 @@
       <div class="col-sm-10">
         <%= form.text_area :citation, class: "form-control",
                            aria: { label: 'Provided citation' },
-                           data: { auto_citation_target: 'manual' } %>
+                           data: { auto_citation_target: 'manual',
+                                   action: "no-newlines#change", no_newlines_target: 'input', controller: 'no-newlines' } %>
         <%= form.text_area :citation_auto,
                            class: "form-control", readonly: true,
                            aria: { label: 'Automatically generated citation' },

--- a/app/components/works/related_work_row_component.html.erb
+++ b/app/components/works/related_work_row_component.html.erb
@@ -3,7 +3,9 @@
     <%= form.label :citation, 'Citation of related published work', class: 'form-label col-md-2' %>
 
     <div class="col-md-9">
-      <%= form.text_field :citation, class: 'form-control' %>
+      <%= form.text_area :citation, class: 'form-control',
+                         data: { action: "no-newlines#change", no_newlines_target: 'input', controller: 'no-newlines' }
+                          %>
     </div>
 
     <div class="col-md-1">

--- a/app/components/works/title_component.html.erb
+++ b/app/components/works/title_component.html.erb
@@ -6,9 +6,13 @@
        <%= render PopoverComponent.new key: 'work.title' %>
      </div>
      <div class="col-sm-9">
-       <%= form.text_field :title, class: "form-control", required: true,
-                           data: { action: "change->auto-citation#updateDisplay",
-                                   auto_citation_target: 'titleField' } %>
+       <%= form.text_area :title, class: "form-control", required: true, rows: 1,
+                           data: { action: "no-newlines#change change->auto-citation#updateDisplay",
+                                   auto_citation_target: 'titleField',
+                                   no_newlines_target: 'input',
+                                   controller: 'no-newlines'
+
+                           } %>
        <div class="invalid-feedback">You must provide a title</div>
      </div>
    </div>

--- a/app/packs/controllers/no_newlines_controller.js
+++ b/app/packs/controllers/no_newlines_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "stimulus"
+
+// This controller removes newlines from an input such as a textarea.
+// This allows the input to wrap long text.
+export default class extends Controller {
+  static targets = ["input"]
+
+  change() {
+    this.inputTarget.value = this.inputTarget.value.replace( /\r?\n/gi, '' )
+  }
+}

--- a/spec/components/works/title_component_spec.rb
+++ b/spec/components/works/title_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Works::TitleComponent do
   let(:form) do
     instance_double(ActionView::Helpers::FormBuilder,
                     label: nil,
-                    text_field: nil,
+                    text_area: nil,
                     fields_for: nil)
   end
 


### PR DESCRIPTION
closes #1032

## Why was this change made?
Better data entry.


## How was this change tested?
Local


## Which documentation and/or configurations were updated?
NA

Note that default citation was already a text area.


