### PR TITLE
Don't log changes two times

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -27,7 +27,6 @@ class WorksController < ObjectsController
 
     @form = work_form(work_version)
     if @form.validate(work_params) && @form.save
-      work.event_context = { user: current_user }
       after_save(form: @form)
     else
       @form.prepopulate!

--- a/app/services/work_observer.rb
+++ b/app/services/work_observer.rb
@@ -4,7 +4,13 @@
 # Actions that happen when something happens to a work
 class WorkObserver
   def self.before_transition(work_version, transition)
-    work_version.work.events.create(work_version.work.event_context.merge(event_type: transition.event))
+    attributes = work_version.work.event_context.merge(event_type: transition.event)
+
+    # an begin_deposit event is always preceded by a update_metadata event.
+    # We don't want to log the description for that event twice, so clear it out.
+    attributes = attributes.except(:description) if transition.event == :begin_deposit
+
+    work_version.work.events.create(attributes)
   end
 
   def self.after_transition(work_version, transition)

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -148,6 +148,11 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
         expect(page).to have_content 'Citation from user input'
         expect(page).to have_content 'Everyone'
         expect(page).to have_content 'CC0-1.0'
+
+        within '#events' do
+          # The things that have been updated should only be logged in one event
+          expect(page).to have_content 'title of deposit modified', count: 1
+        end
       end
     end
 


### PR DESCRIPTION


## Why was this change made?

Previously we were logging changes on the update and then on the deposit events.

## How was this change tested?



## Which documentation and/or configurations were updated?



