### PR TITLE
go back to collection details/settings when canceling editing

### DIFF
--- a/app/components/collections/update/details_form_component.html.erb
+++ b/app/components/collections/update/details_form_component.html.erb
@@ -24,7 +24,7 @@
     <div class="col-auto">
     </div>
     <div class="col-auto">
-      <%= link_to 'Cancel', dashboard_path, class: 'btn btn-link' %>
+      <%= link_to 'Cancel', collection_version_path(model), class: 'btn btn-link' %>
       <%= form.submit 'Save as draft', class: 'btn btn-primary', id: 'save-draft-button', data: { action: 'unsaved-changes#allowFormSubmission' } %>
       <%= form.submit 'Deposit', class: 'btn btn-primary', data: { action: 'unsaved-changes#allowFormSubmission' } %>
     </div>

--- a/app/components/collections/update/settings_form_component.html.erb
+++ b/app/components/collections/update/settings_form_component.html.erb
@@ -22,7 +22,7 @@
 
   <div class="row">
     <div class="col text-end">
-      <%= link_to 'Cancel', dashboard_path, class: 'btn btn-link' %>
+      <%= link_to 'Cancel', collection_path(model), class: 'btn btn-link' %>
       <%= form.submit 'Save', class: 'btn btn-primary', data: { action: 'unsaved-changes#allowFormSubmission' } %>
     </div>
   </div>

--- a/spec/features/create_new_collection_spec.rb
+++ b/spec/features/create_new_collection_spec.rb
@@ -43,22 +43,14 @@ RSpec.describe 'Create a new collection', js: true do
       expect(page).to have_content('Depositing')
 
       # Simulate the deposit process
-      collection_version = CollectionVersion.last
-      collection_version.collection.update!(druid: 'druid:dc224fz4940')
-      collection_version.deposit_complete!
+      CollectionVersion.last.tap do |version|
+        version.collection.update!(druid: 'druid:dc224fz4940')
+        version.deposit_complete!
+      end
 
       # This link appears when depositing is complete
       click_link "Edit #{name}"
       expect(page).not_to have_content('Depositing')
-
-      # Cancel editing to confirm we get back to the collection settings view page
-      click_link 'Cancel'
-      expect(page).to have_current_path(collection_path(collection_version.collection))
-
-      # now visit the edit details page, and Cancel editing to confirm we return to the collection details view page
-      visit edit_collection_version_path(collection_version)
-      click_link 'Cancel'
-      expect(page).to have_current_path(collection_version_path(collection_version))
     end
 
     it 'shows a confirmation if you cancel the collection deposit and goes back if confirmed' do

--- a/spec/features/create_new_collection_spec.rb
+++ b/spec/features/create_new_collection_spec.rb
@@ -43,14 +43,22 @@ RSpec.describe 'Create a new collection', js: true do
       expect(page).to have_content('Depositing')
 
       # Simulate the deposit process
-      CollectionVersion.last.tap do |version|
-        version.collection.update!(druid: 'druid:dc224fz4940')
-        version.deposit_complete!
-      end
+      collection_version = CollectionVersion.last
+      collection_version.collection.update!(druid: 'druid:dc224fz4940')
+      collection_version.deposit_complete!
 
       # This link appears when depositing is complete
       click_link "Edit #{name}"
       expect(page).not_to have_content('Depositing')
+
+      # Cancel editing to confirm we get back to the collection settings view page
+      click_link 'Cancel'
+      expect(page).to have_current_path(collection_path(collection_version.collection))
+
+      # now visit the edit details page, and Cancel editing to confirm we return to the collection details view page
+      visit edit_collection_version_path(collection_version)
+      click_link 'Cancel'
+      expect(page).to have_current_path(collection_version_path(collection_version))
     end
 
     it 'shows a confirmation if you cancel the collection deposit and goes back if confirmed' do


### PR DESCRIPTION
## Why was this change made?

Fixes #1949 - cancel target location should be collection view pages when editing

## How was this change tested?

Added new expectations to edit collection spec

## Which documentation and/or configurations were updated?



