### PR TITLE
Add custom validity for Orcid validation errors.

### DIFF
--- a/app/packs/controllers/contributors_controller.js
+++ b/app/packs/controllers/contributors_controller.js
@@ -108,6 +108,7 @@ export default class extends Controller {
   clearOrcidError() {
     this.orcidFeedbackTarget.innerText = 'You must provide an ORCID iD'
     this.orcidTarget.classList.remove('is-invalid')
+    this.orcidTarget.setCustomValidity('')
     this.orcidTarget.readOnly = false
   }
 
@@ -115,6 +116,7 @@ export default class extends Controller {
     this.orcidTarget.readOnly = false
     this.orcidFeedbackTarget.innerText = error
     this.orcidTarget.classList.add('is-invalid')
+    this.orcidTarget.setCustomValidity(error)
   }
 
   // Displays name retrieved for ORCID.


### PR DESCRIPTION
## Why was this change made?
The Orcid validation was not being applied when validating a form for deposit.

![image](https://user-images.githubusercontent.com/588335/129909268-5aaf84a4-3003-4f63-b70a-3da9056e6a89.png)


## How was this change tested?
Local


## Which documentation and/or configurations were updated?



