### PR TITLE
Fixes data sorting for All Collections table.

### DIFF
--- a/app/components/dashboard/all_collections_component.html.erb
+++ b/app/components/dashboard/all_collections_component.html.erb
@@ -25,7 +25,7 @@
         <th>Pending</th>
         <th>Returned</th>
         <th>Reserved</th>
-        <th>Last modified</th>
+        <th data-type="date" data-format="MMM DD, YYYY">Last modified</th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
closes #1999

## Why was this change made?



## How was this change tested?
Local

Before:
![image](https://user-images.githubusercontent.com/588335/130291779-34c2bdac-d8fd-42e2-b389-07c4dc65be43.png)


After:
![image](https://user-images.githubusercontent.com/588335/130291722-8cee27da-60e4-4fcd-9b8a-bba932762cf5.png)



## Which documentation and/or configurations were updated?



