### PR TITLE
Upgrade turbo-rails to a released version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem 'sneakers', '~> 2.11' # rabbitMQ background processing
 gem 'sorbet-rails', '~> 0.7.4'
 gem 'sorbet-runtime'
 gem 'state_machines-activerecord'
-gem 'turbo-rails', github: 'hotwired/turbo-rails', ref: 'd89e1a0'
+gem 'turbo-rails', '~> 0.6.0'
 gem 'view_component', '~> 2.18'
 gem 'webpacker', '6.0.0.beta7'
 gem 'whenever'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/hotwired/turbo-rails.git
-  revision: d89e1a0f36373180806ceab6949fb25e0d74264a
-  ref: d89e1a0
-  specs:
-    turbo-rails (0.5.11)
-      rails (>= 6.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -506,6 +498,8 @@ GEM
       diff-lcs
       patience_diff
     thor (1.1.0)
+    turbo-rails (0.6.0)
+      rails (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
@@ -602,7 +596,7 @@ DEPENDENCIES
   state_machines-activerecord
   state_machines-graphviz
   super_diff
-  turbo-rails!
+  turbo-rails (~> 0.6.0)
   view_component (~> 2.18)
   web-console (>= 3.3.0)
   webmock

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.1",
     "@github/time-elements": "^3.1.2",
-    "@hotwired/turbo-rails": "^7.0.0-beta.7",
+    "@hotwired/turbo-rails": "^7.0.0-rc.1",
     "@popperjs/core": "2",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,18 +894,18 @@
   resolved "https://registry.yarnpkg.com/@github/time-elements/-/time-elements-3.1.2.tgz#cc36d7a34ff2033d7f0b216f1a724405b8fbc201"
   integrity sha512-YVtZVLBikP6I7na22kfB9PKIseISwX41MFJ7lPuNz1VVH2IR5cpRRU6F1X6kcchPChljuvMUR4OiwMWHOJQ8kQ==
 
-"@hotwired/turbo-rails@^7.0.0-beta.7":
-  version "7.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.0.0-beta.7.tgz#ca347999d4a62af447554bebe0ab46dd7c241661"
-  integrity sha512-aoX91p2pIApEywhWNHqbaQ+gtNBr3+u38X0jSEHPdqVAK8lLRtHJomP3s1psSuYTiRaOuIeh6IhHDRYyAmZxKg==
+"@hotwired/turbo-rails@^7.0.0-rc.1":
+  version "7.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.0.0-rc.1.tgz#68cc07b2a1e7d9b29240c525c657722b3f0c3842"
+  integrity sha512-LLOgtHWb/cnz0bXlfJ9khWHapQuCOuUI48yiSVgL3veklvbX1vyQlk/ALn35Z6nHTi7Bf+MHMS9H5W2c/vwKuw==
   dependencies:
-    "@hotwired/turbo" "^7.0.0-beta.7"
+    "@hotwired/turbo" "^7.0.0-rc.1"
     "@rails/actioncable" "^6.0.0"
 
-"@hotwired/turbo@^7.0.0-beta.7":
-  version "7.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.0.0-beta.7.tgz#0f519af4e63698a9fb44d2db9019cdb5ddd048db"
-  integrity sha512-w4Oajhnqnz+b2rM325FjPnENVij1yWJy+q6bwSgmCvRG4715T7PoC6YwTPd4h6PVUGgy5WpqgDadzKdEV+qtLw==
+"@hotwired/turbo@^7.0.0-rc.1":
+  version "7.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.0.0-rc.1.tgz#a5c1be86def1cc39b3011c935c5734b8632af5c3"
+  integrity sha512-niNA68ku4TZYbV3biwTPf1L5CidP50S2xfeb5rGQfodvPB9UAtkqKFFRIA0LL8y0DG4MGIZ/QFlbvlmFea5p4w==
 
 "@popperjs/core@2":
   version "2.9.2"


### PR DESCRIPTION
## Why was this change made?
We were pinned to a github version until this release was made, so this clears some tech debt.



## How was this change tested?



## Which documentation and/or configurations were updated?



