### PR TITLE
move grouped dates on work edit page into fieldsets

### DIFF
--- a/app/components/works/available_date_component.html.erb
+++ b/app/components/works/available_date_component.html.erb
@@ -1,40 +1,43 @@
-<div data-controller="complex-radio available-date">
-  <div class="mb-3 row">
-    <div class="col-sm-10 release-option" data-complex-radio-target="selection">
-      <%= form.radio_button :release, 'immediate', class: 'form-check-input',
-                            data: {
-                              action: 'complex-radio#disableUnselectedInputs change->auto-citation#updateDisplay available-date#clearError'
-                            } %>
-      <%= form.label :release_immediate, 'Immediately once deposit is completed' %>
-    </div>
-  </div>
-
-  <div class="embargo-date mb-5">
-    <div class="row<%= ' is-invalid' if error? %>">
+<fieldset>
+  <legend class="h5">Release date</legend>
+  <div data-controller="complex-radio available-date">
+    <div class="mb-3 row">
       <div class="col-sm-10 release-option" data-complex-radio-target="selection">
-        <%= form.radio_button :release, 'embargo', class: 'form-check-input',
+        <%= form.radio_button :release, 'immediate', class: 'form-check-input',
                               data: {
-                                action: 'complex-radio#disableUnselectedInputs change->auto-citation#updateDisplay available-date#validate',
-                                auto_citation_target: 'embargo'
+                                action: 'complex-radio#disableUnselectedInputs change->auto-citation#updateDisplay available-date#clearError'
                               } %>
-        <%= form.label :release_embargo, 'On this date' %>
-
-        <div class="year">
-          <label for="work_embargo_year" class="visually-hidden">Embargo year</label>
-          <%= year_field %>
-        </div>
-
-        <div class="month">
-          <label for="work_embargo_month" class="visually-hidden">Embargo month</label>
-          <%= month_field %>
-        </div>
-
-        <div class="day">
-          <label for="work_embargo_day" class="visually-hidden">Embargo day</label>
-          <%= day_field %>
-        </div>
+        <%= form.label :release_immediate, 'Immediately once deposit is completed' %>
       </div>
     </div>
-    <div class="invalid-feedback" data-available-date-target="error"><%= error_message %></div>
+
+    <div class="embargo-date mb-5">
+      <div class="row<%= ' is-invalid' if error? %>">
+        <div class="col-sm-10 release-option" data-complex-radio-target="selection">
+          <%= form.radio_button :release, 'embargo', class: 'form-check-input',
+                                data: {
+                                  action: 'complex-radio#disableUnselectedInputs change->auto-citation#updateDisplay available-date#validate',
+                                  auto_citation_target: 'embargo'
+                                } %>
+          <%= form.label :release_embargo, 'On this date' %>
+
+          <div class="year">
+            <label for="work_embargo_year" class="visually-hidden">Embargo year</label>
+            <%= year_field %>
+          </div>
+
+          <div class="month">
+            <label for="work_embargo_month" class="visually-hidden">Embargo month</label>
+            <%= month_field %>
+          </div>
+
+          <div class="day">
+            <label for="work_embargo_day" class="visually-hidden">Embargo day</label>
+            <%= day_field %>
+          </div>
+        </div>
+      </div>
+      <div class="invalid-feedback" data-available-date-target="error"><%= error_message %></div>
+    </div>
   </div>
-</div>
+</fieldset>

--- a/app/components/works/available_date_component.html.erb
+++ b/app/components/works/available_date_component.html.erb
@@ -1,5 +1,5 @@
 <fieldset>
-  <legend class="h5">Release date</legend>
+  <legend class="visually-hidden">Release date</legend>
   <div data-controller="complex-radio available-date">
     <div class="mb-3 row">
       <div class="col-sm-10 release-option" data-complex-radio-target="selection">

--- a/app/components/works/dates_component.html.erb
+++ b/app/components/works/dates_component.html.erb
@@ -6,117 +6,116 @@
                                                  min_year: min_year,
                                                  max_year: max_year) %>
 
