### PR TITLE
Determines type of subject terms from FAST and include in cocina.

### DIFF
--- a/app/components/works/keywords_row_component.html.erb
+++ b/app/components/works/keywords_row_component.html.erb
@@ -3,7 +3,11 @@
     <%= form.label :label, 'Keyword', class: 'col-form-label sr-only' %>
     <div data-controller="autocomplete autocomplete-edit" data-autocomplete-url-value="/autocomplete" data-autocomplete-min-length-value="3" class="dropdown">
       <%= form.text_field :label, { class: "form-control#{ 'is-invalid' if error?}", required: true, 'data-autocomplete-target': 'input', 'data-autocomplete-edit-target': 'input' } %>
-      <%= form.hidden_field :uri, { required: true, 'data-autocomplete-target': 'hidden', 'data-autocomplete-edit-target': 'uri', 'data-action': 'autocomplete-edit#change' }%>
+      <!-- This input is populated by autocomplete controller.-->
+      <!-- That triggers the autocomplete-edit controller, which populates the uri and cocina type inputs. -->
+      <input type="hidden" data-autocomplete-target="hidden" data-autocomplete-edit-target="value" data-action="autocomplete-edit#change" />
+      <%= form.hidden_field :uri, { required: true, 'data-autocomplete-edit-target': 'uri' }%>
+      <%= form.hidden_field :cocina_type, { required: true, 'data-autocomplete-edit-target': 'type' }%>
       <ul class="show dropdown-menu" data-autocomplete-target="results"></ul>
       <div class="invalid-feedback">Keyword must be filled in</div>
     </div>

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -225,7 +225,7 @@ class WorksController < ObjectsController
                      authors_attributes: %i[_destroy id full_name first_name last_name role_term weight orcid],
                      contributors_attributes: %i[_destroy id full_name first_name last_name role_term],
                      contact_emails_attributes: %i[_destroy id email],
-                     keywords_attributes: %i[_destroy id label uri],
+                     keywords_attributes: %i[_destroy id label uri cocina_type],
                      related_works_attributes: %i[_destroy id citation],
                      related_links_attributes: %i[_destroy id link_title url])
   end

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -127,6 +127,7 @@ class DraftWorkForm < Reform::Form
     property :id, type: Dry::Types['params.nil'] | Dry::Types['params.integer']
     property :label
     property :uri
+    property :cocina_type
     property :_destroy, virtual: true, type: Dry::Types['params.nil'] | Dry::Types['params.bool']
   end
 

--- a/app/packs/controllers/autocomplete_edit_controller.js
+++ b/app/packs/controllers/autocomplete_edit_controller.js
@@ -1,15 +1,18 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  static targets = ["uri", "input"]
+  static targets = ["uri", "input", "value", "type"]
 
   connect() {
     this.change()
   }
 
   change() {
-    if(this.uriTarget.value) {
+    if(this.valueTarget.value) {
       this.inputTarget.readOnly = true
+      const [uri, cocina_type] = this.valueTarget.value.split('::')
+      this.uriTarget.value = uri
+      this.typeTarget.value = cocina_type
     }
   }
 }

--- a/app/services/cocina_generator/description/generator.rb
+++ b/app/services/cocina_generator/description/generator.rb
@@ -56,7 +56,7 @@ module CocinaGenerator
       def keywords
         work_version.keywords.map do |keyword|
           props = {
-            value: keyword.label, type: 'topic'
+            value: keyword.label, type: keyword.cocina_type || 'topic'
           }
           if keyword.uri.present?
             props[:uri] = keyword.uri

--- a/db/migrate/20210816133101_add_cocina_type_to_keywords.rb
+++ b/db/migrate/20210816133101_add_cocina_type_to_keywords.rb
@@ -1,0 +1,5 @@
+class AddCocinaTypeToKeywords < ActiveRecord::Migration[6.1]
+  def change
+    add_column :keywords, :cocina_type, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -370,7 +370,8 @@ CREATE TABLE public.keywords (
     label character varying,
     uri character varying,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    cocina_type character varying
 );
 
 
@@ -1291,6 +1292,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210616201626'),
 ('20210719185721'),
 ('20210721164925'),
-('20210802203252');
+('20210802203252'),
+('20210816133101');
 
 

--- a/spec/factories/keywords.rb
+++ b/spec/factories/keywords.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     work_version { nil }
     label { 'MyKeyword' }
     uri { 'http://example.org/uri' }
+    cocina_type { 'place' }
   end
 end

--- a/spec/requests/autocomplete_spec.rb
+++ b/spec/requests/autocomplete_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Autocomplete Controller' do
     }
   end
 
