### PR TITLE
Prevent the 'false' string from evaluating truthy when creating a DOI

### DIFF
--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -30,7 +30,7 @@ class DraftWorkForm < Reform::Form
     self.release = embargo_date.present? ? 'embargo' : 'immediate' if release.blank?
   end)
   property :embargo_date, embargo_date: true, on: :work_version
-  property :assign_doi, on: :work
+  property :assign_doi, on: :work, type: Dry::Types['params.nil'] | Dry::Types['params.bool']
 
   validates_with EmbargoDateParts,
                  if: proc { |form| form.user_can_set_availability? && form.release == 'embargo' }


### PR DESCRIPTION
## Why was this change made?

bug report from Amy

## How was this change tested?



## Which documentation and/or configurations were updated?



