### PR TITLE
Provides future DOI on item view page.

### DIFF
--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -38,7 +38,7 @@
       <tr>
         <th scope="row">DOI</th>
         <td>
-          <%= doi_link %>
+          <%= doi_value %>
         </td>
       </tr>
       <tr>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -58,3 +58,6 @@ notifications:
 
 access:
   use_and_reproduction_statement: User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.
+
+datacite:
+  prefix: '10.80343'

--- a/spec/components/works/detail_component_spec.rb
+++ b/spec/components/works/detail_component_spec.rb
@@ -74,14 +74,56 @@ RSpec.describe Works::DetailComponent, type: :component do
     end
   end
 
-  context 'with a DOI' do
-    let(:work_version) { build_stubbed(:work_version, :deposited, version: 2, work: work) }
-    let(:work) { build_stubbed(:work, doi: '10.25740/bc123df4567') }
+  describe 'DOI' do
+    context 'with a DOI' do
+      let(:work_version) { build_stubbed(:work_version, :deposited, version: 2, work: work) }
+      let(:work) { build_stubbed(:work, doi: '10.25740/bc123df4567') }
 
-    it 'renders the doi_link' do
-      expect(rendered.css('a[href="https://doi.org/10.25740/bc123df4567"]').to_html)
-        .to include 'https://doi.org/10.25740/bc123df4567'
-      expect(rendered.to_html).to include 'DOI assigned (see above)'
+      it 'renders the doi_link' do
+        expect(rendered.css('a[href="https://doi.org/10.25740/bc123df4567"]').to_html)
+          .to include 'https://doi.org/10.25740/bc123df4567'
+        expect(rendered.to_html).to include 'DOI assigned (see above)'
+      end
+    end
+
+    context 'with reserved PURL and collection automatically assigns DOI' do
+      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
+      let(:work) { build_stubbed(:work, collection: collection, assign_doi: false, druid: 'druid:bc123df4567') }
+      let(:collection) { build_stubbed(:collection, doi_option: 'yes') }
+
+      it 'renders the doi setting' do
+        expect(rendered.to_html).to include 'The DOI for this item will be DOI:10.80343/bc123df4567'
+      end
+    end
+
+    context 'with reserved PURL and collection allows depositor to select' do
+      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
+      let(:work) { build_stubbed(:work, collection: collection, assign_doi: false, druid: 'druid:bc123df4567') }
+      let(:collection) { build_stubbed(:collection, doi_option: 'depositor-selects') }
+
+      it 'renders the doi setting' do
+        expect(rendered.to_html).to include 'The DOI for this item will be DOI:10.80343/bc123df4567'
+      end
+    end
+
+    context 'without a reserved PURL and collection automatically assigns DOI' do
+      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
+      let(:work) { build_stubbed(:work, collection: collection, assign_doi: false) }
+      let(:collection) { build_stubbed(:collection, doi_option: 'yes') }
+
+      it 'renders the doi setting' do
+        expect(rendered.to_html).to include 'DOI will become available once the work has been deposited.'
+      end
+    end
+
+    context 'without a reserved PURL and depositor selects to assign' do
+      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
+      let(:work) { build_stubbed(:work, collection: collection, assign_doi: true) }
+      let(:collection) { build_stubbed(:collection, doi_option: 'depositor-selects') }
+
+      it 'renders the doi setting' do
+        expect(rendered.to_html).to include 'DOI will become available once the work has been deposited.'
+      end
     end
   end
 
@@ -107,11 +149,21 @@ RSpec.describe Works::DetailComponent, type: :component do
 
     context "when collection doesn't permit DOIs" do
       let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
-      let(:work) { build_stubbed(:work, collection: collection) }
+      let(:work) { build_stubbed(:work, collection: collection, assign_doi: true) }
       let(:collection) { build_stubbed(:collection, doi_option: 'no') }
 
       it 'renders the doi setting' do
         expect(rendered.to_html).to include 'DOI will not be assigned'
+      end
+    end
+
+    context 'when collection automatically assigns DOI' do
+      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
+      let(:work) { build_stubbed(:work, collection: collection, assign_doi: false) }
+      let(:collection) { build_stubbed(:collection, doi_option: 'yes') }
+
+      it 'renders the doi setting' do
+        expect(rendered.to_html).to include 'DOI not assigned'
       end
     end
   end


### PR DESCRIPTION
closes #1730

## Why was this change made?
So that the user knows what the future DOI will be.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


