### PR TITLE
Enable user to delete the first entry of multi-entry fields.

### DIFF
--- a/app/components/related_link_row_component.html.erb
+++ b/app/components/related_link_row_component.html.erb
@@ -7,13 +7,11 @@
     </div>
 
     <div class="col-md-1">
-      <% if not_first_link? %>
-        <%= button_tag type: 'button', class: 'btn btn-sm float-end', aria: { label: "Remove #{link_title}" },
-                       data: { action: "click->nested-form#removeAssociation" } do %>
-          <span class="far fa-trash-alt"></span>
-        <% end %>
-        <%= form.hidden_field :_destroy %>
+      <%= button_tag type: 'button', class: 'btn btn-sm float-end', aria: { label: "Remove #{link_title}" },
+                     data: { action: "click->nested-form#removeAssociation" } do %>
+        <span class="far fa-trash-alt"></span>
       <% end %>
+      <%= form.hidden_field :_destroy %>
     </div>
   </div>
 

--- a/app/components/related_link_row_component.rb
+++ b/app/components/related_link_row_component.rb
@@ -10,10 +10,6 @@ class RelatedLinkRowComponent < ApplicationComponent
 
   delegate :link_title, to: :model_instance
 
-  def not_first_link?
-    form.index != 0
-  end
-
   def model_instance
     form.object
   end

--- a/app/components/works/contact_email_row_component.html.erb
+++ b/app/components/works/contact_email_row_component.html.erb
@@ -7,7 +7,6 @@
                          pattern: Devise.email_regexp.source, required: true %>
     <div class="invalid-feedback">You must provide a valid email address</div>
   </div>
-  <% if not_first_email? %>
   <div class="col-sm-1">
     <%= button_tag type: 'button', class: 'btn btn-sm float-end', aria: { label: 'Remove' },
      data: { action: "click->nested-form#removeAssociation",
@@ -16,5 +15,4 @@
     <% end %>
     <%= form.hidden_field :_destroy %>
   </div>
-  <% end %>
 </div>

--- a/app/components/works/contact_email_row_component.rb
+++ b/app/components/works/contact_email_row_component.rb
@@ -14,10 +14,6 @@ module Works
       render PopoverComponent.new key: key
     end
 
-    def not_first_email?
-      form.index != 0
-    end
-
     def bootstrap_classes
       return 'col-sm-10 col-xl-8' if form.object_name.start_with?('collection')
 

--- a/app/components/works/related_work_row_component.html.erb
+++ b/app/components/works/related_work_row_component.html.erb
@@ -9,13 +9,11 @@
     </div>
 
     <div class="col-md-1">
-      <% if not_first_work? %>
-        <%= button_tag type: 'button', class: 'btn btn-sm float-end', aria: { label: "Remove #{citation}" },
-                       data: { action: "click->nested-form#removeAssociation" } do %>
-          <span class="far fa-trash-alt"></span>
-        <% end %>
-        <%= form.hidden_field :_destroy %>
+      <%= button_tag type: 'button', class: 'btn btn-sm float-end', aria: { label: "Remove #{citation}" },
+                     data: { action: "click->nested-form#removeAssociation" } do %>
+        <span class="far fa-trash-alt"></span>
       <% end %>
+      <%= form.hidden_field :_destroy %>
     </div>
   </div>
 </div>

--- a/app/components/works/related_work_row_component.rb
+++ b/app/components/works/related_work_row_component.rb
@@ -11,10 +11,6 @@ module Works
 
     delegate :citation, to: :work
 
-    def not_first_work?
-      form.index != 0
-    end
-
     def work
       form.object
     end

--- a/spec/components/related_link_component_spec.rb
+++ b/spec/components/related_link_component_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe RelatedLinkComponent, type: :component do
     let(:work_version) { build_stubbed(:work_version, related_links: related_links) }
     let(:model_form) { WorkForm.new(work_version: work_version, work: work) }
 
-    it 'renders a delete button for all links but the first' do
+    it 'renders a delete button for all links' do
       expect(rendered.css('button[@aria-label="Remove Second Link"]')).to be_present
-      expect(rendered.css('button[@aria-label="Remove First Link"]')).not_to be_present
+      expect(rendered.css('button[@aria-label="Remove First Link"]')).to be_present
     end
   end
 
@@ -28,9 +28,9 @@ RSpec.describe RelatedLinkComponent, type: :component do
     let(:collection) { collection_version.collection }
     let(:collection_version) { build_stubbed(:collection_version, related_links: related_links) }
 
-    it 'renders a delete button for all links but the first' do
+    it 'renders a delete button for all links' do
       expect(rendered.css('button[@aria-label="Remove Second Link"]')).to be_present
-      expect(rendered.css('button[@aria-label="Remove First Link"]')).not_to be_present
+      expect(rendered.css('button[@aria-label="Remove First Link"]')).to be_present
     end
   end
 end

--- a/spec/components/works/related_work_component_spec.rb
+++ b/spec/components/works/related_work_component_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Works::RelatedWorkComponent, type: :component do
   let(:work_version) { build_stubbed(:work_version, related_works: related_works) }
   let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
 
-  it 'renders a delete button for all works but the first' do
+  it 'renders a delete button for all works' do
     expect(rendered.css('button[@aria-label="Remove Second Citation"]')).to be_present
-    expect(rendered.css('button[@aria-label="Remove First Citation"]')).not_to be_present
+    expect(rendered.css('button[@aria-label="Remove First Citation"]')).to be_present
   end
 end


### PR DESCRIPTION
closes #1499

## Why was this change made?
UX


## How was this change tested?
Local, unit


## Which documentation and/or configurations were updated?
NA


