### PR TITLE
Update to using the modern circle docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,19 @@
 version: 2.1
 orbs:
   node: circleci/node@4.1.0
+  ruby: circleci/ruby@1.1.4
+  browser-tools: circleci/browser-tools@1.1.3
 references:
-  default_ruby_version: &default_ruby_version 2.7.1-node-browsers
-  default_postgres_version: &default_postgres_version 11-alpine
+  default_ruby_version: &default_ruby_version 2.7-browsers
+  default_postgres_version: &default_postgres_version 13-ram
   ruby_envs: &ruby_envs
     environment:
       BUNDLE_JOBS: 3
       BUNDLE_RETRY: 3
-      BUNDLE_PATH: vendor/bundle
       PGHOST: 127.0.0.1
       PGPASSWORD: sekret
       RAILS_ENV: test
+      PAGER: cat # prevent psql commands using less
   postgres_envs: &postgres_envs
     environment:
       POSTGRES_DB: test
@@ -20,16 +22,16 @@ executors:
   default:
     parameters:
       ruby_tag:
-        description: "The `circleci/ruby` Docker image version tag."
+        description: "The `cimg/ruby` Docker image version tag."
         type: string
         default: *default_ruby_version
     docker:
-      - image: circleci/ruby:<< parameters.ruby_tag >>
+      - image: cimg/ruby:<< parameters.ruby_tag >>
         <<: *ruby_envs
   ruby_with_postgres:
     parameters:
       ruby_tag:
-        description: "The `circleci/ruby` Docker image version tag."
+        description: "The `cimg/ruby` Docker image version tag."
         type: string
         default: *default_ruby_version
       postgres_tag:
@@ -37,7 +39,7 @@ executors:
         type: string
         default: *default_postgres_version
     docker:
-      - image: circleci/ruby:<< parameters.ruby_tag >>
+      - image: cimg/ruby:<< parameters.ruby_tag >>
         <<: *ruby_envs
       - image: circleci/postgres:<< parameters.postgres_tag >>
         <<: *postgres_envs
@@ -46,53 +48,27 @@ jobs:
     executor: default
     steps:
       - checkout
-      - run:
-          name: Install bundler
-          command: gem install bundler
-      - run:
-          name: Which bundler?
-          command: bundle -v
-      - restore_cache:
-          keys:
-            - happy-heron-bundle-{{ checksum "Gemfile.lock" }}
-            - happy-heron-bundle-
-      - run:
-          name: Install Ruby dependencies
-          command: bundle check || bundle install
-      - save_cache:
-          key: happy-heron-bundle-{{ checksum "Gemfile.lock" }}
-          paths:
-            - vendor/bundle
-  lint:
+      - ruby/install-deps:
+          key: happy-heron-v2
+  checking:
     executor: default
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - happy-heron-bundle-{{ checksum "Gemfile.lock" }}
-            - happy-heron-bundle-
-      - run:
-          name: Lint using rubocop
-          command: bundle exec rubocop
-  typecheck:
-    executor: default
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - happy-heron-bundle-{{ checksum "Gemfile.lock" }}
-            - happy-heron-bundle-
+      - ruby/install-deps:
+          key: happy-heron-v2
       - run:
           name: Run static type checking
           command: bundle exec srb tc
+      - ruby/rubocop-check:
+          format: progress
+          label: Inspecting with Rubocop
   test:
     executor: ruby_with_postgres
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - happy-heron-bundle-{{ checksum "Gemfile.lock" }}
-            - happy-heron-bundle-
+      - ruby/install-deps:
+          key: happy-heron-v2
+      - browser-tools/install-chrome
       - run:
           name: Install psql
           command: sudo apt update && sudo apt install -y postgresql-client
@@ -127,10 +103,7 @@ workflows:
   build:
     jobs:
       - build
-      - lint:
-          requires:
-            - build
-      - typecheck:
+      - checking:
           requires:
             - build
       - test:

--- a/spec/services/orcid_service_spec.rb
+++ b/spec/services/orcid_service_spec.rb
@@ -12,10 +12,6 @@ RSpec.describe OrcidService do
   let(:body) { '{"last-modified-date":{"value":1460763728406},"name":{"created-date":{"value":1460763728406},"last-modified-date":{"value":1460763728406},"given-names":{"value":"Justin"},"family-name":{"value":"Littman"},"credit-name":null,"source":null,"visibility":"public","path":"0000-0003-1527-0030"},"other-names":{"last-modified-date":null,"other-name":[],"path":"/0000-0003-1527-0030/other-names"},"biography":null,"path":"/0000-0003-1527-0030/personal-details"}' }
   # rubocop:enable Layout/LineLength
 
-  before do
-    WebMock.disable_net_connect!
-  end
-
   context 'when bad orcid id' do
     let(:orcid) { 'abcd-efgh-ijkl-mnop' }
 


### PR DESCRIPTION


## Why was this change made?
https://circleci.com/developer/images/image/cimg/ruby#image-name states that cimg/ruby was designed to supercede the legacy circleci/ruby:* images


## How was this change tested?



## Which documentation and/or configurations were updated?



