### PR TITLE
Double splat the kwargs to tag.button

### DIFF
--- a/app/components/citation_component.rb
+++ b/app/components/citation_component.rb
@@ -14,7 +14,7 @@ class CitationComponent < ApplicationComponent
 
     attrs[:disabled] = work_version.first_draft? || work_version.purl_reserved?
 
-    tag.button attrs do
+    tag.button(**attrs) do
       # It's a SafeBuffer, not a String
       tag.span(class: 'fas fa-quote-left') + ' Cite' # rubocop:disable Style/StringConcatenation
     end


### PR DESCRIPTION

## Why was this change made?
This prevents a deprecation warning like:
app/components/citation_component.rb:17: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call



## How was this change tested?



## Which documentation and/or configurations were updated?



