### PR TITLE
Allow rejected or pending approval first drafts to be deleted

### DIFF
--- a/app/components/works/buttons_component.rb
+++ b/app/components/works/buttons_component.rb
@@ -36,7 +36,7 @@ module Works
     end
 
     def show_first_draft_cancel?
-      work_version.first_draft?
+      work_version.deleteable?
     end
   end
 end

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -107,7 +107,7 @@ class WorkVersion < ApplicationRecord
   end
 
   def deleteable?
-    (first_draft? || purl_reservation?) || (version == 1 && (pending_approval? || rejected?))
+    first_draft? || purl_reservation? || (version == 1 && (pending_approval? || rejected?))
   end
 
   def add_purl_to_citation

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -106,6 +106,10 @@ class WorkVersion < ApplicationRecord
     version_draft? || first_draft?
   end
 
+  def deleteable?
+    (first_draft? || purl_reservation?) || (version == 1 && (pending_approval? || rejected?))
+  end
+
   def add_purl_to_citation
     return unless citation
 

--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -12,10 +12,20 @@ class WorkPolicy < ApplicationPolicy
   end
 
   def destroy?
-    (administrator? || depositor?) && record.persisted? && (record.head.first_draft? || record.head.purl_reservation?)
+    (administrator? || depositor?) && record.persisted? && (first_draft? || first_draft_in_review?)
   end
 
   delegate :administrator?, to: :user_with_groups
+
+  # a first draft of a deposit or a reserved purl
+  def first_draft?
+    record.head.first_draft? || record.head.purl_reservation?
+  end
+
+  # a first draft of a deposit in reviewer workflow that is either pending approval or returned
+  def first_draft_in_review?
+    record.head.version == 1 && (record.head.pending_approval? || record.head.rejected?)
+  end
 
   def depositor?
     record.depositor == user

--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -12,20 +12,10 @@ class WorkPolicy < ApplicationPolicy
   end
 
   def destroy?
-    (administrator? || depositor?) && record.persisted? && (first_draft? || first_draft_in_review?)
+    (administrator? || depositor?) && record.persisted? && record.head.deleteable?
   end
 
   delegate :administrator?, to: :user_with_groups
-
-  # a first draft of a deposit or a reserved purl
-  def first_draft?
-    record.head.first_draft? || record.head.purl_reservation?
-  end
-
-  # a first draft of a deposit in reviewer workflow that is either pending approval or returned
-  def first_draft_in_review?
-    record.head.version == 1 && (record.head.pending_approval? || record.head.rejected?)
-  end
 
   def depositor?
     record.depositor == user

--- a/spec/features/delete_draft_work_spec.rb
+++ b/spec/features/delete_draft_work_spec.rb
@@ -6,18 +6,25 @@ RSpec.describe 'Delete a draft work', js: true do
   let(:collection) { create(:collection, :with_depositors, depositor_count: 1) }
   let(:work) { create(:work, collection: collection, depositor: user) }
   let(:work_version) { create(:work_version, title: 'Delete me', work: work) }
+  let(:work_pending_approval) { create(:work, collection: collection, depositor: user) }
+  let(:work_version_pending_approval) do
+    create(:work_version, :pending_approval, title: 'Pending Approval - Delete me', work: work_pending_approval)
+  end
+  let(:work_rejected) { create(:work, collection: collection, depositor: user) }
+  let(:work_version_rejected) { create(:work_version, :rejected, title: 'Rejected - Delete me', work: work_rejected) }
   let(:user) { collection.depositors.first }
 
   before do
     create(:collection_version_with_collection, collection: collection)
-    work.update(head: work_version)
     sign_in user
   end
 
   context 'when draft' do
+    before { work.update(head: work_version) }
+
     it 'allow users to delete the work and destroys the model from the dashboard' do
       visit dashboard_path
-      click_button 'No'
+      click_button 'No' # dismiss the "Would you like to continue to working on your draft ..." dialog
 
       accept_confirm do
         within '#deposits-in-progress' do
@@ -34,6 +41,48 @@ RSpec.describe 'Delete a draft work', js: true do
         click_link 'Discard draft'
       end
       expect(Work.exists?(work.id)).to be false
+      expect(page).to have_current_path(collection_works_path(collection.id))
+    end
+  end
+
+  context 'when pending approval' do
+    before { work_pending_approval.update(head: work_version_pending_approval) }
+
+    it 'allow users to delete the work and destroys the model from the dashboard' do
+      visit dashboard_path
+
+      accept_confirm do
+        within '#your-collections' do
+          click_link "Delete #{work_version_pending_approval.title}"
+        end
+      end
+      sleep(1)
+      expect(Work.exists?(work_pending_approval.id)).to be false
+    end
+  end
+
+  context 'when rejected' do
+    before { work_rejected.update(head: work_version_rejected) }
+
+    it 'allow users to delete the work and destroys the model from the dashboard' do
+      visit dashboard_path
+      click_button 'No' # dismiss the "Would you like to continue to working on your draft ..." dialog
+
+      accept_confirm do
+        within '#your-collections' do
+          click_link "Delete #{work_version_rejected.title}"
+        end
+      end
+      sleep(1)
+      expect(Work.exists?(work_rejected.id)).to be false
+    end
+
+    it 'allow users to delete the work and destroys the model from the work edit page' do
+      visit edit_work_path(work_rejected)
+      accept_confirm do
+        click_link 'Discard draft'
+      end
+      expect(Work.exists?(work_rejected.id)).to be false
       expect(page).to have_current_path(collection_works_path(collection.id))
     end
   end


### PR DESCRIPTION
## Why was this change made?

Fixes #1946 - allow rejected (returned) or pending approval first drafts to be deleted

## How was this change tested?

Localhost browser
Updated tests


## Which documentation and/or configurations were updated?



