### PR TITLE
Do not allow editing of FAST keywords. Allow deleting first keyword.

### DIFF
--- a/app/components/works/keywords_row_component.html.erb
+++ b/app/components/works/keywords_row_component.html.erb
@@ -1,21 +1,19 @@
 <div class="mb-3 row plain-container g-0">
   <div class="col-sm-6">
     <%= form.label :label, 'Keyword', class: 'col-form-label sr-only' %>
-    <div data-controller="autocomplete" data-autocomplete-url-value="/autocomplete" data-autocomplete-min-length-value="3" class="dropdown">
-      <%= form.text_field :label, { class: "form-control#{ 'is-invalid' if error?}", required: true, 'data-autocomplete-target': 'input' } %>
-      <%= form.hidden_field :uri, { required: true, 'data-autocomplete-target': 'hidden' }%>
+    <div data-controller="autocomplete autocomplete-edit" data-autocomplete-url-value="/autocomplete" data-autocomplete-min-length-value="3" class="dropdown">
+      <%= form.text_field :label, { class: "form-control#{ 'is-invalid' if error?}", required: true, 'data-autocomplete-target': 'input', 'data-autocomplete-edit-target': 'input' } %>
+      <%= form.hidden_field :uri, { required: true, 'data-autocomplete-target': 'hidden', 'data-autocomplete-edit-target': 'uri', 'data-action': 'autocomplete-edit#change' }%>
       <ul class="show dropdown-menu" data-autocomplete-target="results"></ul>
       <div class="invalid-feedback">Keyword must be filled in</div>
     </div>
   </div>
-  <% if not_first_keyword? %>
-    <div class="col-sm-1">
-      <%= button_tag type: 'button', class: 'btn btn-sm', aria: { label: 'Remove' },
-      data: { action: "click->nested-form#removeAssociation",
-              plain: true } do %>
-        <span class="far fa-trash-alt"></span>
-      <% end %>
-      <%= form.hidden_field :_destroy %>
-    </div>
-  <% end %>
+  <div class="col-sm-1">
+    <%= button_tag type: 'button', class: 'btn btn-sm', aria: { label: 'Remove' },
+    data: { action: "click->nested-form#removeAssociation",
+            plain: true } do %>
+      <span class="far fa-trash-alt"></span>
+    <% end %>
+    <%= form.hidden_field :_destroy %>
+  </div>
 </div>

--- a/app/packs/controllers/autocomplete_edit_controller.js
+++ b/app/packs/controllers/autocomplete_edit_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = ["uri", "input"]
+
+  connect() {
+    this.change()
+  }
+
+  change() {
+    if(this.uriTarget.value) {
+      this.inputTarget.readOnly = true
+    }
+  }
+}

--- a/app/packs/controllers/nested_form_controller.js
+++ b/app/packs/controllers/nested_form_controller.js
@@ -5,7 +5,7 @@ export default class extends Controller {
   static values = { selector: String }
 
   addAssociation(event) {
-    event.preventDefault()
+    if(event) event.preventDefault()
     this.add_itemTarget.insertAdjacentHTML('beforebegin', this.buildNewRowFromTemplate())
   }
 
@@ -15,6 +15,8 @@ export default class extends Controller {
     item.querySelectorAll('input').forEach((element) => element.required = false)
     item.querySelector("input[name*='_destroy']").value = 1
     item.style.display = 'none'
+
+    if(this.isOnlyAssociation(item)) this.addAssociation()
   }
 
   getItemForButton(button) {
@@ -23,5 +25,11 @@ export default class extends Controller {
 
   buildNewRowFromTemplate() {
     return this.templateTarget.innerHTML.replace(/TEMPLATE_RECORD/g, new Date().valueOf())
+  }
+
+  isOnlyAssociation(item) {
+    var onlyAssociation = true
+    item.parentNode.querySelectorAll(this.selectorValue).forEach((node) =>  {if(node.style.display === '') onlyAssociation = false})
+    return onlyAssociation
   }
 }


### PR DESCRIPTION
closes #1737

## Why was this change made?
Additional support for using FAST for keywords.


## How was this change tested?
QA


## Which documentation and/or configurations were updated?
NA


