### PR TITLE
allow reserved purls to be deleted

### DIFF
--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -12,7 +12,7 @@ class WorkPolicy < ApplicationPolicy
   end
 
   def destroy?
-    (administrator? || depositor?) && record.persisted? && record.head.first_draft?
+    (administrator? || depositor?) && record.persisted? && (record.head.first_draft? || record.head.purl_reservation?)
   end
 
   delegate :administrator?, to: :user_with_groups

--- a/spec/features/purl_reservation_spec.rb
+++ b/spec/features/purl_reservation_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Reserve a PURL for a work in a deposited collection', js: true d
     allow(Settings).to receive(:allow_sdr_content_changes).and_return(true)
   end
 
-  it 'deposits a placeholder work, and lists it on the dashboard with its PURL' do
+  it 'deposits a placeholder work, and lists it on the dashboard with its PURL, then remove it' do
     visit dashboard_path
 
     click_button 'Reserve a PURL'
@@ -40,6 +40,15 @@ RSpec.describe 'Reserve a PURL for a work in a deposited collection', js: true d
 
     # this should be updated automatically
     expect(page).to have_content 'PURL Reserved'
+
+    # now delete the reserved purl and confirm it is gone
+    accept_confirm do
+      within '#your-collections-table' do
+        click_link "Delete #{work_version.title}"
+      end
+    end
+    sleep(1)
+    expect(WorkVersion.exists?(work_version.id)).to be false
   end
 
   describe 'setting the type for a reserved purl' do


### PR DESCRIPTION
## Why was this change made?

Fixes #1837 - allow reserved PURLs to be deleted.

~~Question: this just destroys the `Work` and `WorkVersion` in the database, it would for any work that is in a first draft state.  I think it should be fine even after we have a held a PID?~~

## How was this change tested?

Localhost browser, added delete to existing purl reservation test.


## Which documentation and/or configurations were updated?



