### PR TITLE
Update assets for new version of webpacker

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
         <header class="navbar navbar-expand navbar-dark stanford-navbar">
           <nav class="container-xxl flex-wrap flex-md-nowrap" aria-label="Main navigation">
             <a class="navbar-brand p-0 me-auto" href="/" aria-label="Stanford Digital Repository">
-              <%= image_pack_tag('StanfordLibraries-logo-whitetext.svg', height: 32, alt: 'Stanford Digital Repository') %>
+              <%= image_pack_tag('static/StanfordLibraries-logo-whitetext.svg', height: 32, alt: 'Stanford Digital Repository') %>
             </a>
 
             <div id="notifications"></div>
@@ -81,7 +81,7 @@
         <div id="sul-footer">
           <div id="sul-footer-img" class="span2">
             <%= link_to 'https://library.stanford.edu' do %>
-              <%= image_pack_tag "sul-logo-stacked.svg", alt: "Stanford Libraries", height: 45 %>
+              <%= image_pack_tag "static/sul-logo-stacked.svg", alt: "Stanford Libraries", height: 45 %>
             <% end %>
           </div>
           <div id="sul-footer-links" class="span2">

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -20,9 +20,9 @@
   </head>
 
   <body>
-    <div class="red"><%= image_pack_tag('StanfordLibraries-logo-whitetext.png', height: 32, class: 'sul-logo', alt: 'Stanford Libraries') %></div>
+    <div class="red"><%= image_pack_tag('static/StanfordLibraries-logo-whitetext.png', height: 32, class: 'sul-logo', alt: 'Stanford Libraries') %></div>
     <main>
-      <div class="sdr-logo"><%= image_pack_tag('sdr_color_logo.png', height: 32, alt: 'Stanford Digital Repository') %></div>
+      <div class="sdr-logo"><%= image_pack_tag('static/sdr_color_logo.png', height: 32, alt: 'Stanford Digital Repository') %></div>
       <%= yield %>
     </main>
   </body>


### PR DESCRIPTION
## Why was this change made?

I was seeing this error:
```

ActionView::Template::Error (Webpacker can't find StanfordLibraries-logo-whitetext.svg in /Users/jcoyne85/workspace/sul-dlss/happy-heron/public/packs-test/manifest.json. Possible causes:
1. You want to set webpacker.yml value of compile to true for your environment
   unless you are using the `webpack -w` or the webpack-dev-server.
2. webpack has not yet re-run to reflect updates.
3. You have misconfigured Webpacker's config/webpacker.yml file.
4. Your webpack configuration is not creating a manifest.
```

## How was this change tested?



## Which documentation and/or configurations were updated?



