### PR TITLE
Disable reviewers when review workflow turned off.

### DIFF
--- a/app/components/first_draft_collections/create/settings_component.html.erb
+++ b/app/components/first_draft_collections/create/settings_component.html.erb
@@ -97,14 +97,14 @@
     </div>
   </section>
 
-  <section id="review">
+  <section id="review" data-controller="review-workflow">
     <header>Review Workflow</header>
 
     <div class="mb-3 row">
       <%= tag.span t('hints.collection.review_enabled'), class: 'col-sm-10 col-xl-8 col-form-label' %>
       <div class="col-sm-3">
         <div class="form-check form-switch">
-          <%= form.check_box :review_enabled, { class: 'form-check-input' }, 'true', 'false' %>
+          <%= form.check_box :review_enabled, { class: 'form-check-input', data: { action: 'review-workflow#toggle', review_workflow_target: 'enabled' } }, 'true', 'false' %>
           <%= form.label :review_enabled, 'Enable Review Workflow', class: "form-check-label" %>
         </div>
       </div>
@@ -118,7 +118,7 @@
         <%= render PopoverComponent.new key: 'collection.reviewers' %>
       </div>
       <div class="col-sm-10 col-xl-8">
-        <%= form.text_field :reviewer_sunets, class: "form-control", required: false %> <!-- TODO: should prob have at least one required if enabled? -->
+        <%= form.text_field :reviewer_sunets, class: "form-control", required: false, data: { review_workflow_target: 'reviewers' } %> <!-- TODO: should prob have at least one required if enabled? -->
         <div class="invalid-feedback">You must provide reviewers</div>
       </div>
     </div>

--- a/app/packs/controllers/review_workflow_controller.js
+++ b/app/packs/controllers/review_workflow_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = [ "enabled", "reviewers" ]
+
+  connect() {
+    this.toggle()
+  }
+
+  toggle() {
+    this.reviewersTarget.disabled = !this.enabledTarget.checked
+  }
+}

--- a/spec/features/create_new_collection_spec.rb
+++ b/spec/features/create_new_collection_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe 'Create a new collection', js: true do
 
       expect(page).to have_content('Send email to Depositors whose status has changed.')
 
+      find_field 'Additional Reviewers', disabled: true
+      check 'Enable Review Workflow'
+      find_field 'Additional Reviewers'
+
       # breadcrumbs showing
       find('#breadcrumbs') do |nav|
         expect(nav).to have_content('Dashboard')


### PR DESCRIPTION
closes #1702.

## Why was this change made?
Confusing for user to be able to enter reviewers when review workflow turned off.


## How was this change tested?
Local, unit


## Which documentation and/or configurations were updated?
NA


