### PR TITLE
Adds delay to flappy spec.

### DIFF
--- a/spec/features/delete_draft_collection_spec.rb
+++ b/spec/features/delete_draft_collection_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe 'Delete a draft collection', js: true do
       it 'allow users to delete the collection and destroys the model' do
         visit dashboard_path
 
+        # There is an occasional problem where the confirmation modal isn't triggered without a delay.
+        sleep(0.5)
+
         accept_confirm do
           within '#your-collections' do
             click_link "Delete #{collection_version.name}"


### PR DESCRIPTION
closes #1848

## Why was this change made?
So we can stop hitting the Circle re-run button.


## How was this change tested?



## Which documentation and/or configurations were updated?



