### PR TITLE
Stop using publication year to construct citation.

### DIFF
--- a/app/components/works/publication_date_component.rb
+++ b/app/components/works/publication_date_component.rb
@@ -57,9 +57,8 @@ module Works
     def year_field
       number_field_tag "#{prefix}[published(1i)]", published_year,
                        data: {
-                         auto_citation_target: 'year',
                          date_validation_target: 'year',
-                         action: 'change->auto-citation#updateDisplay date-validation#change'
+                         action: 'date-validation#change'
                        },
                        id: "#{prefix}_published_year",
                        placeholder: 'year',

--- a/app/packs/controllers/auto_citation_controller.js
+++ b/app/packs/controllers/auto_citation_controller.js
@@ -3,7 +3,7 @@ import { Controller } from "stimulus";
 export default class extends Controller {
   static targets = ["titleField", "manual", "auto", "switch",
     "contributorFirst", "contributorLast", "contributorRole", "contributorOrg",
-    "year", "embargoYear", "embargo"];
+    "embargoYear", "embargo"];
 
   connect() {
     this.purl = this.data.get("purl") || ":link will be inserted here automatically when available:" // Use a real purl on a persisted item or a placeholder
@@ -72,17 +72,17 @@ export default class extends Controller {
     return this.titleFieldTarget.value
   }
 
-  get year() {
-    if (this.hasEmbargoTarget && this.embargoTarget.checked && this.yearTarget.value.length < 1) {
+  get embargoYear() {
+    if (this.hasEmbargoTarget && this.embargoTarget.checked) {
       return this.embargoYearTarget.value
     }
-    return this.yearTarget.value
+    return null
   }
 
   get date() {
     const date = new Date();
-    if (this.year) {
-      date.setYear(this.year)
+    if (this.embargoYear) {
+      date.setYear(this.embargoYear)
     }
     return `${date.getFullYear()}`
   }

--- a/spec/features/auto_citation_spec.rb
+++ b/spec/features/auto_citation_spec.rb
@@ -45,13 +45,6 @@ RSpec.describe 'Automatically generate a citation', js: true do
 
       # Citation now is one year ahead of today
       expect(elem.value).to have_content "Scully, D. (#{Time.zone.today.year + 1})"
-
-      # Change the publication year
-      fill_in 'Publication year', with: 1996
-      blur_from 'Publication year'
-
-      # Citation now has publication year
-      expect(elem.value).to have_content 'Scully, D. (1996)'
     end
   end
 end

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
         expect(page).to have_content('Deposit to this collection')
         click_link 'My Title'
 
-        expect(page).to have_content 'Keller, M. (2020). My Title. ' \
+        expect(page).to have_content "Keller, M. (#{Time.zone.today.year}). My Title. " \
                                      "Stanford Digital Repository. Available at #{WorkVersion::LINK_TEXT}"
       end
     end


### PR DESCRIPTION
closes #1801

## Why was this change made?
Per ticket.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


