### PR TITLE
Scroll into view on collection results list paging.

### DIFF
--- a/app/packs/controllers/datatable_works_controller.js
+++ b/app/packs/controllers/datatable_works_controller.js
@@ -12,9 +12,13 @@ export default class extends Controller {
       { select: [1, 5, 6, 7, 8], sortable: false } // Disable unsortable columns
     ]
     if (this.hideDepositorValue) columns.push({ select: 2, hidden: true})
-    new DataTable("#worksTable", {
+    const dt = new DataTable("#worksTable", {
       columns: columns,
       searchable: true
+    })
+    // This scrolls the top of the table into view when paging.
+    dt.on('datatable.page', () => {
+      dt.table.scrollIntoView()
     })
   }
 }


### PR DESCRIPTION
closes #1952

## Why was this change made?
User experience


## How was this change tested?
Local


## Which documentation and/or configurations were updated?
NA


