### PR TITLE
Normalize related links that are purls using https

### DIFF
--- a/app/services/cocina_generator/description/related_links_generator.rb
+++ b/app/services/cocina_generator/description/related_links_generator.rb
@@ -15,6 +15,7 @@ module CocinaGenerator
       sig { params(object: T.any(CollectionVersion, WorkVersion)).void }
       def initialize(object:)
         @object = object
+        @purl_host = T.let(Settings.purl_url.sub(%r{^https?://}, ''), String)
       end
 
       sig { returns(T::Array[Cocina::Models::RelatedResource]) }
@@ -26,6 +27,9 @@ module CocinaGenerator
 
       sig { returns(T.any(CollectionVersion, WorkVersion)) }
       attr_reader :object
+
+      sig { returns(String) }
+      attr_reader :purl_host
 
       sig { params(rel_link: RelatedLink).returns(Cocina::Models::RelatedResource) }
       def build_related_link(rel_link)
@@ -41,9 +45,10 @@ module CocinaGenerator
       end
 
       sig { params(rel_link: RelatedLink).returns(Cocina::Models::RelatedResource) }
+      # This normalizes the PURL link to http (as it is currently the canonincal PURL)
       def purl_link(rel_link)
         resource_attrs = {
-          purl: rel_link.url,
+          purl: rel_link.url.sub(/^https/, 'http'),
           access: Cocina::Models::DescriptiveAccessMetadata.new(
             digitalRepository: [Cocina::Models::DescriptiveValue.new(value: 'Stanford Digital Repository')]
           )
@@ -54,7 +59,7 @@ module CocinaGenerator
 
       sig { params(url: String).returns(T::Boolean) }
       def purl?(url)
-        url.start_with?(Settings.purl_url)
+        url.start_with?("https://#{purl_host}") || url.start_with?("http://#{purl_host}")
       end
     end
   end

--- a/spec/services/cocina_generator/description/related_links_generator_spec.rb
+++ b/spec/services/cocina_generator/description/related_links_generator_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe CocinaGenerator::Description::RelatedLinksGenerator do
     let(:work_version) do
       build(:work_version, related_links: [
               build(:related_link, url: 'http://purl.stanford.edu/tx853fp2857'),
+              build(:related_link, url: 'https://purl.stanford.edu/xy933bc2222'),
               build(:related_link)
             ])
     end
@@ -37,6 +38,11 @@ RSpec.describe CocinaGenerator::Description::RelatedLinksGenerator do
       expect(model).to eq([
                             {
                               purl: 'http://purl.stanford.edu/tx853fp2857',
+                              title: [{ value: 'My Awesome Research' }],
+                              access: { digitalRepository: [{ value: 'Stanford Digital Repository' }] }
+                            },
+                            {
+                              purl: 'http://purl.stanford.edu/xy933bc2222',
                               title: [{ value: 'My Awesome Research' }],
                               access: { digitalRepository: [{ value: 'Stanford Digital Repository' }] }
                             },


### PR DESCRIPTION


## Why was this change made?
Because otherwise DSA will fail these from round tripping


## How was this change tested?



## Which documentation and/or configurations were updated?



