### PR TITLE
Assign a DOI when the collection specifies to assign one

### DIFF
--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -36,13 +36,14 @@ class WorkForm < DraftWorkForm
 
   # This is responsible for setting the DOI if the request one on a new version.
   def maybe_assign_doi
-    return unless assign_doi?
-
-    work.doi = "#{Settings.datacite.prefix}/#{work.druid.delete_prefix('druid:')}"
+    work.doi = Doi.for(work.druid) if assign_doi?
   end
 
   def assign_doi?
-    work.druid && collection.doi_option == 'depositor-selects' && assign_doi
+    return false unless work.druid
+
+    (collection.doi_option == 'depositor-selects' && assign_doi) ||
+      collection.doi_option == 'yes'
   end
 
   def availability_component_present?

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -285,31 +285,40 @@ RSpec.describe WorkForm do
   end
 
   describe 'setting doi' do
-    context 'when they request a doi' do
+    context 'without a druid (a first version)' do
       before do
         work.collection.doi_option = 'depositor-selects'
         form.validate(assign_doi: 'true')
+        form.sync
       end
 
-      context 'with a first version (no druid)' do
-        before do
-          form.sync
-        end
+      it 'does not assign a doi' do
+        expect(form.model[:work].doi).to be_nil
+      end
+    end
 
-        it 'does not assign a doi' do
-          expect(form.model[:work].doi).to be_nil
-        end
+    context 'when a DOI is requested' do
+      before do
+        work.collection.doi_option = 'depositor-selects'
+        work.druid = 'druid:bc123df4567'
+        form.validate(assign_doi: 'true')
+        form.sync
       end
 
-      context 'with a subsequent version (has a druid)' do
-        before do
-          work.druid = 'druid:bc123df4567'
-          form.sync
-        end
+      it 'assigns doi' do
+        expect(form.model[:work].doi).to eq '10.80343/bc123df4567'
+      end
+    end
 
-        it 'assigns doi' do
-          expect(form.model[:work].doi).to eq '10.80343/bc123df4567'
-        end
+    context 'when the collection specifies DOIs are assigned to all items' do
+      before do
+        work.collection.doi_option = 'yes'
+        work.druid = 'druid:bc123df4567'
+        form.sync
+      end
+
+      it 'assigns doi' do
+        expect(form.model[:work].doi).to eq '10.80343/bc123df4567'
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?
The collection may have been configured to require DOIs on existing items which have not choosen to get a DOI.  These should now get a doi on their next deposit.

Fixes #2020 


## How was this change tested?



## Which documentation and/or configurations were updated?



