### PR TITLE
Load the terms lazily

### DIFF
--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -1,0 +1,9 @@
+# typed: false
+# frozen_string_literal: true
+
+# Display the terms of deposit
+class TermsController < ApplicationController
+  def show
+    # Just the default render
+  end
+end

--- a/app/views/print/terms_of_deposit.html.erb
+++ b/app/views/print/terms_of_deposit.html.erb
@@ -1,9 +1,15 @@
 <script language='javascript'>
-  window.onload = function() { 
-    document.getElementById("print-link").style.display='none';
-    document.getElementById("save-link").style.display='none';
-    window.print(); 
+  window.onload = function() {
+    window.print();
   }
 </script>
-<a href="javascript:window.close();">Close window</a>
-<%= render partial: 'shared/terms_of_deposit' %>
+<style>
+  @media print {
+    #closeWindow {
+      display: none;
+    }
+  }
+</style>
+<a id="closeWindow" href="javascript:window.close();">Close window</a>
+<h1>Terms of Deposit</h1>
+<%= render 'terms/show' %>

--- a/app/views/shared/_terms_of_deposit.html.erb
+++ b/app/views/shared/_terms_of_deposit.html.erb
@@ -25,61 +25,7 @@
           </div>
         </div>
       <div class="modal-body">
-        <p>
-          In depositing content to the Stanford Digital Repository (SDR), the Depositor grants The
-          Trustees of Leland Stanford Junior University through the Stanford Libraries (Stanford
-          Libraries) the non-exclusive, worldwide, perpetual, irrevocable right to reproduce, distribute,
-          display and transmit such content (the Work), in whole or in part, in such print and electronic
-          formats as may be in existence now or developed in the future, to sublicense others to do the
-          same, and to preserve and store the Work, subject to any third-party release or display
-          restrictions chosen by Depositor through Stanford Libraries’ deposit submission application.
-          Stanford Libraries may make the Work available to users, subject to the applicable Terms of Use<sup>[1]</sup>
-          and to any license applied by Depositor through Stanford Libraries’ deposit submission
-          application. These Terms of Use are subject to change by Stanford Libraries; Stanford Libraries
-          will make a reasonable effort to notify the Depositor when changes occur. More information is
-          available at <a href="http://library.stanford.edu/research/stanford-digital-repository/depositor-services" target="_blank">http://library.stanford.edu/research/stanford-digital-repository/depositor-services</a>.
-        </p>
-        <p>
-          Stanford Libraries is free to reformat, delete or remove access to any or all of the Work in the
-          SDR at its discretion. If Stanford Libraries determines it is necessary to remove access to or
-          delete permanently any specific Work or portions thereof, it will make a reasonable effort to
-          notify the Depositor and make available a copy of the deleted file to Depositor (at Depositor’s
-          expense), provided that (i) it has Depositor’s contact information on file; and (ii) it would be
-          lawful in Stanford Libraries’ determination to do so. Depositor grants no other rights under this
-          license, including, without limitation, any copyright interests in the Work.
-        </p>
-        <p>
-          Depositor represents and warrants that Depositor is the copyright holder of the Work, and/or has
-          obtained all necessary permission of other copyright owner(s) to grant Stanford Libraries the
-          rights required by this license or any applied license, including necessary licenses relating to any
-          third party copyrighted content included in the Work, and any third-party software necessary to
-          access, display, and run or print the Work. More specifically, Depositor warrants that any
-          jointly-owned or third-party owned material, such as graphs, images, photos, music, etc., is
-          clearly identified and acknowledged within the content of the Work, and Depositor is solely
-          responsible and will indemnify Stanford Libraries for any third party claims related to the Work,
-          including any third party content contained therein, as submitted.
-        </p>
-        <p>
-          Depositor further warrants that the Work does not violate any applicable law or agreement, or
-          infringe upon anyone's publicity, privacy or confidentiality rights, including but not limited to
-          privacy rights protected by HIPAA or FERPA. Depositor warrants that the Work does not
-          contain any high risk data, including but not limited to Social Security Numbers, driver’s license
-          numbers or bank account information. (More information is available at
-          <a href="https://uit.stanford.edu/guide/riskclassifications" target="_blank">https://uit.stanford.edu/guide/riskclassifications</a>.)
-          Depositor represents that depositing to the SDR does not violate an existing publication agreement,
-          Institutional Review Board (IRB), or contract governing deposited content. If the content is original
-          work derived from a source work produced and/or owned by a third-party, Depositor represents compliance
-          with the terms of use associated with that source work.
-        </p>
-        <p>
-          Depositor agrees to indemnify and hold harmless Stanford against any third party claims
-          (including those related to copyright, trademark or other intellectual property rights) arising out
-          of or relating to Stanford's deposit, display or other use of the Work as permitted or authorized
-          by this agreement.
-        </p>
-        <p>
-          <sup>[1]</sup> <small>Stanford Digital Repository Terms of Use: <%= Settings.access.use_and_reproduction_statement %></small>
-        </p>
+        <%= turbo_frame_tag :termsOfDeposit, src: terms_path(), loading: 'lazy' %>
       </div>
     </div>
   </div>

--- a/app/views/terms/_show.html.erb
+++ b/app/views/terms/_show.html.erb
@@ -1,0 +1,55 @@
+<p>
+  In depositing content to the Stanford Digital Repository (SDR), the Depositor grants The
+  Trustees of Leland Stanford Junior University through the Stanford Libraries (Stanford
+  Libraries) the non-exclusive, worldwide, perpetual, irrevocable right to reproduce, distribute,
+  display and transmit such content (the Work), in whole or in part, in such print and electronic
+  formats as may be in existence now or developed in the future, to sublicense others to do the
+  same, and to preserve and store the Work, subject to any third-party release or display
+  restrictions chosen by Depositor through Stanford Libraries’ deposit submission application.
+  Stanford Libraries may make the Work available to users, subject to the applicable Terms of Use<sup>[1]</sup>
+  and to any license applied by Depositor through Stanford Libraries’ deposit submission
+  application. These Terms of Use are subject to change by Stanford Libraries; Stanford Libraries
+  will make a reasonable effort to notify the Depositor when changes occur. More information is
+  available at <a href="http://library.stanford.edu/research/stanford-digital-repository/depositor-services" target="_blank">http://library.stanford.edu/research/stanford-digital-repository/depositor-services</a>.
+</p>
+<p>
+  Stanford Libraries is free to reformat, delete or remove access to any or all of the Work in the
+  SDR at its discretion. If Stanford Libraries determines it is necessary to remove access to or
+  delete permanently any specific Work or portions thereof, it will make a reasonable effort to
+  notify the Depositor and make available a copy of the deleted file to Depositor (at Depositor’s
+  expense), provided that (i) it has Depositor’s contact information on file; and (ii) it would be
+  lawful in Stanford Libraries’ determination to do so. Depositor grants no other rights under this
+  license, including, without limitation, any copyright interests in the Work.
+</p>
+<p>
+  Depositor represents and warrants that Depositor is the copyright holder of the Work, and/or has
+  obtained all necessary permission of other copyright owner(s) to grant Stanford Libraries the
+  rights required by this license or any applied license, including necessary licenses relating to any
+  third party copyrighted content included in the Work, and any third-party software necessary to
+  access, display, and run or print the Work. More specifically, Depositor warrants that any
+  jointly-owned or third-party owned material, such as graphs, images, photos, music, etc., is
+  clearly identified and acknowledged within the content of the Work, and Depositor is solely
+  responsible and will indemnify Stanford Libraries for any third party claims related to the Work,
+  including any third party content contained therein, as submitted.
+</p>
+<p>
+  Depositor further warrants that the Work does not violate any applicable law or agreement, or
+  infringe upon anyone's publicity, privacy or confidentiality rights, including but not limited to
+  privacy rights protected by HIPAA or FERPA. Depositor warrants that the Work does not
+  contain any high risk data, including but not limited to Social Security Numbers, driver’s license
+  numbers or bank account information. (More information is available at
+  <a href="https://uit.stanford.edu/guide/riskclassifications" target="_blank">https://uit.stanford.edu/guide/riskclassifications</a>.)
+  Depositor represents that depositing to the SDR does not violate an existing publication agreement,
+  Institutional Review Board (IRB), or contract governing deposited content. If the content is original
+  work derived from a source work produced and/or owned by a third-party, Depositor represents compliance
+  with the terms of use associated with that source work.
+</p>
+<p>
+  Depositor agrees to indemnify and hold harmless Stanford against any third party claims
+  (including those related to copyright, trademark or other intellectual property rights) arising out
+  of or relating to Stanford's deposit, display or other use of the Work as permitted or authorized
+  by this agreement.
+</p>
+<p>
+  <sup>[1]</sup> <small>Stanford Digital Repository Terms of Use: <%= Settings.access.use_and_reproduction_statement %></small>
+</p>

--- a/app/views/terms/show.html.erb
+++ b/app/views/terms/show.html.erb
@@ -1,0 +1,3 @@
+<turbo-frame id="termsOfDeposit">
+  <%= render 'show' %>
+</turbo-frame>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resource :terms, only: :show
+
   resources :first_draft_collections, only: %i[new create edit update]
   resources :collection_versions, only: %i[show destroy edit update] do
     member do


### PR DESCRIPTION


## Why was this change made?

This avoids having pages of legal text hidden on every page and makes it easier to debug broken request tests

## How was this change tested?



## Which documentation and/or configurations were updated?