-  let(:other_params) { '&rows=20&start=0&version=2.2&indent=on&fl=id,fullphrase&sort=usage+desc' }
+  let(:other_params) { '&rows=20&start=0&version=2.2&indent=on&fl=id,fullphrase,type&sort=usage+desc' }
 
   context 'when lookup is successful without wildcard' do
     let(:lookup_resp_body) do
@@ -19,79 +19,86 @@ RSpec.describe 'Autocomplete Controller' do
                 <?xml version="1.0" encoding="UTF-8"?>
                 <response>
         #{'        '}
-                <lst name="responseHeader">
-                  <int name="status">0</int>
-                  <int name="QTime">1</int>
-                  <lst name="params">
-                    <str name="q">keywords:(tea)</str>
-                    <str name="indent">on</str>
-                    <str name="fl">id,fullphrase</str>
-                    <str name="start">0</str>
-                    <str name="sort">usage desc</str>
-                    <str name="rows">20</str>
-                    <str name="version">2.2</str>
-                  </lst>
-                </lst>
                 <result name="response" numFound="299" start="0">
                   <doc>
                     <str name="id">fst00537796</str>
+                    <str name="type">corporate</str>
                     <str name="fullphrase">East India Company</str></doc>
                   <doc>
                     <str name="id">fst01144120</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Tea</str></doc>
                   <doc>
                     <str name="id">fst01144179</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Tea trade</str></doc>
                   <doc>
                     <str name="id">fst00981955</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Japanese tea ceremony</str></doc>
                   <doc>
                     <str name="id">fst01144712</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Tearooms</str></doc>
                   <doc>
                     <str name="id">fst00981970</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Japanese tea ceremony--Utensils</str></doc>
                   <doc>
                     <str name="id">fst00800074</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Afternoon teas</str></doc>
                   <doc>
                     <str name="id">fst01144148</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Tea--Therapeutic use</str></doc>
                   <doc>
                     <str name="id">fst00955318</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Herbal teas</str></doc>
                   <doc>
                     <str name="id">fst01802011</str>
+                    <str name="type">event</str>
                     <str name="fullphrase">Boston Tea Party (Boston, Massachusetts : 1773)</str></doc>
                   <doc>
                     <str name="id">fst01753202</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Cooking (Tea)</str></doc>
                   <doc>
                     <str name="id">fst01144165</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Tea making paraphernalia</str></doc>
                   <doc>
                     <str name="id">fst01762507</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Tea Party movement</str></doc>
                   <doc>
                     <str name="id">fst01144178</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Tea tax (American colonies)</str></doc>
                   <doc>
                     <str name="id">fst00852551</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Chashitsu (Japanese tearooms)</str></doc>
                   <doc>
                     <str name="id">fst01144144</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Tea--Social aspects</str></doc>
                   <doc>
                     <str name="id">fst01144131</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Tea--Health aspects</str></doc>
                   <doc>
                     <str name="id">fst00955319</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Herbal teas--Therapeutic use</str></doc>
                   <doc>
                     <str name="id">fst00981974</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Japanese tea masters</str></doc>
                   <doc>
                     <str name="id">fst01744455</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Chinese tea ceremony</str></doc>
                 </result>
                 </response>
@@ -101,16 +108,16 @@ RSpec.describe 'Autocomplete Controller' do
     # returns the first ten deduplicated _authorized_ forms of FAST terms that match the entered letters.
     let(:suggestions) do
       [
-        { 'Tea' => 'http://id.worldcat.org/fast/1144120/' },
-        { 'Tea Party movement' => 'http://id.worldcat.org/fast/1762507/' },
-        { 'Tea making paraphernalia' => 'http://id.worldcat.org/fast/1144165/' },
-        { 'Tea tax (American colonies)' => 'http://id.worldcat.org/fast/1144178/' },
-        { 'Tea trade' => 'http://id.worldcat.org/fast/1144179/' },
-        { 'Tea--Health aspects' => 'http://id.worldcat.org/fast/1144131/' },
-        { 'Tea--Social aspects' => 'http://id.worldcat.org/fast/1144144/' },
-        { 'Tea--Therapeutic use' => 'http://id.worldcat.org/fast/1144148/' },
-        { 'Tearooms' => 'http://id.worldcat.org/fast/1144712/' },
-        { 'East India Company' => 'http://id.worldcat.org/fast/537796/' }
+        { 'Tea' => 'http://id.worldcat.org/fast/1144120/::topic' },
+        { 'Tea Party movement' => 'http://id.worldcat.org/fast/1762507/::topic' },
+        { 'Tea making paraphernalia' => 'http://id.worldcat.org/fast/1144165/::topic' },
+        { 'Tea tax (American colonies)' => 'http://id.worldcat.org/fast/1144178/::topic' },
+        { 'Tea trade' => 'http://id.worldcat.org/fast/1144179/::topic' },
+        { 'Tea--Health aspects' => 'http://id.worldcat.org/fast/1144131/::topic' },
+        { 'Tea--Social aspects' => 'http://id.worldcat.org/fast/1144144/::topic' },
+        { 'Tea--Therapeutic use' => 'http://id.worldcat.org/fast/1144148/::topic' },
+        { 'Tearooms' => 'http://id.worldcat.org/fast/1144712/::topic' },
+        { 'East India Company' => 'http://id.worldcat.org/fast/537796/::organization' }
       ]
     end
 
