### PR TITLE
request_generator: druid needed to assign doi

### DIFF
--- a/app/services/request_generator.rb
+++ b/app/services/request_generator.rb
@@ -61,7 +61,7 @@ class RequestGenerator
   # If the user decides they want a DOI minted on a new version, we need to set it here.
   def doi
     return work.doi if work.doi
-    return if work_version.first_draft? || !work.assign_doi?
+    return if !work.assign_doi? || work.druid.blank?
 
     "#{Settings.datacite.prefix}/#{work.druid.delete_prefix('druid:')}"
   end

--- a/spec/services/request_generator_spec.rb
+++ b/spec/services/request_generator_spec.rb
@@ -135,12 +135,11 @@ RSpec.describe RequestGenerator do
     end
   end
 
-  context 'with a druid' do
+  context 'with a druid, assign_doi is false' do
     let(:work_version) do
       build(:work_version, work_type: 'text', title: 'Test title', work: work)
     end
     let(:work) { build(:work, id: 7, druid: 'druid:bk123gh4567', collection: collection) }
-
     let(:expected_model) do
       {
         externalIdentifier: 'druid:bk123gh4567',
@@ -188,6 +187,10 @@ RSpec.describe RequestGenerator do
       }
     end
 
+    before do
+      allow(work).to receive(:assign_doi?).and_return(false)
+    end
+
     it 'generates the model' do
       expect(model.to_h).to eq expected_model
     end
@@ -198,7 +201,6 @@ RSpec.describe RequestGenerator do
       build(:work_version, work_type: 'text', title: 'Test title', work: work)
     end
     let(:work) { build(:work, id: 7, druid: 'druid:bk123gh4567', doi: '10.800/bk123gh4567', collection: collection) }
-
     let(:expected_model) do
       {
         externalIdentifier: 'druid:bk123gh4567',
@@ -252,12 +254,11 @@ RSpec.describe RequestGenerator do
     end
   end
 
-  context 'when a doi is requested' do
+  context 'when a doi is requested and there is a druid' do
     let(:work_version) do
       build(:work_version, :version_draft, work_type: 'text', title: 'Test title', work: work)
     end
     let(:work) { build(:work, id: 7, druid: 'druid:bk123gh4567', collection: collection) }
-
     let(:expected_model) do
       {
         externalIdentifier: 'druid:bk123gh4567',
@@ -311,6 +312,60 @@ RSpec.describe RequestGenerator do
     end
   end
 
+  context 'when a doi is requested and there is no druid' do
+    let(:work_version) do
+      build(:work_version, :version_draft, work_type: 'text', title: 'Test title', work: work)
+    end
+    let(:work) { build(:work, id: 7, druid: nil, collection: collection) }
+    let(:expected_model) do
+      {
+        type: 'http://cocina.sul.stanford.edu/models/object.jsonld',
+        label: 'Test title',
+        version: 1,
+        access: {
+          access: 'world',
+          download: 'world',
+          license: license_uri,
+          useAndReproductionStatement: Settings.access.use_and_reproduction_statement
+        },
+        administrative: {
+          hasAdminPolicy: 'druid:zx485kb6348',
+          partOfProject: project_tag
+        },
+        description: {
+          title: [
+            {
+              value: 'Test title'
+            }
+          ],
+          note: [
+            {
+              value: 'test abstract',
+              type: 'summary'
+            },
+            {
+              value: 'test citation',
+              type: 'preferred citation'
+            }
+          ],
+          form: types_form,
+          adminMetadata: admin_metadata
+        },
+        identification: {
+          sourceId: "hydrus:object-#{work_version.work.id}"
+        },
+        structural: {
+          contains: [],
+          isMemberOf: [collection.druid]
+        }
+      }
+    end
+
+    it 'generates the model' do
+      expect(model.to_h).to eq expected_model
+    end
+  end
+
   context 'when a file is present' do
     let!(:blob) do
       ActiveStorage::Blob.create_and_upload!(
@@ -325,6 +380,7 @@ RSpec.describe RequestGenerator do
       # rubocop:disable RSpec/MessageChain
       allow(attached_file).to receive_message_chain(:file, :attachment, :blob).and_return(blob)
       # rubocop:enable RSpec/MessageChain
+      allow(work).to receive(:assign_doi?).and_return(false)
     end
 
     after do


### PR DESCRIPTION
## Why was this change made?

Fixes bug - you can't assign a doi without a druid.

## How was this change tested?

unit tests;   will do more manual testing as I work on testing update_doi_metadata action in DSA, triggered from H2 in stage.

## Which documentation and/or configurations were updated?



