### PR TITLE
Upgrade to cocina models 0.62.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem 'redis', '~> 4.0'
 # pinned because 2.6.0 broke the build: [Reform] Your :populator did not return a Reform::Form instance for `authors`.
 gem 'reform', '~> 2.5.0'
 gem 'reform-rails', '~> 0.2.0'
-gem 'sdr-client', '~> 0.58'
+gem 'sdr-client', '~> 0.60'
 gem 'sidekiq', '~> 6.1'
 gem 'sneakers', '~> 2.11' # rabbitMQ background processing
 gem 'state_machines-activerecord'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       capybara (>= 1.0, < 4)
       launchy
     chronic (0.10.2)
-    cocina-models (0.61.3)
+    cocina-models (0.62.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -406,9 +406,9 @@ GEM
     ruby-next-core (0.12.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    sdr-client (0.59.0)
+    sdr-client (0.60.0)
       activesupport
-      cocina-models (~> 0.61.0)
+      cocina-models (~> 0.62.0)
       dry-monads
       faraday (>= 0.16)
     semantic_range (3.0.0)
@@ -551,7 +551,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
-  sdr-client (~> 0.58)
+  sdr-client (~> 0.60)
   sidekiq (~> 6.1)
   simplecov
   sneakers (~> 2.11)

--- a/app/services/cocina_generator/description/related_links_generator.rb
+++ b/app/services/cocina_generator/description/related_links_generator.rb
@@ -35,10 +35,10 @@ module CocinaGenerator
         Cocina::Models::RelatedResource.new(resource_attrs)
       end
 
-      # This normalizes the PURL link to http (as it is currently the canonincal PURL)
+      # This normalizes the PURL link to https (as it is currently the canonincal PURL)
       def purl_link(rel_link)
         resource_attrs = {
-          purl: rel_link.url.sub(/^https/, 'http'),
+          purl: rel_link.url.sub(/^https?/, 'https'),
           access: Cocina::Models::DescriptiveAccessMetadata.new(
             digitalRepository: [Cocina::Models::DescriptiveValue.new(value: 'Stanford Digital Repository')]
           )

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,7 +44,7 @@ autocomplete_lookup:
 file_uploads_root: tmp/uploads
 
 faq_url: https://library.stanford.edu/research/stanford-digital-repository/terms-deposit
-purl_url: http://purl.stanford.edu
+purl_url: https://purl.stanford.edu
 terms_url: https://stanford.app.box.com/s/lozngarhdzj56z44la38v1zn3a1ggbyu
 sdr_url: https://library.stanford.edu/research/stanford-digital-repository
 

--- a/spec/components/dashboard/collection_component_spec.rb
+++ b/spec/components/dashboard/collection_component_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Dashboard::CollectionComponent, type: :component do
     end
 
     it 'renders a link to purl' do
-      expect(rendered.css('a').map { |node| node['href'] }).to include 'http://purl.stanford.edu/yq268qt4607'
+      expect(rendered.css('a').map { |node| node['href'] }).to include 'https://purl.stanford.edu/yq268qt4607'
     end
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe Collection do
     context 'with a druid' do
       it 'constructs purl' do
         collection.update(druid: 'druid:hb093rg5848')
-        expect(collection.purl).to eq('http://purl.stanford.edu/hb093rg5848')
+        expect(collection.purl).to eq 'https://purl.stanford.edu/hb093rg5848'
       end
     end
 
     context 'with no druid' do
       it 'returns nil' do
-        expect(collection.purl).to eq(nil)
+        expect(collection.purl).to be_nil
       end
     end
   end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe Work do
     context 'with a druid' do
       it 'constructs purl' do
         work.update(druid: 'druid:hb093rg5848')
-        expect(work.purl).to eq('http://purl.stanford.edu/hb093rg5848')
+        expect(work.purl).to eq 'https://purl.stanford.edu/hb093rg5848'
       end
     end
 
     context 'with no druid' do
       it 'returns nil' do
-        expect(work.purl).to eq(nil)
+        expect(work.purl).to be_nil
       end
     end
   end

--- a/spec/services/cocina_generator/collection_generator_spec.rb
+++ b/spec/services/cocina_generator/collection_generator_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe CocinaGenerator::CollectionGenerator do
               value: 'Test title'
             }
           ],
-          purl: 'http://purl.stanford.edu/bk123gh4567',
+          purl: 'https://purl.stanford.edu/bk123gh4567',
           access: {
             accessContact: [
               {

--- a/spec/services/cocina_generator/description/related_links_generator_spec.rb
+++ b/spec/services/cocina_generator/description/related_links_generator_spec.rb
@@ -36,12 +36,12 @@ RSpec.describe CocinaGenerator::Description::RelatedLinksGenerator do
     it 'creates related links' do
       expect(model).to eq([
                             {
-                              purl: 'http://purl.stanford.edu/tx853fp2857',
+                              purl: 'https://purl.stanford.edu/tx853fp2857',
                               title: [{ value: 'My Awesome Research' }],
                               access: { digitalRepository: [{ value: 'Stanford Digital Repository' }] }
                             },
                             {
-                              purl: 'http://purl.stanford.edu/xy933bc2222',
+                              purl: 'https://purl.stanford.edu/xy933bc2222',
                               title: [{ value: 'My Awesome Research' }],
                               access: { digitalRepository: [{ value: 'Stanford Digital Repository' }] }
                             },

--- a/spec/services/cocina_generator/dro_generator_spec.rb
+++ b/spec/services/cocina_generator/dro_generator_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe CocinaGenerator::DROGenerator do
             ],
             form: types_form,
             access: { digitalRepository: [{ value: 'Stanford Digital Repository' }] },
-            purl: 'http://purl.stanford.edu/bk123gh4567',
+            purl: 'https://purl.stanford.edu/bk123gh4567',
             adminMetadata: admin_metadata
           },
           identification: {
@@ -331,7 +331,7 @@ RSpec.describe CocinaGenerator::DROGenerator do
             ],
             form: types_form,
             access: { digitalRepository: [{ value: 'Stanford Digital Repository' }] },
-            purl: 'http://purl.stanford.edu/bk123gh4567',
+            purl: 'https://purl.stanford.edu/bk123gh4567',
             adminMetadata: admin_metadata
           },
           identification: {


### PR DESCRIPTION


## Why was this change made?
Make PURL use https by default.


## How was this change tested?



## Which documentation and/or configurations were updated?



