### PR TITLE
Prevent blank keyword types from being serialized

### DIFF
--- a/app/services/cocina_generator/description/generator.rb
+++ b/app/services/cocina_generator/description/generator.rb
@@ -56,7 +56,7 @@ module CocinaGenerator
       def keywords
         work_version.keywords.map do |keyword|
           props = {
-            value: keyword.label, type: keyword.cocina_type || 'topic'
+            value: keyword.label, type: keyword.cocina_type.presence || 'topic'
           }
           if keyword.uri.present?
             props[:uri] = keyword.uri

--- a/spec/services/cocina_generator/description/generator_spec.rb
+++ b/spec/services/cocina_generator/description/generator_spec.rb
@@ -538,7 +538,7 @@ RSpec.describe CocinaGenerator::Description::Generator do
   end
 
   context 'with subject that has a blank URI and no cocina type' do
-    let(:keyword) { build(:keyword, uri: '', cocina_type: nil) }
+    let(:keyword) { build(:keyword, uri: '', cocina_type: '') }
 
     let(:work_version) do
       build(:work_version, keywords: [keyword])


### PR DESCRIPTION

## Why was this change made?

The form saves an empty string into the database, this must be serialized to cocina as 'topic'. This bug was introduced in https://github.com/sul-dlss/happy-heron/pull/1965


## How was this change tested?



## Which documentation and/or configurations were updated?



