### PR TITLE
align column labels on collection show pages

### DIFF
--- a/app/components/collections/detail_component.html.erb
+++ b/app/components/collections/detail_component.html.erb
@@ -7,15 +7,15 @@
 
   <tbody>
     <tr>
-      <th>Collection name</th>
+      <th class="col-3">Collection name</th>
       <td><%= name %></td>
     </tr>
     <tr>
-      <th>Description</th>
+      <th class="col-3">Description</th>
       <td><%= description %></td>
     </tr>
     <tr>
-      <th>Contact emails</th>
+      <th class="col-3">Contact emails</th>
       <% if contact_emails.empty? %>
       <td>None provided</td>
       <% else %>

--- a/app/components/collections/information_component.html.erb
+++ b/app/components/collections/information_component.html.erb
@@ -2,7 +2,7 @@
   <caption>Collection information</caption>
   <tbody>
     <tr>
-      <th>PURL</th>
+      <th class="col-3">PURL</th>
       <td>
         <% if purl %>
           <%= link_to purl, purl %>
@@ -12,19 +12,19 @@
       </td>
     </tr>
     <tr>
-      <th>Version details</th>
+      <th class="col-3">Version details</th>
       <td><%= version %></td>
     </tr>
     <tr>
-      <th>Created by</th>
+      <th class="col-3">Created by</th>
       <td><%= creator.sunetid %></td>
     </tr>
     <tr>
-      <th>Collection created</th>
+      <th class="col-3">Collection created</th>
       <td><%= created %></td>
     </tr>
     <tr>
-      <th>Last Saved</th>
+      <th class="col-3">Last Saved</th>
       <td><%= last_saved %></td>
     </tr>
   </tbody>

--- a/app/components/collections/links_component.html.erb
+++ b/app/components/collections/links_component.html.erb
@@ -6,7 +6,7 @@
   </caption>
   <tbody>
     <tr>
-      <th scope="row">Related links</th>
+      <th class="col-3" scope="row">Related links</th>
       <% if related_links.empty? %>
         <td>None provided</td>
       <% else %>

--- a/app/components/collections/participants_component.html.erb
+++ b/app/components/collections/participants_component.html.erb
@@ -9,11 +9,11 @@
   </caption>
   <tbody>
     <tr>
-      <th>Managers</th>
+      <th class="col-3">Managers</th>
       <td><%= managers %></td>
     </tr>
     <tr>
-      <th>Depositors</th>
+      <th class="col-3">Depositors</th>
       <td><%= depositors %></td>
     </tr>
   </tbody>

--- a/app/components/collections/release_component.html.erb
+++ b/app/components/collections/release_component.html.erb
@@ -8,11 +8,11 @@
   </caption>
   <tbody>
     <tr>
-      <th>Release</th>
+      <th class="col-3">Release</th>
       <td><%= release_info %> </td>
     </tr>
     <tr>
-      <th>Visibility</th>
+      <th class="col-3">Visibility</th>
       <td><%= access %></td>
     </tr>
   </tbody>

--- a/app/components/collections/terms_of_use_component.html.erb
+++ b/app/components/collections/terms_of_use_component.html.erb
@@ -8,17 +8,17 @@
   </caption>
   <tbody>
     <tr>
-      <th>Terms of use</th>
+      <th class="col-3">Terms of use</th>
       <td><%= I18n.t(:terms_of_use) %></td>
     </tr>
     <% if user_can_set_license? %>
       <tr>
-        <th>Default license (depositor selects)</th>
+        <th class="col-3">Default license (depositor selects)</th>
         <td><%= default_license %></td>
       </tr>
     <% else %>
       <tr>
-        <th>Required license</th>
+        <th class="col-3">Required license</th>
         <td><%= required_license %></td>
       </tr>
     <% end %>

--- a/app/components/collections/workflow_review_component.html.erb
+++ b/app/components/collections/workflow_review_component.html.erb
@@ -8,11 +8,11 @@
   </caption>
   <tbody>
     <tr>
-      <th>Status</th>
+      <th class="col-3">Status</th>
       <td><%= review_workflow_status %></td>
     </tr>
     <tr>
-      <th>Reviewers</th>
+      <th class="col-3">Reviewers</th>
       <td><%= reviewers %></td>
     </tr>
   </tbody>


### PR DESCRIPTION
## Why was this change made?

Fixes #1337 and related to #1935 --- aligns the column labels on the collection detail and settings show pages.  Seen screenshots below to see the change.

**Collection details current:**

![collection-details-current](https://user-images.githubusercontent.com/47137/129250645-1785dcd0-d6a1-4771-bcea-099ea06ddf2a.png)

**Collection details as shown in this PR:**

![collection-details-new](https://user-images.githubusercontent.com/47137/129250685-ce1a7a6b-4e0d-4d2c-970d-1da08eae6a70.png)

**Collection settings current:**

![collection-settings-current](https://user-images.githubusercontent.com/47137/129250703-c2dc86a8-6c67-4246-9063-a02b8126b72c.png)

**Collection settings as shown in this PR:**

![collection-settings-new](https://user-images.githubusercontent.com/47137/129250736-4c540aaa-dff6-4574-b2e9-00daf81c8b42.png)


## How was this change tested?

Localhost browser



## Which documentation and/or configurations were updated?