-  <div class="mb-3 row">
-    <div class="col-sm-3 h6">
-      Creation date
-      <%= render PopoverComponent.new key: 'work.creation_date' %>
-    </div>
-  </div>
+<fieldset>
 
-  <div class="mb-3 row" data-complex-radio-target="selection">
-    <div class="col-sm-2">
-      <%= form.radio_button :created_type, 'single', class: 'form-check-input', data: { action: 'complex-radio#disableUnselectedInputs' } %>
-      <%= form.label :created_type_single, 'Single date' %>
-    </div>
-    <div data-controller="date-validation" class="col-sm-10">
-      <div class="year">
-        <label for="<%= prefix %>_created_year" class="visually-hidden">Created year</label>
-        <%= number_field_tag "#{prefix}[created(1i)]", created_year,
-            data: { date_validation_target: 'year', action: 'date-validation#change' },
-            id: "#{prefix}_created_year",
-            placeholder: 'year',
-            class: "form-control", min: min_year, max: max_year %>
-        <div class="invalid-feedback" data-date-validation-target="error"></div>
+    <legend class="h5">Creation date <%= render PopoverComponent.new key: 'work.creation_date' %></legend>
+
+    <div class="mb-3 row" data-complex-radio-target="selection">
+      <div class="col-sm-2">
+        <%= form.radio_button :created_type, 'single', class: 'form-check-input', data: { action: 'complex-radio#disableUnselectedInputs' } %>
+        <%= form.label :created_type_single, 'Single date' %>
       </div>
-      <div class="month">
-        <label for="<%= prefix %>_created_month" class="visually-hidden">Created month</label>
-        <%= select_month created_month, { prefix: prefix, field_name: 'created(2i)', prompt: 'month'},
-                         data: { date_validation_target: 'month', action: 'date-validation#change' },
-                         id: "#{prefix}_created_month", class: "form-control" %>
-      </div>
-
-      <div class="day">
-        <label for="<%= prefix %>_created_day" class="visually-hidden">Created day</label>
-        <%= select_day created_day, { prefix: prefix, field_name: 'created(3i)', prompt: 'day'},
-                       data: { date_validation_target: 'day', action: 'date-validation#change' },
-                       id: "#{prefix}_created_day", class: "form-control" %>
-      </div>
-       <div>
-       <%= check_box_tag "#{prefix}[created(approx0)]", true, created_approximate?, class: 'form-check-input' %>
-       <%= form.label 'created(approx0)', 'Approximate' %>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="mb-3 row" data-complex-radio-target="selection">
-    <div class="col-md-2">
-      <%= form.radio_button :created_type, 'range', class: 'form-check-input', data: { action: 'complex-radio#disableUnselectedInputs' } %>
-       <%= form.label :created_type_range, 'Date range' %>
-    </div>
-
-    <div class="col-md-10 date-range" data-controller="date-range">
-      <div class="start-date" data-controller="date-validation">
+      <div data-controller="date-validation" class="col-sm-10">
         <div class="year">
-          <label for="<%= prefix %>_created_range_start_year" class="visually-hidden">Created range start year</label>
-          <%= date_range_start_year %>
+          <label for="<%= prefix %>_created_year" class="visually-hidden">Created year</label>
+          <%= number_field_tag "#{prefix}[created(1i)]", created_year,
+              data: { date_validation_target: 'year', action: 'date-validation#change' },
+              id: "#{prefix}_created_year",
+              placeholder: 'year',
+              class: "form-control", min: min_year, max: max_year %>
           <div class="invalid-feedback" data-date-validation-target="error"></div>
-          <div class="invalid-feedback" data-date-range-target="startError"></div>
         </div>
         <div class="month">
