### PR TITLE
cancel work editing goes to work show page

### DIFF
--- a/app/components/works/buttons_component.html.erb
+++ b/app/components/works/buttons_component.html.erb
@@ -19,7 +19,7 @@
     <% end %>
   </div>
   <div class="col-auto">
-    <%= link_to 'Cancel', collection_works_path(collection), class: 'btn btn-link' %>
+    <%= link_to 'Cancel', cancel_link_location, class: 'btn btn-link' %>
     <%= form.submit 'Save as draft', class: 'btn btn-primary', id: 'save-draft-button',
                                      data: { action: 'unsaved-changes#allowFormSubmission' } %>
     <%= form.submit submit_button_label, class: 'btn btn-primary',

--- a/app/components/works/buttons_component.rb
+++ b/app/components/works/buttons_component.rb
@@ -38,5 +38,13 @@ module Works
     def show_first_draft_cancel?
       work_version.first_draft?
     end
+
+    def cancel_link_location
+      if model.persisted?
+        work_path(model)
+      else
+        collection_works_path(collection)
+      end
+    end
   end
 end

--- a/spec/components/works/buttons_component_spec.rb
+++ b/spec/components/works/buttons_component_spec.rb
@@ -5,8 +5,6 @@ require 'rails_helper'
 RSpec.describe Works::ButtonsComponent do
   let(:component) { described_class.new(form: form) }
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
-  let(:work) { build_stubbed(:work, collection: build(:collection, id: 7)) }
-  let(:work_version) { build(:work_version, work: work) }
   let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
   let(:rendered) { render_inline(component) }
 
@@ -14,21 +12,41 @@ RSpec.describe Works::ButtonsComponent do
     allow(controller).to receive(:allowed_to?).and_return(true)
   end
 
-  context 'when collection does not require reviews' do
-    it 'renders submit button as "Deposit"' do
-      expect(rendered.css('input[value="Deposit"]')).to be_present
+  context 'when work is not persisted' do
+    let(:work) { build(:work, collection: build(:collection, id: 7)) }
+    let(:work_version) { build(:work_version, work: work, state: 'new') }
+
+    it 'renders cancel button with target location as work show page' do
+      expect(rendered.css('a[text()="Cancel"]')).to be_present
+      expect(rendered.css("a[href='/collections/7/works']")).to be_present
     end
   end
 
-  context 'when collection requires reviews' do
-    let(:work) { build_stubbed(:work, collection: build(:collection, :with_reviewers, id: 8)) }
+  context 'when work is persisted' do
+    let(:work) { build_stubbed(:work, collection: build(:collection, id: 7)) }
+    let(:work_version) { build(:work_version, work: work) }
 
-    it 'renders submit button as "Submit for approval"' do
-      expect(rendered.css('input[value="Submit for approval"]')).to be_present
+    it 'renders cancel button with target location as work show page' do
+      expect(rendered.css('a[text()="Cancel"]')).to be_present
+      expect(rendered.css("a[href='/works/#{work.id}']")).to be_present
     end
-  end
 
-  it 'renders the save draft button' do
-    expect(rendered.css('input[value="Save as draft"]')).to be_present
+    context 'when collection does not require reviews' do
+      it 'renders submit button as "Deposit"' do
+        expect(rendered.css('input[value="Deposit"]')).to be_present
+      end
+    end
+
+    context 'when collection requires reviews' do
+      let(:work) { build_stubbed(:work, collection: build(:collection, :with_reviewers, id: 8)) }
+
+      it 'renders submit button as "Submit for approval"' do
+        expect(rendered.css('input[value="Submit for approval"]')).to be_present
+      end
+    end
+
+    it 'renders the save draft button' do
+      expect(rendered.css('input[value="Save as draft"]')).to be_present
+    end
   end
 end

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -228,21 +228,6 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
       user.update(last_work_terms_agreement: Time.zone.now.years_ago(2))
     end
 
-    context 'when user clicks cancel link' do
-      it 'goes to collection deposits page if you click cancel' do
-        visit dashboard_path
-
-        click_button '+ Deposit to this collection' # , match: :first
-        find('label', text: 'Sound').click
-        check 'Podcast'
-        click_button 'Continue'
-
-        click_link 'Cancel'
-
-        expect(page).to have_current_path(collection_works_path(collection))
-      end
-    end
-
     context 'when successful deposit' do
       context 'with a user-supplied citation' do
         it 'deposits and renders work show page' do

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -228,6 +228,21 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
       user.update(last_work_terms_agreement: Time.zone.now.years_ago(2))
     end
 
+    context 'when user clicks cancel link' do
+      it 'goes to collection deposits page if you click cancel' do
+        visit dashboard_path
+
+        click_button '+ Deposit to this collection' # , match: :first
+        find('label', text: 'Sound').click
+        check 'Podcast'
+        click_button 'Continue'
+
+        click_link 'Cancel'
+
+        expect(page).to have_current_path(collection_works_path(collection))
+      end
+    end
+
     context 'when successful deposit' do
       context 'with a user-supplied citation' do
         it 'deposits and renders work show page' do

--- a/spec/features/edit_draft_work_spec.rb
+++ b/spec/features/edit_draft_work_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Edit a draft work', js: true do
       end
     end
 
-    it 'shows a confirmation if you cancel the deposit and goes back if confirmed' do
+    it 'shows a confirmation if you cancel the deposit and goes back to work show page if confirmed' do
       visit dashboard_path
 
       click_link 'Yes!'
@@ -72,7 +72,7 @@ RSpec.describe 'Edit a draft work', js: true do
         click_link 'Cancel'
       end
 
-      expect(page).to have_current_path(collection_works_path(work.collection))
+      expect(page).to have_current_path(work_path(work))
     end
 
     it 'shows a confirmation if you cancel the deposit and stays on the page if not confirmed' do


### PR DESCRIPTION
## Why was this change made?

Fixes #1950 - cancel link on work edit form should go to work show page (if existing work) or collection works listing page (if new work)

## How was this change tested?

Updated existing test, added new test


## Which documentation and/or configurations were updated?



