### PR TITLE
Hides collection participant results list when query deleted.

### DIFF
--- a/app/packs/controllers/collection_participant_form_controller.js
+++ b/app/packs/controllers/collection_participant_form_controller.js
@@ -62,6 +62,11 @@ export default class extends Controller {
 
 
   search(e) {
+    if(e.target.value === '') {
+      this.resultTarget.hidden = true
+      return
+    }
+
     this.resultTarget.hidden = false
     fetch('/accounts/' + e.target.value)
       .then(response => response.json())


### PR DESCRIPTION
closes #1925

## Why was this change made?
User experience.


## How was this change tested?
Local.


## Which documentation and/or configurations were updated?
NA