-          <label for="<%= prefix %>_created_range_start_month" class="visually-hidden">Created range start month</label>
-          <%= select_month created_range_start_month,
-              { prefix: prefix, field_name: 'created_range(2i)', prompt: 'month'},
-              data: { date_validation_target: 'month', date_range_target: 'startMonth', action: 'date-range#change' },
-              id: "#{prefix}_created_range_start_month",
-              class: "form-control" %>
-        </div>
-        <div class="day">
-          <label for="<%= prefix %>_created_range_start_day" class="visually-hidden">Created range start day</label>
-          <%= select_day created_range_start_day,
-              { prefix: prefix, field_name: 'created_range(3i)', prompt: 'day'},
-              data: { date_validation_target: 'day', date_range_target: 'startDay', action: 'date-range#change' },
-              id: "#{prefix}_created_range_start_day",
-              class: "form-control" %>
-        </div>
-        <div>
-         <%= check_box_tag "#{prefix}[created_range(approx0)]", true, created_range_start_approximate?, class: 'form-check-input' %>
-         <label for="<%= prefix %>_created_range_start_approx">Approximate</label>
-        </div>
-      </div>
-
-      <div class="range-separator">
-        to
-      </div>
-
-      <div class="end-date" data-controller="date-validation">
-        <div class="year">
-          <label for="<%= prefix %>_created_range_end_year" class="visually-hidden">Created range end year</label>
-          <%= date_range_end_year %>
-          <div class="invalid-feedback" data-date-validation-target="error"></div>
-          <div class="invalid-feedback" data-date-range-target="endError"></div>
-        </div>
-        <div class="month">
-          <label for="<%= prefix %>_created_range_end_month" class="visually-hidden">Created range end month</label>
-          <%= select_month created_range_end_month,
-              { prefix: prefix, field_name: 'created_range(5i)', prompt: 'month' },
-              data: { date_validation_target: 'month', date_range_target: 'endMonth', action: 'date-range#change' },
-              id: "#{prefix}_created_range_end_month", class: "form-control" %>
+          <label for="<%= prefix %>_created_month" class="visually-hidden">Created month</label>
+          <%= select_month created_month, { prefix: prefix, field_name: 'created(2i)', prompt: 'month'},
+                          data: { date_validation_target: 'month', action: 'date-validation#change' },
+                          id: "#{prefix}_created_month", class: "form-control" %>
         </div>
 
         <div class="day">
-          <label for="<%= prefix %>_created_range_end_day" class="visually-hidden">Created range end day</label>
-          <%= select_day created_range_end_day,
-              { prefix: prefix, field_name: 'created_range(6i)', prompt: 'day' },
-              data: { date_validation_target: 'day', date_range_target: 'endDay', action: 'date-range#change' },
-              id: "#{prefix}_created_range_end_day", class: "form-control" %>
+          <label for="<%= prefix %>_created_day" class="visually-hidden">Created day</label>
+          <%= select_day created_day, { prefix: prefix, field_name: 'created(3i)', prompt: 'day'},
+                        data: { date_validation_target: 'day', action: 'date-validation#change' },
+                        id: "#{prefix}_created_day", class: "form-control" %>
         </div>
         <div>
-         <%= check_box_tag "#{prefix}[created_range(approx3)]", true, created_range_end_approximate?, class: 'form-check-input' %>
-         <label for="<%= prefix %>_created_range_end_approx">Approximate</label>
+        <%= check_box_tag "#{prefix}[created(approx0)]", true, created_approximate?, class: 'form-check-input' %>
+        <%= form.label 'created(approx0)', 'Approximate' %>
         </div>
       </div>
     </div>