@@ -133,25 +140,14 @@ RSpec.describe 'Autocomplete Controller' do
                 <?xml version="1.0" encoding="UTF-8"?>
                 <response>
         #{'        '}
-                <lst name="responseHeader">
-                  <int name="status">0</int>
-                  <int name="QTime">1</int>
-                  <lst name="params">
-                    <str name="q">keywords:(tesl)</str>
-                    <str name="indent">on</str>
-                    <str name="fl">id,fullphrase</str>
-                    <str name="start">0</str>
-                    <str name="sort">usage desc</str>
-                    <str name="rows">20</str>
-                    <str name="version">2.2</str>
-                  </lst>
-                </lst>
                 <result name="response" numFound="2" start="0">
                   <doc>
                     <str name="id">fst00911692</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">English language--Study and teaching--Foreign speakers</str></doc>
                   <doc>
                     <str name="id">fst01787825</str>
+                    <str name="type">corporate</str>
                     <str name="fullphrase">Muzej Nikole Tesle</str></doc>
                 </result>
                 </response>
@@ -165,11 +161,11 @@ RSpec.describe 'Autocomplete Controller' do
         #{'        '}
                 <lst name="responseHeader">
                   <int name="status">0</int>
-                  <int name="QTime">1</int>
+                  <int name="QTime">0</int>
                   <lst name="params">
                     <str name="q">keywords:(tesl*)</str>
                     <str name="indent">on</str>
-                    <str name="fl">id,fullphrase</str>
+                    <str name="fl">id,fullphrase,type</str>
                     <str name="start">0</str>
                     <str name="sort">usage desc</str>
                     <str name="rows">20</str>
@@ -179,63 +175,83 @@ RSpec.describe 'Autocomplete Controller' do
                 <result name="response" numFound="24" start="0">
                   <doc>
                     <str name="id">fst00911692</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">English language--Study and teaching--Foreign speakers</str></doc>
                   <doc>
                     <str name="id">fst00028173</str>
+                    <str name="type">person</str>
                     <str name="fullphrase">Tesla, Nikola, 1856-1943</str></doc>
                   <doc>
                     <str name="id">fst01917360</str>
+                    <str name="type">corporate</str>
                     <str name="fullphrase">Tesla Motors</str></doc>
                   <doc>
                     <str name="id">fst01148179</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Tesla coils</str></doc>
                   <doc>
                     <str name="id">fst00081416</str>
+                    <str name="type">person</str>
                     <str name="fullphrase">Teslenko, Arkhyp I︠U︡khymovych, 1882-1911</str></doc>
                   <doc>
                     <str name="id">fst01622914</str>
+                    <str name="type">corporate</str>
                     <str name="fullphrase">Teslin Tlingit Council</str></doc>
                   <doc>
                     <str name="id">fst01742752</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Tesla Roadster automobile</str></doc>
                   <doc>
                     <str name="id">fst01787825</str>
+                    <str name="type">corporate</str>
                     <str name="fullphrase">Muzej Nikole Tesle</str></doc>
                   <doc>
                     <str name="id">fst00665529</str>
+                    <str name="type">corporate</str>
                     <str name="fullphrase">Tesla (Musical group)</str></doc>
                   <doc>
                     <str name="id">fst00483782</str>
+                    <str name="type">person</str>
                     <str name="fullphrase">Tesla, Nikola, 1856-1943 (Spirit)</str></doc>
                   <doc>
                     <str name="id">fst01292783</str>
+                    <str name="type">geographic</str>
                     <str name="fullphrase">California--Tesla</str></doc>
                   <doc>
                     <str name="id">fst01311465</str>
+                    <str name="type">geographic</str>
                     <str name="fullphrase">Canada--Teslin River</str></doc>
                   <doc>
                     <str name="id">fst01696224</str>
+                    <str name="type">geographic</str>
                     <str name="fullphrase">Serbia--Nikola Tesla</str></doc>
                   <doc>
                     <str name="id">fst01850620</str>
+                    <str name="type">person</str>
                     <str name="fullphrase">Teslenko, Nikolaĭ V., 1870-1942</str></doc>
                   <doc>
                     <str name="id">fst01983442</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Tesla Model S automobile</str></doc>
                   <doc>
                     <str name="id">fst00790766</str>
+                    <str name="type">corporate</str>
                     <str name="fullphrase">Tesla Power Project</str></doc>
                   <doc>
                     <str name="id">fst01983485</str>
