### PR TITLE
allow reviewers and collection managers to delete works

### DIFF
--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -12,10 +12,15 @@ class WorkPolicy < ApplicationPolicy
   end
 
   def destroy?
-    (administrator? || depositor?) && record.persisted? && record.head.deleteable?
+    (administrator? || depositor? || reviews_collection? || manages_collection?(collection)) &&
+      record.persisted? && record.head.deleteable?
   end
 
   delegate :administrator?, to: :user_with_groups
+
+  def reviews_collection?
+    allowed_to?(:review?, record.collection)
+  end
 
   def depositor?
     record.depositor == user


### PR DESCRIPTION
## Why was this change made?

To address #1951 - add collection managers and reviewers to the work delete policy

## How was this change tested?

Existing tests


## Which documentation and/or configurations were updated?



