### PR TITLE
Make the datacite specific form last

### DIFF
--- a/app/services/cocina_generator/description/types_generator.rb
+++ b/app/services/cocina_generator/description/types_generator.rb
@@ -15,8 +15,11 @@ module CocinaGenerator
         @work_version = work_version
       end
 
+      # Note that order is important here, because this is the order that dor-services-app
+      # will reconstruct the cocina from the mods.  If they are different it will raise a
+      # round tripping error.
       def generate
-        build_structured_values + datacite_type + build_genres + build_resource_types
+        build_structured_values + build_genres + build_resource_types + datacite_type
       end
 
       private

--- a/spec/services/cocina_generator/description/generator_spec.rb
+++ b/spec/services/cocina_generator/description/generator_spec.rb
@@ -42,13 +42,6 @@ RSpec.describe CocinaGenerator::Description::Generator do
         type: 'resource type'
       },
       {
-        value: 'Text',
-        type: 'resource type',
-        source: {
-          value: 'DataCite resource types'
-        }
-      },
-      {
         source: {
           code: 'marcgt'
         },
@@ -70,6 +63,13 @@ RSpec.describe CocinaGenerator::Description::Generator do
         },
         type: 'resource type',
         value: 'text'
+      },
+      {
+        value: 'Text',
+        type: 'resource type',
+        source: {
+          value: 'DataCite resource types'
+        }
       }
     ]
   end

--- a/spec/services/cocina_generator/description/types_generator_spec.rb
+++ b/spec/services/cocina_generator/description/types_generator_spec.rb
@@ -86,11 +86,6 @@ RSpec.describe CocinaGenerator::Description::TypesGenerator do
               type: 'resource type'
             ),
             Cocina::Models::DescriptiveValue.new(
-              type: 'resource type',
-              value: 'Image',
-              source: { value: 'DataCite resource types' }
-            ),
-            Cocina::Models::DescriptiveValue.new(
               type: 'genre',
               value: 'Computer-aided designs',
               uri: 'http://id.loc.gov/vocabulary/graphicMaterials/tgm002405',
@@ -100,6 +95,11 @@ RSpec.describe CocinaGenerator::Description::TypesGenerator do
               type: 'resource type',
               value: 'still image',
               source: { value: 'MODS resource types' }
+            ),
+            Cocina::Models::DescriptiveValue.new(
+              type: 'resource type',
+              value: 'Image',
+              source: { value: 'DataCite resource types' }
             )
           ]
         )
@@ -124,13 +124,13 @@ RSpec.describe CocinaGenerator::Description::TypesGenerator do
             ),
             Cocina::Models::DescriptiveValue.new(
               type: 'resource type',
-              value: 'Text',
-              source: { value: 'DataCite resource types' }
+              value: 'text',
+              source: { value: 'MODS resource types' }
             ),
             Cocina::Models::DescriptiveValue.new(
               type: 'resource type',
-              value: 'text',
-              source: { value: 'MODS resource types' }
+              value: 'Text',
+              source: { value: 'DataCite resource types' }
             )
           ]
         )
@@ -155,13 +155,13 @@ RSpec.describe CocinaGenerator::Description::TypesGenerator do
             ),
             Cocina::Models::DescriptiveValue.new(
               type: 'resource type',
-              value: 'Sound',
-              source: { value: 'DataCite resource types' }
+              value: 'sound recording',
+              source: { value: 'MODS resource types' }
             ),
             Cocina::Models::DescriptiveValue.new(
               type: 'resource type',
-              value: 'sound recording',
-              source: { value: 'MODS resource types' }
+              value: 'Sound',
+              source: { value: 'DataCite resource types' }
             )
           ]
         )
@@ -285,11 +285,6 @@ RSpec.describe CocinaGenerator::Description::TypesGenerator do
                 type: 'resource type'
               },
               {
-                type: 'resource type',
-                value: 'Dataset',
-                source: { value: 'DataCite resource types' }
-              },
-              {
                 value: 'Data sets',
                 type: 'genre',
                 uri: 'http://id.loc.gov/authorities/genreForms/gf2018026119',
@@ -311,6 +306,11 @@ RSpec.describe CocinaGenerator::Description::TypesGenerator do
                 source: {
                   uri: 'http://id.loc.gov/vocabulary/resourceTypes/'
                 }
+              },
+              {
+                type: 'resource type',
+                value: 'Dataset',
+                source: { value: 'DataCite resource types' }
               }
             ]
           }
@@ -343,16 +343,16 @@ RSpec.describe CocinaGenerator::Description::TypesGenerator do
                 type: 'resource type'
               },
               {
-                type: 'resource type',
-                value: 'Text',
-                source: { value: 'DataCite resource types' }
-              },
-              {
                 value: 'text',
                 type: 'resource type',
                 source: {
                   value: 'MODS resource types'
                 }
+              },
+              {
+                type: 'resource type',
+                value: 'Text',
+                source: { value: 'DataCite resource types' }
               }
             ]
           }
@@ -389,11 +389,6 @@ RSpec.describe CocinaGenerator::Description::TypesGenerator do
                 type: 'resource type'
               },
               {
-                type: 'resource type',
-                value: 'Software',
-                source: { value: 'DataCite resource types' }
-              },
-              {
                 value: 'computer program',
                 type: 'genre',
                 uri: 'http://id.loc.gov/vocabulary/marcgt/com',
@@ -414,6 +409,11 @@ RSpec.describe CocinaGenerator::Description::TypesGenerator do
                 source: {
                   value: 'MODS resource types'
                 }
+              },
+              {
+                type: 'resource type',
+                value: 'Software',
+                source: { value: 'DataCite resource types' }
               }
             ]
           }

--- a/spec/services/cocina_generator/dro_generator_spec.rb
+++ b/spec/services/cocina_generator/dro_generator_spec.rb
@@ -29,13 +29,6 @@ RSpec.describe CocinaGenerator::DROGenerator do
         type: 'resource type'
       },
       {
-        value: 'Text',
-        type: 'resource type',
-        source: {
-          value: 'DataCite resource types'
-        }
-      },
-      {
         source: {
           code: 'marcgt'
         },
@@ -57,6 +50,13 @@ RSpec.describe CocinaGenerator::DROGenerator do
         },
         type: 'resource type',
         value: 'text'
+      },
+      {
+        value: 'Text',
+        type: 'resource type',
+        source: {
+          value: 'DataCite resource types'
+        }
       }
     ]
   end


### PR DESCRIPTION


## Why was this change made?
This is the order that DSA constructs the cocina from the MODS, so failing to order this way creates a round tripping error


## How was this change tested?



## Which documentation and/or configurations were updated?



