### PR TITLE
Use simple_format for abstract

### DIFF
--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -134,7 +134,7 @@
     <tbody>
     <tr>
       <th scope="row">Abstract</th>
-      <td><%= abstract %></td>
+      <td><%= simple_format abstract %></td>
     </tr>
     <tr>
       <th scope="row">Keywords</th>


### PR DESCRIPTION

## Why was this change made?

This enables the show page to draw linebreaks where the user entered them.

Fixes #1666 

## How was this change tested?

<img width="1084" alt="Screen Shot 2021-06-18 at 11 30 56 AM" src="https://user-images.githubusercontent.com/92044/122591626-d114c280-d028-11eb-9ae0-f14031ad0fe6.png">



## Which documentation and/or configurations were updated?



