### PR TITLE
refactor policies to remove code duplication for delete works

### DIFF
--- a/app/policies/common_work_policy.rb
+++ b/app/policies/common_work_policy.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Base class for work and work_version policies
+class CommonWorkPolicy < ApplicationPolicy
+  alias_rule :delete?, to: :destroy?
+
+  private
+
+  def administors_collection?
+    administrator? || depositor? || reviews_collection? || manages_collection?(collection)
+  end
+
+  def reviews_collection?
+    allowed_to?(:review?, collection)
+  end
+end

--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 # Authorization policy for Work objects
-class WorkPolicy < ApplicationPolicy
-  alias_rule :delete?, to: :destroy?
-
+class WorkPolicy < CommonWorkPolicy
   # Return the relation defining the collections you can view.
   scope_for :relation do |relation|
     relation.where(collection_id: user.manages_collection_ids + user.reviews_collection_ids).or(
@@ -12,15 +10,11 @@ class WorkPolicy < ApplicationPolicy
   end
 
   def destroy?
-    (administrator? || depositor? || reviews_collection? || manages_collection?(record.collection)) &&
-      record.persisted? && record.head.deleteable?
+    administors_collection? && record.persisted? && record.head.deleteable?
   end
 
   delegate :administrator?, to: :user_with_groups
-
-  def reviews_collection?
-    allowed_to?(:review?, record.collection)
-  end
+  delegate :collection, to: :record
 
   def depositor?
     record.depositor == user

--- a/app/policies/work_version_policy.rb
+++ b/app/policies/work_version_policy.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-# Authorization policy for WorkVersion   objects
-class WorkVersionPolicy < ApplicationPolicy
+# Authorization policy for WorkVersion objects
+class WorkVersionPolicy < CommonWorkPolicy
   alias_rule :edit?, :update_type?, to: :update?
-  alias_rule :delete?, to: :destroy?
 
   relation_scope :edits do |scope|
     if administrator?
@@ -57,8 +56,7 @@ class WorkVersionPolicy < ApplicationPolicy
   end
 
   def destroy?
-    (administrator? || depositor? || reviews_collection? || manages_collection?(collection)) &&
-      record.persisted? && record.draft?
+    administors_collection? && record.persisted? && record.draft?
   end
 
   private
@@ -71,9 +69,5 @@ class WorkVersionPolicy < ApplicationPolicy
 
   def depositor?
     record.work.depositor == user
-  end
-
-  def reviews_collection?
-    allowed_to?(:review?, collection)
   end
 end


### PR DESCRIPTION
## Why was this change made?

Follow on from #1980 to refactor work and work_version policy to avoid code duplication.  Create new base class for works and work_versions, move a couple methods there used by all work related policies.

## How was this change tested?

Existing tests


## Which documentation and/or configurations were updated?