-  </div>
+
+
+    <div class="mb-3 row" data-complex-radio-target="selection">
+      <div class="col-md-2">
+        <%= form.radio_button :created_type, 'range', class: 'form-check-input', data: { action: 'complex-radio#disableUnselectedInputs' } %>
+        <%= form.label :created_type_range, 'Date range' %>
+      </div>
+
+      <div class="col-md-10 date-range" data-controller="date-range">
+        <div class="start-date" data-controller="date-validation">
+          <div class="year">
+            <label for="<%= prefix %>_created_range_start_year" class="visually-hidden">Created range start year</label>
+            <%= date_range_start_year %>
+            <div class="invalid-feedback" data-date-validation-target="error"></div>
+            <div class="invalid-feedback" data-date-range-target="startError"></div>
+          </div>
+          <div class="month">
+            <label for="<%= prefix %>_created_range_start_month" class="visually-hidden">Created range start month</label>
+            <%= select_month created_range_start_month,
+                { prefix: prefix, field_name: 'created_range(2i)', prompt: 'month'},
+                data: { date_validation_target: 'month', date_range_target: 'startMonth', action: 'date-range#change' },
+                id: "#{prefix}_created_range_start_month",
+                class: "form-control" %>
+          </div>
+          <div class="day">
+            <label for="<%= prefix %>_created_range_start_day" class="visually-hidden">Created range start day</label>
+            <%= select_day created_range_start_day,
+                { prefix: prefix, field_name: 'created_range(3i)', prompt: 'day'},
+                data: { date_validation_target: 'day', date_range_target: 'startDay', action: 'date-range#change' },
+                id: "#{prefix}_created_range_start_day",
+                class: "form-control" %>
+          </div>
+          <div>
+          <%= check_box_tag "#{prefix}[created_range(approx0)]", true, created_range_start_approximate?, class: 'form-check-input' %>
+          <label for="<%= prefix %>_created_range_start_approx">Approximate</label>
+          </div>
+        </div>
+
+        <div class="range-separator">
+          to
+        </div>
+
+        <div class="end-date" data-controller="date-validation">
+          <div class="year">
+            <label for="<%= prefix %>_created_range_end_year" class="visually-hidden">Created range end year</label>
+            <%= date_range_end_year %>
+            <div class="invalid-feedback" data-date-validation-target="error"></div>
+            <div class="invalid-feedback" data-date-range-target="endError"></div>
+          </div>
+          <div class="month">
+            <label for="<%= prefix %>_created_range_end_month" class="visually-hidden">Created range end month</label>
+            <%= select_month created_range_end_month,
+                { prefix: prefix, field_name: 'created_range(5i)', prompt: 'month' },
+                data: { date_validation_target: 'month', date_range_target: 'endMonth', action: 'date-range#change' },
+                id: "#{prefix}_created_range_end_month", class: "form-control" %>
+          </div>
+
+          <div class="day">
+            <label for="<%= prefix %>_created_range_end_day" class="visually-hidden">Created range end day</label>
+            <%= select_day created_range_end_day,
+                { prefix: prefix, field_name: 'created_range(6i)', prompt: 'day' },
+                data: { date_validation_target: 'day', date_range_target: 'endDay', action: 'date-range#change' },
+                id: "#{prefix}_created_range_end_day", class: "form-control" %>
+          </div>
+          <div>
+          <%= check_box_tag "#{prefix}[created_range(approx3)]", true, created_range_end_approximate?, class: 'form-check-input' %>
+          <label for="<%= prefix %>_created_range_end_approx">Approximate</label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </fieldset>
 
 </section>

--- a/app/components/works/dates_component.html.erb
+++ b/app/components/works/dates_component.html.erb
@@ -8,7 +8,14 @@
 
 <fieldset>
 
-    <legend class="h5">Creation date <%= render PopoverComponent.new key: 'work.creation_date' %></legend>
+    <legend class="visually-hidden">Creation date</legend>
+
+    <div class="mb-3 row">
+      <div class="col-sm-3 h6">
+        Creation date
+        <%= render PopoverComponent.new key: 'work.creation_date' %>
+      </div>
+    </div>
 
     <div class="mb-3 row" data-complex-radio-target="selection">
       <div class="col-sm-2">

--- a/app/components/works/dates_component.html.erb
+++ b/app/components/works/dates_component.html.erb
@@ -6,7 +6,7 @@
                                                  min_year: min_year,
                                                  max_year: max_year) %>
 
-<fieldset>
+  <fieldset>
 
     <legend class="visually-hidden">Creation date</legend>
 


### PR DESCRIPTION
## Why was this change made?

Fixes #1827 - move input controls that are related to the same field into a single fieldset (just wrap the existing div) and ensure they have a legend.

## How was this change tested?

Localhost browser

## Which documentation and/or configurations were updated?



