### PR TITLE
Related links that are purls have a special expression in cocina

### DIFF
--- a/app/services/cocina_generator/description/related_links_generator.rb
+++ b/app/services/cocina_generator/description/related_links_generator.rb
@@ -19,21 +19,43 @@ module CocinaGenerator
 
       sig { returns(T::Array[Cocina::Models::RelatedResource]) }
       def generate
-        object.related_links.map do |rel_link|
-          resource_attrs = {
-            access: Cocina::Models::DescriptiveAccessMetadata.new(
-              url: [Cocina::Models::DescriptiveValue.new(value: rel_link.url)]
-            )
-          }
-          resource_attrs[:title] = [{ value: rel_link.link_title }] if rel_link.link_title.present?
-          Cocina::Models::RelatedResource.new(resource_attrs)
-        end
+        object.related_links.map { |rel_link| build_related_link(rel_link) }
       end
 
       private
 
       sig { returns(T.any(CollectionVersion, WorkVersion)) }
       attr_reader :object
+
+      sig { params(rel_link: RelatedLink).returns(Cocina::Models::RelatedResource) }
+      def build_related_link(rel_link)
+        return purl_link(rel_link) if purl?(rel_link.url)
+
+        resource_attrs = {
+          access: Cocina::Models::DescriptiveAccessMetadata.new(
+            url: [Cocina::Models::DescriptiveValue.new(value: rel_link.url)]
+          )
+        }
+        resource_attrs[:title] = [{ value: rel_link.link_title }] if rel_link.link_title.present?
+        Cocina::Models::RelatedResource.new(resource_attrs)
+      end
+
+      sig { params(rel_link: RelatedLink).returns(Cocina::Models::RelatedResource) }
+      def purl_link(rel_link)
+        resource_attrs = {
+          purl: rel_link.url,
+          access: Cocina::Models::DescriptiveAccessMetadata.new(
+            digitalRepository: [Cocina::Models::DescriptiveValue.new(value: 'Stanford Digital Repository')]
+          )
+        }
+        resource_attrs[:title] = [{ value: rel_link.link_title }] if rel_link.link_title.present?
+        Cocina::Models::RelatedResource.new(resource_attrs)
+      end
+
+      sig { params(url: String).returns(T::Boolean) }
+      def purl?(url)
+        url.start_with?(Settings.purl_url)
+      end
     end
   end
 end

--- a/sorbet/custom/cocina-models.rbi
+++ b/sorbet/custom/cocina-models.rbi
@@ -43,7 +43,7 @@ module Cocina::Models
     sig do
         params(url: T.nilable(T::Array[DescriptiveValue]),
                accessContact: T.nilable(T::Array[T::Hash[T.untyped, T.untyped]]),
-               digitalRepository: T.nilable(T::Array[T::Hash[T.untyped, T.untyped]]),
+               digitalRepository: T.nilable(T::Array[DescriptiveValue]),
         ).void
     end
   def initialize(url: nil, accessContact: nil, digitalRepository: nil); end
@@ -63,9 +63,10 @@ module Cocina::Models
       params(type: T.nilable(String),
              access: DescriptiveAccessMetadata,
              title: T::Array[DescriptiveValue],
-             note: T::Array[DescriptiveValue]).void
+             note: T::Array[DescriptiveValue],
+             purl: T.nilable(String)).void
     end
-    def initialize(type: nil, access: nil, title: nil, note: nil); end
+    def initialize(type: nil, access: nil, title: nil, note: nil, purl: nil); end
   end
 
   class DROStructural

--- a/spec/services/cocina_generator/description/related_links_generator_spec.rb
+++ b/spec/services/cocina_generator/description/related_links_generator_spec.rb
@@ -1,0 +1,50 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CocinaGenerator::Description::RelatedLinksGenerator do
+  subject(:model) { described_class.generate(object: work_version).map(&:to_h) }
+
+  context 'with external URIs' do
+    let(:work_version) do
+      build(:work_version, related_links: [build(:related_link), build(:related_link)])
+    end
+
+    it 'creates related links' do
+      expect(model).to eq([
+                            {
+                              title: [{ value: 'My Awesome Research' }],
+                              access: { url: [{ value: 'http://my.awesome.research.io' }] }
+                            },
+                            {
+                              title: [{ value: 'My Awesome Research' }],
+                              access: { url: [{ value: 'http://my.awesome.research.io' }] }
+                            }
+                          ])
+    end
+  end
+
+  context 'with PURL URIs' do
+    let(:work_version) do
+      build(:work_version, related_links: [
+              build(:related_link, url: 'http://purl.stanford.edu/tx853fp2857'),
+              build(:related_link)
+            ])
+    end
+
+    it 'creates related links' do
+      expect(model).to eq([
+                            {
+                              purl: 'http://purl.stanford.edu/tx853fp2857',
+                              title: [{ value: 'My Awesome Research' }],
+                              access: { digitalRepository: [{ value: 'Stanford Digital Repository' }] }
+                            },
+                            {
+                              title: [{ value: 'My Awesome Research' }],
+                              access: { url: [{ value: 'http://my.awesome.research.io' }] }
+                            }
+                          ])
+    end
+  end
+end


### PR DESCRIPTION


## Why was this change made?
This prevents DSA from raising a round trip error when PURL links are provided.


## How was this change tested?



## Which documentation and/or configurations were updated?



