### PR TITLE
Remove col specification from file column for file table.

### DIFF
--- a/app/components/works/show/files_component.html.erb
+++ b/app/components/works/show/files_component.html.erb
@@ -1,7 +1,7 @@
 <table class="table table-sm mb-5">
   <thead class="table-light">
   <tr>
-    <th scope="col" class="table-title col-3">Files
+    <th scope="col" class="table-title">Files
       <span class="ms-3"><%= render Works::EditLinkComponent.new(work_version: work_version, anchor: 'file', label: 'Edit files') %></span>
       <%= link_to work_zip_path(work_version.work), class: 'ms-4' do %>
         <span class="fas fa-download" aria-hidden="true"></span><span class="visually-hidden">Download All Files</span>


### PR DESCRIPTION
closes #1888

## Why was this change made?
Allow the file name column to stretch for long file names.

![image](https://user-images.githubusercontent.com/588335/129905824-ca7ff0df-2a43-4ff2-8eda-55e12423abe0.png)


## How was this change tested?
Local


## Which documentation and/or configurations were updated?
NA


