### PR TITLE
Records correct changes when creating a new version.

### DIFF
--- a/spec/requests/edit_work_spec.rb
+++ b/spec/requests/edit_work_spec.rb
@@ -49,10 +49,11 @@ RSpec.describe 'Updating an existing work' do
             license: 'CC0-1.0',
             release: 'immediate'
           }.tap do |param|
+            # Keywords aren't changing.
             work_version.keywords.each_with_object(param[:keywords_attributes]).with_index do |(keyword, attrs), index|
               attrs[index.to_s] =
-                { '_destroy' => 'false', 'id' => keyword.id, 'label' => 'Feminism',
-                  'uri' => 'http://id.worldcat.org/fast/922671' }
+                { '_destroy' => '', 'id' => keyword.id, 'label' => keyword.label,
+                  'uri' => keyword.uri }
             end
 
             work_version.authors.each_with_object(param[:authors_attributes]).with_index do |(author, attrs), index|
@@ -78,6 +79,9 @@ RSpec.describe 'Updating an existing work' do
           expect(CollectionObserver).to have_received(:version_draft_created)
           expect(WorkVersion.where(work: work).count).to eq 2
           expect(work.reload.head).to be_version_draft
+          # Only changed fields are recorded in event.
+          expect(work.events.first.description).to eq('title of deposit modified, contact email modified, ' \
+            'authors modified, file description changed')
           expect(response).to redirect_to(work)
         end
       end


### PR DESCRIPTION
closes #1694

## Why was this change made?
All properties that were collections were erroneously being reported as changed even if they weren't.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


