### PR TITLE
Run the cron job on prod

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,7 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-# TODO: add the 'cron' environment when we roll out in production
-server 'sul-h2-prod.stanford.edu', user: 'h2', roles: %w[web app db]
+server 'sul-h2-prod.stanford.edu', user: 'h2', roles: %w[web app db cron]
 
 Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
## Why was this change made?

Now that we are in production, we want to alert users that they have unfinished deposits they need to finish.

## How was this change tested?



## Which documentation and/or configurations were updated?



