### PR TITLE
cocina generator: date range with end dates both approx tweak

### DIFF
--- a/app/services/cocina_generator/description/generator.rb
+++ b/app/services/cocina_generator/description/generator.rb
@@ -127,17 +127,26 @@ module CocinaGenerator
         )
       end
 
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/CyclomaticComplexity
       sig { params(date: EDTF::Interval).returns(T::Hash[T.untyped, T.untyped]) }
       def interval_props_for(date)
         structured_values = []
         structured_values << date_props_for(date.from, type: 'start') if date.from
         structured_values << date_props_for(date.to, type: 'end') if date.to
-        {
+        result_props = {
           structuredValue: structured_values
-        }.tap do |props|
-          props[:qualifier] = 'approximate' if date.from&.uncertain? || date.to&.uncertain?
+        }
+
+        if date.from&.uncertain? || date.to&.uncertain?
+          result_props[:qualifier] = 'approximate'
+          result_props[:structuredValue].each { |struct_date_val| struct_date_val.delete(:qualifier) }
         end
+
+        result_props.compact
       end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       sig { params(date: Date, type: T.nilable(String)).returns(T::Hash[T.untyped, T.untyped]) }
       def date_props_for(date, type: nil)

--- a/spec/services/cocina_generator/description/generator_spec.rb
+++ b/spec/services/cocina_generator/description/generator_spec.rb
@@ -514,8 +514,8 @@ RSpec.describe CocinaGenerator::Description::Generator do
                 {
                   encoding: { code: 'edtf' },
                   structuredValue: [
-                    { value: '2020-03-04', type: 'start', qualifier: 'approximate' },
-                    { value: '2020-10-31', type: 'end', qualifier: 'approximate' }
+                    { value: '2020-03-04', type: 'start' },
+                    { value: '2020-10-31', type: 'end' }
                   ],
                   qualifier: 'approximate',
                   type: 'creation'


### PR DESCRIPTION
## Why was this change made?

we were getting an HB roundtripping error

## How was this change tested?

unit test

## Which documentation and/or configurations were updated?



