### PR TITLE
Adds display of ORCID to work detail page.

### DIFF
--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -94,18 +94,21 @@
     </tbody>
   </table>
 
-  <table class="table table-sm caption-header">
+  <table id="contributors" class="table table-sm caption-header">
     <caption>Authors and contributors
-      <%= render Works::EditLinkComponent.new(work_version: work_version,anchor: 'author', label: 'Edit authors and contributors') %>
+      <%= render Works::EditLinkComponent.new(work_version: work_version, anchor: 'author', label: 'Edit authors and contributors') %>
     </caption>
     <tbody>
     <% contributors.each do |contributor| %>
       <tr>
         <% if contributor.person? %>
-          <td><%= contributor.first_name %> <%= contributor.last_name %></td>
+          <td>
+            <%= contributor.first_name %> <%= contributor.last_name %>
+          </td>
         <% else %>
           <td><%= contributor.full_name %></td>
         <% end %>
+        <td><%= render Works::Show::OrcidComponent.new(orcid: contributor.orcid) %></td>
         <td><%= contributor.role %></td>
       </tr>
     <% end %>

--- a/app/components/works/show/orcid_component.html.erb
+++ b/app/components/works/show/orcid_component.html.erb
@@ -1,0 +1,5 @@
+<% if orcid %>
+  <%= link_to orcid do %>
+    <img loading="lazy" class="wp-image-9646" style="width: 16px;" src="https://info.orcid.org/wp-content/uploads/2020/12/orcid_16x16.gif" alt="orcid logo" width="16" height="16"> <%= orcid %>
+  <% end %>
+<% end %>

--- a/app/components/works/show/orcid_component.rb
+++ b/app/components/works/show/orcid_component.rb
@@ -1,0 +1,15 @@
+# typed: true
+# frozen_string_literal: true
+
+module Works
+  module Show
+    # Displays an ORCID id
+    class OrcidComponent < ApplicationComponent
+      def initialize(orcid:)
+        @orcid = orcid
+      end
+
+      attr_reader :orcid
+    end
+  end
+end

--- a/spec/components/works/detail_component_spec.rb
+++ b/spec/components/works/detail_component_spec.rb
@@ -74,6 +74,20 @@ RSpec.describe Works::DetailComponent, type: :component do
     end
   end
 
+  describe 'contributors' do
+    let(:work_version) { build_stubbed(:work_version, authors: [author1, author2], contributors: [contributor]) }
+    let(:author1) { build_stubbed(:person_author, orcid: 'https://orcid.org/0000-0002-1825-0097') }
+    let(:author2) { build_stubbed(:person_author) }
+    let(:contributor) { build_stubbed(:person_contributor, orcid: 'https://orcid.org/0000-0002-1825-0098') }
+
+    it 'renders the contributor' do
+      expect(rendered.css('#contributors a').to_html).to include('https://orcid.org/0000-0002-1825-0097')
+      expect(rendered.css('#contributors a').to_html).to include('https://orcid.org/0000-0002-1825-0098')
+      # Edit pencil and two links. No link for author without ORCID.
+      expect(rendered.css('#contributors').search('a').size).to eq 3
+    end
+  end
+
   describe '#created' do
     let(:work_version) { build_stubbed(:work_version, created_edtf: edtf) }
 


### PR DESCRIPTION
closes #1735

## Why was this change made?
Per ticket


## How was this change tested?
Unit, local


![image](https://user-images.githubusercontent.com/588335/128057730-c8fdc293-abd3-432d-af21-b4dca04ce4e5.png)

## Which documentation and/or configurations were updated?
NA


