### PR TITLE
Use slider widget for registering a DOI 

### DIFF
--- a/app/components/works/doi_component.html.erb
+++ b/app/components/works/doi_component.html.erb
@@ -16,13 +16,20 @@
         <%= form.label :assign_doi, 'Do you want a DOI to be assigned to your deposit?', class: "form-check-label col-sm-5" %>
 
         <div class="col-sm-2">
-          <div class="form-check form-switch">
+          <label class="switch" aria-label="Use auto-generated citation">
             <%= form.check_box :assign_doi,
                                {
-                                 class: 'form-check-input'
+                                 data: {
+                                   action: 'change->auto-citation#switchChanged',
+                                   auto_citation_target: 'switch'
+                                 }
                                },
                                'true', 'false' %>
-          </div>
+            <div class="slider round">
+              <span class="on">Yes</span>
+              <span class="off">No</span>
+            </div>
+          </label>
         </div>
       </div>
 

--- a/app/packs/stylesheets/palette.scss
+++ b/app/packs/stylesheets/palette.scss
@@ -3,6 +3,7 @@ $ibis-white: #f3e7e7; // light pinkish hue used in what's changing box
 // https://identity.stanford.edu/design-elements/color/primary-colors/
 $stanford-cardinal: #8c1515;
 $stanford-cool-grey: #53565a; // used in SDR header (not yet added)
+$tapa: #767674; // "60% black" in Stanford brand identity
 $silver-sand: #c0c0bf; // "30% black" in Stanford brand identity
 $whisper: #eaeaea; // "10% black" in Stanford brand identity, used as modal bg color
 

--- a/app/packs/stylesheets/switch.scss
+++ b/app/packs/stylesheets/switch.scss
@@ -27,23 +27,13 @@
     color: white;
   }
 
-  .off
-  {
-    position: absolute;
-    transform: translate(-50%,-50%);
-    top: 50%;
-    left: 50%;
-    font-size: 10px;
-    font-family: Verdana, sans-serif;
-  }
-
   .on, .off
   {
     position: absolute;
     transform: translate(-50%,-50%);
     top: 50%;
     left: 50%;
-    font-size: 11px;
+    font-size: 0.8rem;
     font-family: Verdana, sans-serif;
   }
 }
@@ -54,10 +44,15 @@
   height: 26px;
   width: 26px;
   left: 4px;
-  bottom: 4px;
-  background-color: white;
+  bottom: 3px;
+  border: 1px solid $tapa;
+  background-color: $silver-sand;
   -webkit-transition: .4s;
   transition: .4s;
+}
+
+input[type=checkbox] + .slider {
+  background-color: $white;
 }
 
 input[type=checkbox]:checked + .slider {
@@ -82,6 +77,7 @@ input[type=checkbox]:checked + .slider .off
 
 /* Rounded sliders */
 .slider.round {
+  border: 1px solid $tapa;
   border-radius: 34px;
 }
 


### PR DESCRIPTION




## Why was this change made?

Fixes #1938


This updates slider styles so we can see the slider against a gray background

## How was this change tested?
Before:
<img width="154" alt="Screen Shot 2021-08-12 at 11 14 51 AM" src="https://user-images.githubusercontent.com/92044/129274850-a5ba3e95-5d0c-41d9-82d7-d2c092d417f3.png">
<img width="145" alt="Screen Shot 2021-08-12 at 11 14 46 AM" src="https://user-images.githubusercontent.com/92044/129274851-cd36b0cc-3935-481e-ba38-32746bd1b02d.png">



After:
<img width="134" alt="Screen Shot 2021-08-12 at 4 50 13 PM" src="https://user-images.githubusercontent.com/92044/129274825-46344b51-6c47-4714-ab94-beea079cd551.png">
<img width="137" alt="Screen Shot 2021-08-12 at 4 50 08 PM" src="https://user-images.githubusercontent.com/92044/129274826-e9775d65-e773-4de2-b87f-6bc94d959641.png">

## Which documentation and/or configurations were updated?



