### PR TITLE
allow reviewers and collection managers to also delete work_versions

### DIFF
--- a/app/policies/work_version_policy.rb
+++ b/app/policies/work_version_policy.rb
@@ -57,7 +57,8 @@ class WorkVersionPolicy < ApplicationPolicy
   end
 
   def destroy?
-    (administrator? || depositor?) && record.persisted? && record.version_draft?
+    (administrator? || depositor? || reviews_collection? || manages_collection?(collection)) &&
+      record.persisted? && record.draft?
   end
 
   private

--- a/spec/policies/work_version_policy_spec.rb
+++ b/spec/policies/work_version_policy_spec.rb
@@ -151,6 +151,100 @@ RSpec.describe WorkVersionPolicy do
     end
   end
 
+  describe_rule :destroy? do
+    context 'when persisted and version_draft' do
+      before { record.state = 'version_draft' }
+
+      failed 'when user is not a depositor, reviewer or manager for the collection'
+
+      # `succeed` is `context` + `specify`, which checks
+      # that the result of application wasn't successful
+      succeed 'when user is a depositor' do
+        let(:work) { build_stubbed :work, depositor: user }
+      end
+
+      succeed 'when user is a collection manager' do
+        before { collection.managed_by = [user] }
+      end
+
+      succeed 'when user is a reviewer' do
+        before { collection.reviewed_by = [user] }
+      end
+
+      succeed 'when user is an admin' do
+        let(:groups) { [Settings.authorization_workgroup_names.administrators] }
+      end
+    end
+
+    context 'when persisted and first_draft' do
+      before { record.state = 'first_draft' }
+
+      failed 'when user is not a depositor, reviewer or manager for the collection'
+
+      # `succeed` is `context` + `specify`, which checks
+      # that the result of application wasn't successful
+      succeed 'when user is a depositor' do
+        let(:work) { build_stubbed :work, depositor: user }
+      end
+
+      succeed 'when user is a collection manager' do
+        before { collection.managed_by = [user] }
+      end
+
+      succeed 'when user is a reviewer' do
+        before { collection.reviewed_by = [user] }
+      end
+
+      succeed 'when user is an admin' do
+        let(:groups) { [Settings.authorization_workgroup_names.administrators] }
+      end
+    end
+
+    context 'when deposited (and thus not deletable)' do
+      before { record.state = 'deposited' }
+
+      failed 'when user is neither a depositor, reviewer or manager for the collection'
+
+      failed 'when user is a depositor' do
+        let(:work) { build_stubbed :work, depositor: user }
+      end
+
+      failed 'when user is a collection manager' do
+        before { collection.managed_by = [user] }
+      end
+
+      failed 'when user is a reviewer' do
+        before { collection.reviewed_by = [user] }
+      end
+
+      failed 'when user is an admin' do
+        let(:groups) { [Settings.authorization_workgroup_names.administrators] }
+      end
+    end
+
+    context 'when not persisted' do
+      let(:record) { WorkVersion.new(attributes_for(:work_version).merge(work: work)) }
+
+      failed 'when user is not a depositor, reviewer or manager for the collection'
+
+      failed 'when user is a depositor' do
+        let(:work) { build_stubbed :work, depositor: user }
+      end
+
+      failed 'when user is a collection manager' do
+        before { collection.managed_by = [user] }
+      end
+
+      failed 'when user is a reviewer' do
+        before { collection.reviewed_by = [user] }
+      end
+
+      failed 'when user is an admin' do
+        let(:groups) { [Settings.authorization_workgroup_names.administrators] }
+      end
+    end
+  end
+
   describe 'scope' do
     subject(:scope) { policy.apply_scope(collection.works, type: :active_record_relation, name: :edits) }
 


### PR DESCRIPTION
## Why was this change made?

To address https://github.com/sul-dlss/happy-heron/issues/1951#issuecomment-901451204 -- it looks like perhaps our updating of the work policy in #1964 now allows the delete icon to be shown for everyone who can delete, but when the deletion is actually attempted, the work_version policy prevented the deletion (for a collection manager).  The theory is that it works for admins and depositors since they are currently allowed to delete work_versions, but not for collection managers or reviewers because they are not currently allowed to delete work_versions.  This code matches up the work and work_version policies so that they are the same group of people.

## How was this change tested?

Added tests


## Which documentation and/or configurations were updated?