+                    <str name="type">topic</str>
                     <str name="fullphrase">Tesla automobiles</str></doc>
                   <doc>
                     <str name="id">fst00494688</str>
+                    <str name="type">person</str>
                     <str name="fullphrase">Tesli︠a︡, Ivan</str></doc>
                   <doc>
                     <str name="id">fst01475215</str>
+                    <str name="type">person</str>
                     <str name="fullphrase">Teslenko, O. P. (Olʹga Pankratʹevna)</str></doc>
                   <doc>
                     <str name="id">fst01662813</str>
+                    <str name="type">person</str>
                     <str name="fullphrase">Tesler, Oleg</str></doc>
                 </result>
                 </response>
@@ -245,16 +261,16 @@ RSpec.describe 'Autocomplete Controller' do
     # returns the first ten deduplicated _authorized_ forms of FAST terms that match the entered letters.
     let(:suggestions) do
       [
-        { 'Tesla (Musical group)' => 'http://id.worldcat.org/fast/665529/' },
-        { 'Tesla Model S automobile' => 'http://id.worldcat.org/fast/1983442/' },
-        { 'Tesla Motors' => 'http://id.worldcat.org/fast/1917360/' },
-        { 'Tesla Power Project' => 'http://id.worldcat.org/fast/790766/' },
-        { 'Tesla Roadster automobile' => 'http://id.worldcat.org/fast/1742752/' },
-        { 'Tesla automobiles' => 'http://id.worldcat.org/fast/1983485/' },
-        { 'Tesla coils' => 'http://id.worldcat.org/fast/1148179/' },
-        { 'Tesla, Nikola, 1856-1943' => 'http://id.worldcat.org/fast/28173/' },
-        { 'Tesla, Nikola, 1856-1943 (Spirit)' => 'http://id.worldcat.org/fast/483782/' },
-        { 'Teslenko, Arkhyp I︠U︡khymovych, 1882-1911' => 'http://id.worldcat.org/fast/81416/' }
+        { 'Tesla (Musical group)' => 'http://id.worldcat.org/fast/665529/::organization' },
+        { 'Tesla Model S automobile' => 'http://id.worldcat.org/fast/1983442/::topic' },
+        { 'Tesla Motors' => 'http://id.worldcat.org/fast/1917360/::organization' },
+        { 'Tesla Power Project' => 'http://id.worldcat.org/fast/790766/::organization' },
+        { 'Tesla Roadster automobile' => 'http://id.worldcat.org/fast/1742752/::topic' },
+        { 'Tesla automobiles' => 'http://id.worldcat.org/fast/1983485/::topic' },
+        { 'Tesla coils' => 'http://id.worldcat.org/fast/1148179/::topic' },
+        { 'Tesla, Nikola, 1856-1943' => 'http://id.worldcat.org/fast/28173/::person' },
+        { 'Tesla, Nikola, 1856-1943 (Spirit)' => 'http://id.worldcat.org/fast/483782/::person' },
+        { 'Teslenko, Arkhyp I︠U︡khymovych, 1882-1911' => 'http://id.worldcat.org/fast/81416/::person' }
       ]
     end
 

--- a/spec/services/cocina_generator/description/generator_spec.rb
+++ b/spec/services/cocina_generator/description/generator_spec.rb
@@ -169,9 +169,9 @@ RSpec.describe CocinaGenerator::Description::Generator do
         }
       ],
       subject: [
-        { type: 'topic', value: 'MyKeyword', uri: 'http://example.org/uri', source: fast_source },
-        { type: 'topic', value: 'MyKeyword', uri: 'http://example.org/uri', source: fast_source },
-        { type: 'topic', value: 'MyKeyword', uri: 'http://example.org/uri', source: fast_source }
+        { type: 'place', value: 'MyKeyword', uri: 'http://example.org/uri', source: fast_source },
+        { type: 'place', value: 'MyKeyword', uri: 'http://example.org/uri', source: fast_source },
+        { type: 'place', value: 'MyKeyword', uri: 'http://example.org/uri', source: fast_source }
       ],
       note: [
         { type: 'abstract', value: 'test abstract' },
@@ -537,8 +537,8 @@ RSpec.describe CocinaGenerator::Description::Generator do
     end
   end
 
-  context 'with subject that has a blank URI' do
-    let(:keyword) { build(:keyword, uri: '') }
+  context 'with subject that has a blank URI and no cocina type' do
+    let(:keyword) { build(:keyword, uri: '', cocina_type: nil) }
 
     let(:work_version) do
       build(:work_version, keywords: [keyword])


### PR DESCRIPTION
closes #1874

## Why was this change made?
Accurate subject metadata.


## How was this change tested?
Unit

## Which documentation and/or configurations were updated?
NA


