### PR TITLE
Separate deposit job from reserve PURL job

### DIFF
--- a/app/jobs/deposit_job.rb
+++ b/app/jobs/deposit_job.rb
@@ -25,7 +25,7 @@ class DepositJob < BaseDepositJob
     case new_request_dro
     when Cocina::Models::RequestDRO
       work_version = arguments.first
-      SdrClient::Deposit::CreateResource.run(accession: !work_version.reserving_purl?,
+      SdrClient::Deposit::CreateResource.run(accession: true,
                                              assign_doi: work_version.work.assign_doi?,
                                              metadata: new_request_dro,
                                              logger: Rails.logger,

--- a/app/jobs/reserve_job.rb
+++ b/app/jobs/reserve_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Register a DRUID in the SDR API.
+class ReserveJob < BaseDepositJob
+  queue_as :default
+
+  def perform(work_version)
+    login_result = login
+    raise login_result.failure unless login_result.success?
+
+    request_dro = CocinaGenerator::DROGenerator.generate_model(work_version: work_version)
+    SdrClient::Deposit::CreateResource.run(accession: false,
+                                           metadata: request_dro,
+                                           logger: Rails.logger,
+                                           connection: connection)
+  end
+
+  def connection
+    @connection ||= SdrClient::Connection.new(url: Settings.sdr_api.url)
+  end
+end

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -49,7 +49,7 @@ class WorkVersion < ApplicationRecord
 
     after_transition WorkObserver.method(:after_transition)
     after_transition on: :begin_deposit, do: WorkObserver.method(:after_begin_deposit)
-    after_transition on: :reserve_purl, do: WorkObserver.method(:after_begin_deposit)
+    after_transition on: :reserve_purl, do: WorkObserver.method(:after_begin_reserve)
     after_transition on: :reject, do: WorkObserver.method(:after_rejected)
     after_transition on: :submit_for_review, do: WorkObserver.method(:after_submit_for_review)
     after_transition on: :deposit_complete, do: WorkObserver.method(:after_deposit_complete)

--- a/app/services/work_observer.rb
+++ b/app/services/work_observer.rb
@@ -16,6 +16,10 @@ class WorkObserver
     # nop
   end
 
+  def self.after_begin_reserve(work_version, _transition)
+    ReserveJob.perform_later(work_version)
+  end
+
   def self.after_begin_deposit(work_version, _transition)
     DepositJob.perform_later(work_version)
   end

--- a/spec/jobs/deposit_job_spec.rb
+++ b/spec/jobs/deposit_job_spec.rb
@@ -45,18 +45,6 @@ RSpec.describe DepositJob do
       expect(SdrClient::Deposit::UploadFiles).to have_received(:upload)
     end
 
-    context 'when the deposit is for a PURL reservation' do
-      let(:work_version) do
-        build(:work_version, :reserving_purl, work: work)
-      end
-
-      it 'calls CreateResource.run with false for the accession param' do
-        described_class.perform_now(work_version)
-        expect(SdrClient::Deposit::CreateResource).to have_received(:run)
-          .with(a_hash_including(accession: false, assign_doi: false))
-      end
-    end
-
     context 'when the deposit wants a doi' do
       let(:work) { build(:work, collection: collection, assign_doi: true) }
 

--- a/spec/jobs/reserve_job_spec.rb
+++ b/spec/jobs/reserve_job_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReserveJob do
+  include Dry::Monads[:result]
+
+  let(:conn) { instance_double(SdrClient::Connection) }
+  let(:work) { build(:work, collection: collection, assign_doi: false) }
+  let(:work_version) do
+    build(:work_version, :reserving_purl, work: work)
+  end
+  let(:collection) { build(:collection, druid: 'druid:bc123df4567', doi_option: 'depositor-selects') }
+
+  before do
+    allow(SdrClient::Login).to receive(:run).and_return(Success())
+    allow(SdrClient::Connection).to receive(:new).and_return(conn)
+    allow(Honeybadger).to receive(:notify)
+  end
+
+  context 'when the reserve request is successful' do
+    before do
+      allow(SdrClient::Deposit::CreateResource).to receive(:run).and_return(1234)
+    end
+
+    it 'calls CreateResource.run with false for the accession param' do
+      described_class.perform_now(work_version)
+      expect(SdrClient::Deposit::CreateResource).to have_received(:run)
+        .with(a_hash_including(accession: false))
+    end
+  end
+
+  context 'when the deposit request is not successful' do
+    before do
+      allow(SdrClient::Deposit::CreateResource).to receive(:run).and_raise('Deposit failed.')
+    end
+
+    it 'notifies' do
+      expect { described_class.perform_now(work_version) }.to raise_error(RuntimeError, 'Deposit failed.')
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?
This reduces the number of conditionals we need to support, making it easier to debug problems.



## How was this change tested?



## Which documentation and/or configurations were updated?



