### PR TITLE
Add orcid database field to contributors

### DIFF
--- a/db/migrate/20210802203252_add_orcid_to_abstract_contributors.rb
+++ b/db/migrate/20210802203252_add_orcid_to_abstract_contributors.rb
@@ -1,0 +1,5 @@
+class AddOrcidToAbstractContributors < ActiveRecord::Migration[6.1]
+  def change
+    add_column :abstract_contributors, :orcid, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -36,7 +36,8 @@ CREATE TABLE public.abstract_contributors (
     role character varying NOT NULL,
     full_name character varying,
     type character varying,
-    weight integer
+    weight integer,
+    orcid character varying
 );
 
 
@@ -1287,6 +1288,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210520161846'),
 ('20210527193102'),
 ('20210608161622'),
-('20210616201626');
+('20210616201626'),
+('20210802203252');
 
 


### PR DESCRIPTION
## Why was this change made?
So we can persist the orcid of a contributor.


## How was this change tested?



## Which documentation and/or configurations were updated?



