### PR TITLE
Assign a DOI when creating a new version

### DIFF
--- a/app/forms/reservation_form.rb
+++ b/app/forms/reservation_form.rb
@@ -10,6 +10,21 @@ class ReservationForm < Reform::Form
   property :title, on: :work_version
   property :assign_doi, on: :work
 
+  def deserialize!(params)
+    deserialize_doi(params)
+    super
+  end
+
+  # Force assign_doi to match what the collection enforces
+  def deserialize_doi(params)
+    case model[:work].collection.doi_option
+    when 'no'
+      params['assign_doi'] = 'false'
+    when 'yes'
+      params['assign_doi'] = 'true'
+    end
+  end
+
   # Ensure that this work version is now the head of the work versions for this work
   def save_model
     Work.transaction do

--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -20,12 +20,29 @@ class WorkForm < DraftWorkForm
   validates :embargo_date, embargo_date: true, if: :availability_component_present?
   validates :agree_to_terms, presence: true
 
+  # Copies form properties to the model. Called internally by reform prior to save.
+  def sync(*)
+    maybe_assign_doi
+    super
+  end
+
   private
 
   delegate :already_immediately_released?, :already_embargo_released?, to: :work
 
   def work
     model[:work]
+  end
+
+  # This is responsible for setting the DOI if the request one on a new version.
+  def maybe_assign_doi
+    return unless assign_doi?
+
+    work.doi = "#{Settings.datacite.prefix}/#{work.druid.delete_prefix('druid:')}"
+  end
+
+  def assign_doi?
+    work.druid && collection.doi_option == 'depositor-selects' && assign_doi
   end
 
   def availability_component_present?

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -46,10 +46,6 @@ class Work < ApplicationRecord
     head&.deposited? && head.embargo_date.present? && head.embargo_date < Time.zone.today
   end
 
-  def assign_doi?
-    collection.doi_option == 'yes' || (collection.doi_option == 'depositor-selects' && assign_doi)
-  end
-
   delegate :name, to: :depositor, prefix: true
   delegate :purl_reservation?, to: :head
 

--- a/app/services/cocina_generator/dro_generator.rb
+++ b/app/services/cocina_generator/dro_generator.rb
@@ -49,14 +49,7 @@ module CocinaGenerator
       }.compact
     end
 
-    # If the work already has a DOI, just return it.
-    # If the user decides they want a DOI minted on a new version, we need to set it here.
-    def doi
-      return work.doi if work.doi
-      return if !work.assign_doi? || work.druid.blank?
-
-      "#{Settings.datacite.prefix}/#{work.druid.delete_prefix('druid:')}"
-    end
+    delegate :doi, to: :work
 
     def cocina_type
       WorkType.find(work_version.work_type).cocina_type

--- a/spec/features/purl_reservation_spec.rb
+++ b/spec/features/purl_reservation_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Reserve a PURL for a work in a deposited collection', js: true d
     expect(work_version.work.collection).to eq collection
     expect(work_version.work.depositor).to eq user
     expect(work_version.work_type).to eq WorkType.purl_reservation_type.id
-    expect(work_version.work.assign_doi).to be true
+    expect(work_version.work.assign_doi?).to be true
 
     # IRL, dor-services-app would send a message that RabbitMQ would route to h2.druid_assigned,
     # for processing by AssignPidJob, so we'll just fake that by running the job manually

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -283,4 +283,34 @@ RSpec.describe WorkForm do
       end
     end
   end
+
+  describe 'setting doi' do
+    context 'when they request a doi' do
+      before do
+        work.collection.doi_option = 'depositor-selects'
+        form.validate(assign_doi: 'true')
+      end
+
+      context 'with a first version (no druid)' do
+        before do
+          form.sync
+        end
+
+        it 'does not assign a doi' do
+          expect(form.model[:work].doi).to be_nil
+        end
+      end
+
+      context 'with a subsequent version (has a druid)' do
+        before do
+          work.druid = 'druid:bc123df4567'
+          form.sync
+        end
+
+        it 'assigns doi' do
+          expect(form.model[:work].doi).to eq '10.80343/bc123df4567'
+        end
+      end
+    end
+  end
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -28,29 +28,4 @@ RSpec.describe Work do
       end
     end
   end
-
-  describe '#assign_doi?' do
-    context 'when collection specifies DOI is assigned' do
-      it 'returns true' do
-        expect(work.assign_doi?).to be true
-      end
-    end
-
-    context 'when collection specifies DOI is not assigned' do
-      let(:collection_doi_option) { 'no' }
-      let(:assign_doi) { true }
-
-      it 'returns false' do
-        expect(work.assign_doi?).to be false
-      end
-    end
-
-    context 'when collection specifies depositor selects' do
-      let(:collection_doi_option) { 'depositor-selects' }
-
-      it 'returns assign_doi' do
-        expect(work.assign_doi?).to be false
-      end
-    end
-  end
 end

--- a/spec/services/cocina_generator/dro_generator_spec.rb
+++ b/spec/services/cocina_generator/dro_generator_spec.rb
@@ -262,64 +262,6 @@ RSpec.describe CocinaGenerator::DROGenerator do
     end
   end
 
-  context 'when a doi is requested and there is a druid' do
-    let(:work_version) do
-      build(:work_version, :version_draft, work_type: 'text', title: 'Test title', work: work)
-    end
-    let(:work) { build(:work, id: 7, druid: 'druid:bk123gh4567', collection: collection) }
-    let(:expected_model) do
-      {
-        externalIdentifier: 'druid:bk123gh4567',
-        type: 'http://cocina.sul.stanford.edu/models/object.jsonld',
-        label: 'Test title',
-        version: 1,
-        access: {
-          access: 'world',
-          download: 'world',
-          license: license_uri,
-          useAndReproductionStatement: Settings.access.use_and_reproduction_statement
-        },
-        administrative: {
-          hasAdminPolicy: 'druid:zx485kb6348',
-          partOfProject: project_tag
-        },
-        description: {
-          title: [
-            {
-              value: 'Test title'
-            }
-          ],
-          note: [
-            {
-              value: 'test abstract',
-              type: 'abstract'
-            },
-            {
-              value: 'test citation',
-              type: 'preferred citation'
-            }
-          ],
-          form: types_form,
-          access: { digitalRepository: [{ value: 'Stanford Digital Repository' }] },
-          purl: 'https://purl.stanford.edu/bk123gh4567',
-          adminMetadata: admin_metadata
-        },
-        identification: {
-          sourceId: "hydrus:object-#{work_version.work.id}",
-          doi: '10.80343/bk123gh4567'
-        },
-        structural: {
-          contains: [],
-          isMemberOf: [collection.druid]
-        }
-      }
-    end
-
-    it 'generates the model' do
-      expect(model.to_h).to eq expected_model
-    end
-  end
-
   context 'when a doi is requested and there is no druid' do
     let(:work_version) do
       build(:work_version, :version_draft, work_type: 'text', title: 'Test title', work: work)


### PR DESCRIPTION


## Why was this change made?
Previously we were not setting a DOI if it was only requested in a second version

Fixes #2005


## How was this change tested?



## Which documentation and/or configurations were updated?



