### PR TITLE
Specify types on nested models to prevent them being marked as changed

### DIFF
--- a/app/components/works/file_row_component.html.erb
+++ b/app/components/works/file_row_component.html.erb
@@ -31,7 +31,6 @@
 
   <div class="dz-details col-md-2">
     <%= form.hidden_field :_destroy %>
-    <%= form.hidden_field :file %>
     <%= form.check_box :hide, class: 'form-check-input' %>
     <%= form.label :hide, 'Hide file', class: 'form-check-label col-form-label ' %>
     <%= render PopoverComponent.new key: 'work.hide_file' %>

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -77,13 +77,13 @@ class DraftWorkForm < Reform::Form
   end
 
   contributor = lambda { |*|
-    property :id
+    property :id, type: Dry::Types['params.nil'] | Dry::Types['params.integer']
     property :first_name
     property :last_name
     property :full_name
     property :role_term
-    property :_destroy, virtual: true
-    property :weight
+    property :_destroy, virtual: true, type: Dry::Types['params.nil'] | Dry::Types['params.bool']
+    property :weight, type: Dry::Types['params.nil'] | Dry::Types['params.integer']
   }
 
   collection :contributors,
@@ -101,50 +101,46 @@ class DraftWorkForm < Reform::Form
   collection :attached_files,
              populator: AttachedFilesPopulator.new(:attached_files, AttachedFile),
              on: :work_version do
-    property :id
+    property :id, type: Dry::Types['params.nil'] | Dry::Types['params.integer']
     property :label
-    property :hide
-    # The file property is virtual so it doesn't get set on update, which causes:
-    # ArgumentError: Could not find or build blob
-    # So we set it manually when creating.
-    property :file, virtual: true
-    property :_destroy, virtual: true
+    property :hide, type: Dry::Types['params.bool']
+    property :_destroy, virtual: true, type: Dry::Types['params.nil'] | Dry::Types['params.bool']
   end
 
   collection :contact_emails, populator: ContactEmailsPopulator.new(:contact_emails, ContactEmail),
                               prepopulator: ->(*) { contact_emails << ContactEmail.new if contact_emails.blank? },
                               on: :work_version do
-    property :id
+    property :id, type: Dry::Types['params.nil'] | Dry::Types['params.integer']
     property :email
-    property :_destroy, virtual: true
+    property :_destroy, virtual: true, type: Dry::Types['params.nil'] | Dry::Types['params.bool']
   end
 
   collection :keywords,
              populator: KeywordsPopulator.new(:keywords, Keyword),
              prepopulator: ->(*) { keywords << Keyword.new if keywords.blank? },
              on: :work_version do
-    property :id
+    property :id, type: Dry::Types['params.nil'] | Dry::Types['params.integer']
     property :label
     property :uri
-    property :_destroy, virtual: true
+    property :_destroy, virtual: true, type: Dry::Types['params.nil'] | Dry::Types['params.bool']
   end
 
   collection :related_works,
              populator: RelatedWorksPopulator.new(:related_works, RelatedWork),
              prepopulator: ->(*) { related_works << RelatedWork.new if related_works.blank? },
              on: :work_version do
-    property :id
+    property :id, type: Dry::Types['params.nil'] | Dry::Types['params.integer']
     property :citation
-    property :_destroy, virtual: true
+    property :_destroy, virtual: true, type: Dry::Types['params.nil'] | Dry::Types['params.bool']
   end
 
   collection :related_links, populator: RelatedLinksPopulator.new(:related_links, RelatedLink),
                              prepopulator: ->(*) { related_links << RelatedLink.new if related_links.blank? },
                              on: :work_version do
-    property :id
+    property :id, type: Dry::Types['params.nil'] | Dry::Types['params.integer']
     property :link_title
     property :url
-    property :_destroy, virtual: true
+    property :_destroy, virtual: true, type: Dry::Types['params.nil'] | Dry::Types['params.bool']
   end
 
   def collection

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe WorkForm do
       expect(form.attached_files.size).to eq 1
       expect(form.attached_files.first.label).to eq 'hello'
       expect(form.attached_files.first.hide).to be true
-      expect(form.attached_files.first.file).to eq blob.signed_id
+      expect(form.attached_files.first.model.file.blob_id).to eq blob.id
     end
   end
 

--- a/spec/services/work_version_event_description_builder_spec.rb
+++ b/spec/services/work_version_event_description_builder_spec.rb
@@ -6,11 +6,15 @@ require 'rails_helper'
 RSpec.describe WorkVersionEventDescriptionBuilder do
   subject(:result) { described_class.build(form) }
 
-  let(:work_version) { create(:work_version_with_work, collection: build(:collection)) }
+  let(:work_version) { create(:work_version_with_work, collection: build(:collection, :depositor_selects_access)) }
   let(:work) { work_version.work }
   let(:form) { DraftWorkForm.new(work_version: work_version, work: work) }
 
   context 'when nothing has changed' do
+    before do
+      form.validate({})
+    end
+
     it { is_expected.to be_blank }
   end
 
@@ -37,25 +41,33 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
   end
 
   context 'when many fields have changed' do
+    let(:params) do
+      ActionController::Parameters.new(
+        title: 'new title', abstract: 'foo',
+        contact_emails: [{ 'email' => 'foo@bar.io' }],
+        authors: [{ 'role_term' => 'person|Author', 'first_name' => 'Megan' }],
+        contributors: [{ 'role_term' => 'person|Author', 'first_name' => 'Sara' }],
+        related_links: [{ 'link_title' => 'Hey', 'url' => 'http://io.io' }],
+        related_works: [{ 'citation' => 'Hey' }],
+        'published(1i)' => '2020',
+        'created(1i)' => '2020',
+        keywords: [{ 'label' => 'Brown coal' }],
+        release: 'embargo',
+        'embargo_date(1i)' => '2021', 'embargo_date(2i)' => '3', 'embargo_date(3i)' => '3',
+        license: 'ODbL-1.0',
+        access: 'stanford',
+        citation: 'Lorem ipsum',
+        subtype: %w[foo bar],
+        attached_files_attributes: { '0' =>
+                      { 'label' => '', '_destroy' => 'false', 'hide' => '0',
+                        'file' => 'eyJfcmFpbHMiOnsibWVzc2FnZS...' } }
+      )
+    end
+
     before do
       allow(AttachedFile).to receive(:new).and_return(AttachedFile.new)
 
-      form.validate(title: 'new title', abstract: 'foo',
-                    contact_emails: [{ 'email' => 'foo@bar.io' }],
-                    authors: [{ 'role_term' => 'person|Author', 'first_name' => 'Megan' }],
-                    contributors: [{ 'role_term' => 'person|Author', 'first_name' => 'Sara' }],
-                    related_links: [{ 'link_title' => 'Hey', 'url' => 'http://io.io' }],
-                    related_works: [{ 'citation' => 'Hey' }],
-                    published_edtf: '2020', created_edtf: '2020',
-                    keywords: [{ 'label' => 'Brown coal' }],
-                    license: 'http://cc.org/cc0-1.0',
-                    access: 'stanford',
-                    embargo_date: '2099-07-01',
-                    citation: 'Lorem ipsum',
-                    subtype: %w[foo bar],
-                    attached_files: [
-                      { 'label' => 'xml.svg', 'hide' => false, 'file' => '123782312abcdef' }
-                    ])
+      form.validate(params)
     end
 
     it 'has a complete description' do


### PR DESCRIPTION
## Why was this change made?

Otherwise it considers these to have changed because _destroy being set to an empty string is considered a change from it being false

Fixes #1695

## How was this change tested?



## Which documentation and/or configurations were updated?



