### PR TITLE
Don't request a doi when doi is not permitted

### DIFF
--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -150,18 +150,16 @@ class DraftWorkForm < Reform::Form
     property :_destroy, virtual: true, type: Dry::Types['params.nil'] | Dry::Types['params.bool']
   end
 
-  def collection
-    model.fetch(:work).collection
+  delegate :collection, :persisted?, :to_param, to: :work
+
+  def work
+    model[:work]
   end
 
   def description
     return if model.fetch(:work_version).deposited?
 
     super
-  end
-
-  def persisted?
-    model.fetch(:work).persisted?
   end
 
   # Wrap the entire operation (root model and nested model save) in a transaction.
@@ -175,11 +173,7 @@ class DraftWorkForm < Reform::Form
   # Ensure that this work version is now the head of the work versions for this work
   def save_model
     super
-    model.fetch(:work).update(head: model.fetch(:work_version))
-  end
-
-  def to_param
-    model.fetch(:work).to_param
+    work.update(head: model.fetch(:work_version))
   end
 
   # Override reform so that this looks just like a Work

--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -26,13 +26,24 @@ class WorkForm < DraftWorkForm
     super
   end
 
+  def deserialize!(params)
+    deserialize_doi(params)
+    super
+  end
+
+  # Force assign_doi to match what the collection enforces
+  def deserialize_doi(params)
+    case collection.doi_option
+    when 'no'
+      params['assign_doi'] = 'false'
+    when 'yes'
+      params['assign_doi'] = 'true'
+    end
+  end
+
   private
 
   delegate :already_immediately_released?, :already_embargo_released?, to: :work
-
-  def work
-    model[:work]
-  end
 
   # This is responsible for setting the DOI if the request one on a new version.
   def maybe_assign_doi

--- a/spec/requests/edit_work_spec.rb
+++ b/spec/requests/edit_work_spec.rb
@@ -122,6 +122,23 @@ RSpec.describe 'Updating an existing work' do
             expect(response).to redirect_to(next_step_work_path(work))
           end
         end
+
+        context 'when a doi is not permitted' do
+          let(:work) { create(:work, :with_druid, collection: collection) }
+
+          before do
+            collection.update!(doi_option: 'no')
+          end
+
+          it 'sets assign_doi to false' do
+            patch "/works/#{work.id}", params: { work: work_params, commit: 'Deposit' }
+            expect(CollectionObserver).to have_received(:version_draft_created)
+            expect(WorkVersion.where(work: work).count).to eq 2
+            expect(work.reload.head).to be_depositing
+            expect(work.assign_doi).to be false
+            expect(response).to redirect_to(next_step_work_path(work))
+          end
+        end
       end
 
       context 'with a validation problem' do


### PR DESCRIPTION
## Why was this change made?

DOIs were being set when in a collection that does not permit them.

## How was this change tested?

Tested on stage.

## Which documentation and/or configurations were updated?



