### PR TITLE
Open the 'What is a DOI' link in a new tab

### DIFF
--- a/app/components/collections/settings_component.html.erb
+++ b/app/components/collections/settings_component.html.erb
@@ -50,7 +50,7 @@
 
     <fieldset class="mb-5">
       <legend class="h5">Will a DOI be assigned to the deposits in this collection?* <%= render PopoverComponent.new key: 'collection.doi' %>
-        <%= link_to 'What is a DOI?', 'https://library.stanford.edu/research/stanford-digital-repository/documentation/purls-and-dois' %>
+        <%= link_to 'What is a DOI?', Settings.external_links.what_is_a_doi, target: '_blank' %>
       </legend>
       <div class="form-check">
         <%= form.radio_button :doi_option, 'yes', class: "form-check-input" %>

--- a/app/components/works/doi_component.html.erb
+++ b/app/components/works/doi_component.html.erb
@@ -3,7 +3,7 @@
     DOI assignment
 
   </legend>
-  <%= link_to 'What is a DOI?', 'https://library.stanford.edu/research/stanford-digital-repository/documentation/purls-and-dois' %>
+  <%= link_to 'What is a DOI?', Settings.external_links.what_is_a_doi, target: '_blank' %>
   <div class="mb-3 inner-container">
     <% if doi %>
       <p>The DOI assigned to this work is <%= link_to doi, doi %>.</p>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,6 +28,9 @@ h2:
 
 earliest_year: 1000
 
+external_links:
+  what_is_a_doi: https://library.stanford.edu/research/stanford-digital-repository/documentation/purls-and-dois
+
 # feature flag
 allow_sdr_content_changes: true
 


### PR DESCRIPTION
Fixes #1937

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



