### PR TITLE
Restore the hidden file field

### DIFF
--- a/app/components/works/file_row_component.html.erb
+++ b/app/components/works/file_row_component.html.erb
@@ -31,6 +31,7 @@
 
   <div class="dz-details col-md-2">
     <%= form.hidden_field :_destroy %>
+    <%= form.hidden_field :file %>
     <%= form.check_box :hide, class: 'form-check-input' %>
     <%= form.label :hide, 'Hide file', class: 'form-check-label col-form-label ' %>
     <%= render PopoverComponent.new key: 'work.hide_file' %>

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -107,6 +107,8 @@ class DraftWorkForm < Reform::Form
     property :id, type: Dry::Types['params.nil'] | Dry::Types['params.integer']
     property :label
     property :hide, type: Dry::Types['params.bool']
+    # The file property is only necessary if there is a server side validation error and we need to re-render the form.
+    property :file, virtual: true
     property :_destroy, virtual: true, type: Dry::Types['params.nil'] | Dry::Types['params.bool']
   end
 


### PR DESCRIPTION


## Why was this change made?

This was removed as part of https://github.com/sul-dlss/happy-heron/commit/770a7ba4a0ef6ac2bfc8aa1b6511ab41319942eb#diff-81e6b6427ea21d10a73dc41dd6b55cbdccd6002a200ddf5cce9b5e26daee19f6

However, this field is necessary when we redraw the form after a server side validation fails (such as the embargo date is in the past).

Fixes #1352
Fixes #1700

## How was this change tested?



## Which documentation and/or configurations were updated?



