### PR TITLE
Switches to canonical PURLs.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -41,7 +41,7 @@ autocomplete_lookup:
 file_uploads_root: tmp/uploads
 
 faq_url: https://library.stanford.edu/research/stanford-digital-repository/terms-deposit
-purl_url: https://purl.stanford.edu
+purl_url: http://purl.stanford.edu
 terms_url: https://stanford.app.box.com/s/lozngarhdzj56z44la38v1zn3a1ggbyu
 
 host: <%= Socket.gethostname %>

--- a/spec/components/dashboard/collection_component_spec.rb
+++ b/spec/components/dashboard/collection_component_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Dashboard::CollectionComponent, type: :component do
     end
 
     it 'renders a link to purl' do
-      expect(rendered.css('a').map { |node| node['href'] }).to include 'https://purl.stanford.edu/yq268qt4607'
+      expect(rendered.css('a').map { |node| node['href'] }).to include 'http://purl.stanford.edu/yq268qt4607'
     end
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Collection do
     context 'with a druid' do
       it 'constructs purl' do
         collection.update(druid: 'druid:hb093rg5848')
-        expect(collection.purl).to eq('https://purl.stanford.edu/hb093rg5848')
+        expect(collection.purl).to eq('http://purl.stanford.edu/hb093rg5848')
       end
     end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Work do
     context 'with a druid' do
       it 'constructs purl' do
         work.update(druid: 'druid:hb093rg5848')
-        expect(work.purl).to eq('https://purl.stanford.edu/hb093rg5848')
+        expect(work.purl).to eq('http://purl.stanford.edu/hb093rg5848')
       end
     end
 

--- a/spec/services/collection_generator_spec.rb
+++ b/spec/services/collection_generator_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe CollectionGenerator do
               value: 'Test title'
             }
           ],
-          purl: 'https://purl.stanford.edu/bk123gh4567',
+          purl: 'http://purl.stanford.edu/bk123gh4567',
           access: {
             accessContact: [
               {

--- a/spec/services/request_generator_spec.rb
+++ b/spec/services/request_generator_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe RequestGenerator do
             ],
             form: types_form,
             access: { digitalRepository: [{ value: 'Stanford Digital Repository' }] },
-            purl: 'https://purl.stanford.edu/bk123gh4567'
+            purl: 'http://purl.stanford.edu/bk123gh4567'
           },
           identification: {
             sourceId: "hydrus:object-#{work_version.work.id}"
@@ -305,7 +305,7 @@ RSpec.describe RequestGenerator do
             ],
             form: types_form,
             access: { digitalRepository: [{ value: 'Stanford Digital Repository' }] },
-            purl: 'https://purl.stanford.edu/bk123gh4567'
+            purl: 'http://purl.stanford.edu/bk123gh4567'
           },
           identification: {
             sourceId: "hydrus:object-#{work_version.work.id}"


### PR DESCRIPTION
closes #1710

## Why was this change made?
So that roundtrip validation succeeds when submitting update.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


