### PR TITLE
switch from apparition to cuprite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,9 +30,9 @@ group :development do
 end
 
 group :test do
-  gem 'apparition'
   gem 'capybara', '~> 3.34'
   gem 'capybara-screenshot'
+  gem 'cuprite'
 end
 
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,9 +67,6 @@ GEM
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     amq-protocol (2.3.2)
-    apparition (0.6.0)
-      capybara (~> 3.13, < 4)
-      websocket-driver (>= 0.6.5)
     ast (2.4.2)
     attr_extras (6.2.4)
     bcrypt (3.1.16)
@@ -120,6 +117,7 @@ GEM
       capybara (>= 1.0, < 4)
       launchy
     chronic (0.10.2)
+    cliver (0.3.2)
     cocina-models (0.62.0)
       activesupport
       dry-struct (~> 1.0)
@@ -137,6 +135,9 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    cuprite (0.13)
+      capybara (>= 2.1, < 4)
+      ferrum (~> 0.11.0)
     declarative (0.0.20)
     declarative-builder (0.1.0)
       declarative-option (< 0.2.0)
@@ -239,6 +240,11 @@ GEM
     faraday-rack (1.0.0)
     faraday_middleware (1.1.0)
       faraday (~> 1.0)
+    ferrum (0.11)
+      addressable (~> 2.5)
+      cliver (~> 0.3)
+      concurrent-ruby (~> 1.1)
+      websocket-driver (>= 0.6, < 0.8)
     ffi (1.15.3)
     globalid (0.5.2)
       activesupport (>= 5.0)
@@ -511,7 +517,6 @@ PLATFORMS
 DEPENDENCIES
   action_policy (~> 0.5.3)
   addressable (~> 2.8.0)
-  apparition
   bootsnap (>= 1.4.2)
   bunny (~> 2.17)
   byebug
@@ -522,6 +527,7 @@ DEPENDENCIES
   capybara (~> 3.34)
   capybara-screenshot
   config (~> 2.2)
+  cuprite
   devise (~> 4.7)
   devise-remote-user (~> 1.0)
   dlss-capistrano (~> 3.11)

--- a/spec/features/purl_reservation_spec.rb
+++ b/spec/features/purl_reservation_spec.rb
@@ -59,7 +59,9 @@ RSpec.describe 'Reserve a PURL for a work in a deposited collection', js: true d
     it 'from the dashboard' do
       visit dashboard_path
 
-      click_link "Choose Type and Edit #{work_version.title}"
+      within_table collection_version.name do
+        click_link "Choose Type and Edit #{work_version.title}"
+      end
       find('label', text: 'Music').click
       check 'Sound'
       check 'Image'

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
-require 'capybara/apparition'
+require 'capybara/cuprite'
 require 'capybara/rails'
 require 'capybara/rspec'
 
-# Uncomment for a headed browser:
-# Capybara.register_driver :apparition do |app|
-#   Capybara::Apparition::Driver.new(app, headless: false)
-# end
+Capybara.javascript_driver = :cuprite
+Capybara.register_driver(:cuprite) do |app|
+  Capybara::Cuprite::Driver.new(app, window_size: [1200, 800])
+end
 
-Capybara.javascript_driver = :apparition
 Capybara.disable_animation = true
 Capybara.enable_aria_label = true
 Capybara.server = :puma, { Silent: true }


### PR DESCRIPTION

## Why was this change made?

Cuprite is now a Rails default and it doesn't throw all the deprecation warnings that apparition does.
Fixes #1966


## How was this change tested?



## Which documentation and/or configurations were updated?



