### PR TITLE
Add a message for an already deposited item that doesn't have a DOI

### DIFF
--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -11,9 +11,9 @@ module Works
 
     delegate :purl, :collection, :events, :doi, :assign_doi, :druid, to: :work
 
-    delegate :doi_option, to: :collection
+    delegate :doi_option, to: :collection, prefix: true
 
-    delegate :work_type, :contact_emails, :abstract, :citation,
+    delegate :work_type, :contact_emails, :abstract, :citation, :first_draft?,
              :attached_files, :related_works, :related_links,
              :created_edtf, :published_edtf, :rejected?, :work, :description, to: :work_version
 
@@ -22,7 +22,7 @@ module Works
     end
 
     def version
-      return '1 - initial version' if work_version.version == 1
+      return '1 - initial version' if first_draft?
 
       "#{work_version.version} - #{description}"
     end
@@ -31,7 +31,7 @@ module Works
       # If there is a DOI, return a link to it.
       return doi_link if doi
 
-      case doi_option
+      case collection_doi_option
       when 'yes'
         doi_later
       when 'depositor-selects'
@@ -41,13 +41,13 @@ module Works
           doi_opt_out
         end
       end
-      # Nothing is returned if doi_option is 'no'
+      # Nothing is returned if collection_doi_option is 'no'
     end
 
     def doi_setting
       return 'DOI assigned (see above)' if doi
 
-      case doi_option
+      case collection_doi_option
       when 'depositor-selects'
         assign_doi ? 'DOI not assigned' : 'Opted out of receiving a DOI'
       when 'yes'
@@ -137,7 +137,11 @@ module Works
     end
 
     def doi_later
-      tag.em 'DOI will become available once the work has been deposited.'
+      return tag.em 'DOI will become available once the work has been deposited.' if first_draft?
+
+      # This is a version draft, the collection must have been changed to "yes"
+      # after this item was deposited.
+      'DOI will become available once a new version is deposited.'
     end
   end
 end

--- a/spec/components/works/detail_component_spec.rb
+++ b/spec/components/works/detail_component_spec.rb
@@ -88,59 +88,82 @@ RSpec.describe Works::DetailComponent, type: :component do
   end
 
   describe 'DOI' do
+    subject(:details) { rendered.css('*').xpath("./table[caption/text()='Details']").first }
+
     context 'with a DOI' do
       let(:work_version) { build_stubbed(:work_version, :deposited, version: 2, work: work) }
       let(:work) { build_stubbed(:work, doi: '10.25740/bc123df4567') }
 
       it 'renders the doi_link' do
-        expect(rendered.css('a[href="https://doi.org/10.25740/bc123df4567"]').to_html)
+        expect(details.css('a[href="https://doi.org/10.25740/bc123df4567"]').to_html)
           .to include 'https://doi.org/10.25740/bc123df4567'
-        expect(rendered.to_html).to include 'DOI assigned (see above)'
       end
     end
 
-    context 'with reserved PURL and collection automatically assigns DOI' do
-      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
-      let(:work) { build_stubbed(:work, collection: collection, assign_doi: false, druid: 'druid:bc123df4567') }
+    context 'with a collection set to automatically assign a DOI' do
       let(:collection) { build_stubbed(:collection, doi_option: 'yes') }
 
-      it 'renders the doi setting' do
-        expect(rendered.to_html).to include 'DOI will become available once the work has been deposited.'
+      context 'with reserved PURL' do
+        let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
+        let(:work) { build_stubbed(:work, collection: collection, assign_doi: false, druid: 'druid:bc123df4567') }
+
+        it 'renders the doi setting' do
+          expect(details.to_html).to include 'DOI will become available once the work has been deposited.'
+        end
+      end
+
+      context 'when it is a first_draft without a reserved PURL' do
+        let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
+        let(:work) { build_stubbed(:work, collection: collection, assign_doi: false) }
+
+        it 'renders the doi setting' do
+          expect(details.to_html).to include 'DOI will become available once the work has been deposited.'
+        end
+      end
+
+      context 'when it is a version_draft without a reserved PURL' do
+        let(:work_version) { build_stubbed(:work_version, :version_draft, work: work) }
+        let(:work) { build_stubbed(:work, collection: collection, assign_doi: false) }
+
+        it 'renders the doi setting' do
+          expect(details.to_html).to include 'DOI will become available once a new version is deposited.'
+        end
       end
     end
 
-    context 'with reserved PURL and collection allows depositor to select, and they choose no' do
-      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
-      let(:work) { build_stubbed(:work, collection: collection, assign_doi: false, druid: 'druid:bc123df4567') }
+    context 'with a collection set to depositor-selects' do
       let(:collection) { build_stubbed(:collection, doi_option: 'depositor-selects') }
 
-      it 'renders the doi setting' do
-        expect(rendered.to_html).to include 'A DOI has not been assigned to this item.'
+      context 'when they choose no and have a reserved purl' do
+        let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
+        let(:work) { build_stubbed(:work, collection: collection, assign_doi: false, druid: 'druid:bc123df4567') }
+
+        it 'renders the doi setting' do
+          expect(details.to_html).to include 'A DOI has not been assigned to this item.'
+        end
       end
-    end
 
-    context 'without a reserved PURL and collection automatically assigns DOI' do
-      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
-      let(:work) { build_stubbed(:work, collection: collection, assign_doi: false) }
-      let(:collection) { build_stubbed(:collection, doi_option: 'yes') }
+      context 'when they choose yes without a reserved purl' do
+        let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
+        let(:work) { build_stubbed(:work, collection: collection, assign_doi: true) }
 
-      it 'renders the doi setting' do
-        expect(rendered.to_html).to include 'DOI will become available once the work has been deposited.'
-      end
-    end
-
-    context 'without a reserved PURL and depositor selects to assign' do
-      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
-      let(:work) { build_stubbed(:work, collection: collection, assign_doi: true) }
-      let(:collection) { build_stubbed(:collection, doi_option: 'depositor-selects') }
-
-      it 'renders the doi setting' do
-        expect(rendered.to_html).to include 'DOI will become available once the work has been deposited.'
+        it 'renders the doi setting' do
+          expect(details.to_html).to include 'DOI will become available once the work has been deposited.'
+        end
       end
     end
   end
 
   describe 'DOI settings' do
+    context 'with a DOI' do
+      let(:work_version) { build_stubbed(:work_version, :deposited, version: 2, work: work) }
+      let(:work) { build_stubbed(:work, doi: '10.25740/bc123df4567') }
+
+      it 'renders the doi_link' do
+        expect(rendered.to_html).to include 'DOI assigned (see above)'
+      end
+    end
+
     context 'when DOI was requested' do
       let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
       let(:work) { build_stubbed(:work, assign_doi: true) }

--- a/spec/support/view_component.rb
+++ b/spec/support/view_component.rb
@@ -9,4 +9,5 @@ RSpec.configure do |config|
   end
 
   config.include ViewComponent::TestHelpers, type: :component
+  config.include Capybara::RSpecMatchers, type: :component
 end


### PR DESCRIPTION
...But will get a DOI when it is deposited.


## Why was this change made?

Fixes #1959

## How was this change tested?



## Which documentation and/or configurations were updated?



