### PR TITLE
Close modals before turbo caches.

### DIFF
--- a/app/packs/entrypoints/application.js
+++ b/app/packs/entrypoints/application.js
@@ -27,3 +27,10 @@ import 'simple-datatables'
 // const imagePath = (name) => images(name, true)
 
 require('modules/validate-forms')
+
+window.addEventListener("turbolinks:before-cache", function() {
+    // Close modal window
+    document.querySelectorAll('div.modal').forEach(function (elem) {
+        bootstrap.Modal.getInstance(elem).hide()
+    })
+})


### PR DESCRIPTION
closes #1357

## Why was this change made?
Turbo was caching with an open modal causing the modal to flash on page changes.


## How was this change tested?
Local


## Which documentation and/or configurations were updated?
NA


