### PR TITLE
Disable honeybadger when working in the console

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,5 +41,11 @@ module HappyHeron
     config.action_cable.mount_path = '/cable'
 
     config.action_mailer.default_url_options = { host: Settings.host }
+
+    console do
+      Honeybadger.configure do |config|
+        config.report_data = false
+      end
+    end
   end
 end


### PR DESCRIPTION


## Why was this change made?

Typically when you have an error in the console, it's a typo or something you don't need everyone to know about.  This also cuts down on the SIGHUP errors if you leave your console open and it times out.

Fixes #1520

## How was this change tested?



## Which documentation and/or configurations were updated?



