### PR TITLE
Do not send redundant/unnecessary participant change notifications.

### DIFF
--- a/app/models/collection_change_set.rb
+++ b/app/models/collection_change_set.rb
@@ -43,8 +43,17 @@ class CollectionChangeSet
 
   sig { returns(T::Boolean) }
   def participants_changed?
-    added_managers.present? || added_depositors.present? || added_reviewers.present? ||
-      removed_managers.present? || removed_depositors.present? || removed_reviewers.present?
+    changed_participants.present?
+  end
+
+  sig { returns(T::Array[User]) }
+  def changed_participants
+    (added_managers +
+      added_depositors +
+      added_reviewers +
+      removed_managers +
+      removed_depositors +
+      removed_reviewers).uniq
   end
 
   sig { returns(String) }

--- a/app/services/collection_observer.rb
+++ b/app/services/collection_observer.rb
@@ -101,9 +101,12 @@ class CollectionObserver
   def self.send_participant_change_emails(collection, change_set)
     return unless collection.email_when_participants_changed? && change_set.participants_changed?
 
-    (collection.managed_by + collection.reviewed_by).each do |user|
-      CollectionsMailer.with(collection_version: collection.head, user: user)
-                       .participants_changed_email.deliver_later
+    (collection.managed_by + collection.reviewed_by).uniq.each do |user|
+      # Don't send if the user is the only changed participant.
+      unless change_set.changed_participants == [user]
+        CollectionsMailer.with(collection_version: collection.head, user: user)
+                         .participants_changed_email.deliver_later
+      end
     end
   end
   private_class_method :send_participant_change_emails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,3 +96,5 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 end
+
+RSpec::Matchers.define_negated_matcher :not_to_have_enqueued_job, :have_enqueued_job


### PR DESCRIPTION
closes #973

## Why was this change made?
Users were being sent gratuitous emails.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


