### PR TITLE
Restrict files to stanford-only when the object access stanford

### DIFF
--- a/app/services/cocina_generator/structural/file_generator.rb
+++ b/app/services/cocina_generator/structural/file_generator.rb
@@ -78,7 +78,7 @@ module CocinaGenerator
         if hidden_file?
           { access: 'dark', download: 'none' }
         else
-          { access: 'world', download: 'world' }
+          { access: work_version.access, download: work_version.access }
         end
       end
 

--- a/spec/services/cocina_generator/structural/file_generator_spec.rb
+++ b/spec/services/cocina_generator/structural/file_generator_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 RSpec.describe CocinaGenerator::Structural::FileGenerator do
   let(:model) { described_class.generate(work_version: work_version, attached_file: attached_file) }
-  let(:work_version) { build(:work_version) }
 
   describe '#access' do
     subject { model.access }
@@ -12,10 +11,21 @@ RSpec.describe CocinaGenerator::Structural::FileGenerator do
     context 'when file is visible' do
       let(:attached_file) { create(:attached_file, :with_file, work_version: work_version) }
 
-      it { is_expected.to eq Cocina::Models::FileAccess.new(access: 'world', download: 'world') }
+      context 'when work is public' do
+        let(:work_version) { build(:work_version) }
+
+        it { is_expected.to eq Cocina::Models::FileAccess.new(access: 'world', download: 'world') }
+      end
+
+      context 'when work is stanford-only' do
+        let(:work_version) { build(:work_version, access: 'stanford') }
+
+        it { is_expected.to eq Cocina::Models::FileAccess.new(access: 'stanford', download: 'stanford') }
+      end
     end
 
     context 'when file is hidden' do
+      let(:work_version) { build(:work_version) }
       let(:attached_file) { create(:attached_file, :with_file, work_version: work_version, hide: true) }
 
       it { is_expected.to eq Cocina::Models::FileAccess.new(access: 'dark', download: 'none') }


### PR DESCRIPTION


## Why was this change made?

Fixes #1933

## How was this change tested?



## Which documentation and/or configurations were updated?



