### PR TITLE
update 'what is a doi?' links

### DIFF
--- a/app/components/first_draft_collections/create/settings_component.html.erb
+++ b/app/components/first_draft_collections/create/settings_component.html.erb
@@ -50,7 +50,7 @@
 
     <fieldset class="mb-5">
       <legend class="h5">Will a DOI be assigned to the deposits in this collection?* <%= render PopoverComponent.new key: 'collection.doi' %>
-        <%= link_to 'What is a DOI?', 'https://library.stanford.edu/data-services/doi-services' %>
+        <%= link_to 'What is a DOI?', 'https://library.stanford.edu/research/stanford-digital-repository/documentation/purls-and-dois' %>
       </legend>
       <div class="form-check">
         <%= form.radio_button :doi_option, 'yes', class: "form-check-input" %>

--- a/app/components/works/doi_component.html.erb
+++ b/app/components/works/doi_component.html.erb
@@ -3,7 +3,7 @@
     DOI assignment
 
   </legend>
-  <%= link_to 'What is a DOI?', 'https://library.stanford.edu/data-services/doi-services' %>
+  <%= link_to 'What is a DOI?', 'https://library.stanford.edu/research/stanford-digital-repository/documentation/purls-and-dois' %>
   <div class="mb-3 inner-container">
     <% if doi %>
       <p>The DOI assigned to this work is <%= link_to doi, doi %>.</p>


### PR DESCRIPTION
## Why was this change made?

Fixes #1865

![image](https://user-images.githubusercontent.com/96775/127907203-99b999de-360f-4ca1-aad3-e1d3cc9d02b0.png)

![image](https://user-images.githubusercontent.com/96775/127907316-8b89280c-9c4e-401f-a52e-77d19b55b46a.png)

## How was this change tested?

locally

## Which documentation and/or configurations were updated?



