### PR TITLE
Remove blank URIs from cocina.

### DIFF
--- a/app/services/description_generator.rb
+++ b/app/services/description_generator.rb
@@ -62,7 +62,8 @@ class DescriptionGenerator
   sig { returns(T::Array[Cocina::Models::DescriptiveValue]) }
   def keywords
     work_version.keywords.map do |keyword|
-      Cocina::Models::DescriptiveValue.new(value: T.must(keyword.label), type: 'topic', uri: keyword.uri)
+      props = { value: T.must(keyword.label), type: 'topic', uri: keyword.uri.presence }.compact
+      Cocina::Models::DescriptiveValue.new(props)
     end
   end
 

--- a/spec/services/description_generator_spec.rb
+++ b/spec/services/description_generator_spec.rb
@@ -489,4 +489,16 @@ RSpec.describe DescriptionGenerator do
       expect(model[:note]).to be nil
     end
   end
+
+  context 'with subject that has a blank URI' do
+    let(:keyword) { build(:keyword, uri: '') }
+
+    let(:work_version) do
+      build(:work_version, keywords: [keyword])
+    end
+
+    it 'does not add URI to model' do
+      expect(model[:subject]).to eq [{ value: 'MyKeyword', type: 'topic' }]
+    end
+  end
 end


### PR DESCRIPTION
closes #1697

## Why was this change made?
Depositing was failing due to roundtrip validation errors because empty URIs are removed in dor-services-app mapping.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


