### PR TITLE
use first name for emails, full name for everything else

### DIFF
--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -12,5 +12,9 @@ class UserPresenter
     model.name || 'New SDR User' # return either the name in the database or a default if none exists (i.e. new users)
   end
 
+  def first_name
+    model.first_name || 'New SDR User' # return either the first_name in the database or a default if none exists
+  end
+
   delegate :email, to: :model
 end

--- a/app/views/collections_mailer/deposit_access_removed_email.html.erb
+++ b/app/views/collections_mailer/deposit_access_removed_email.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>A Manager of the <%= @collection_version.name %> collection has updated the permissions
    for this collection and removed you as a Depositor. You no longer have permission

--- a/app/views/collections_mailer/first_draft_created.html.erb
+++ b/app/views/collections_mailer/first_draft_created.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>The Depositor <%= @depositor.name %> has created a draft in the <%= @collection_version.name %> collection.</p>
 

--- a/app/views/collections_mailer/invitation_to_deposit_email.html.erb
+++ b/app/views/collections_mailer/invitation_to_deposit_email.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>You have been invited to deposit to the <%= @collection_version.name %> collection in the Stanford Digital Repository.
   Start your deposit at <%= link_to collection_url(@collection), collection_url(@collection, anchor: 'deposits') %>.</p>

--- a/app/views/collections_mailer/item_deposited.html.erb
+++ b/app/views/collections_mailer/item_deposited.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>The Depositor <%= @depositor.name %> has submitted a deposit in the <%= @collection_version.name %> collection.</p>
 

--- a/app/views/collections_mailer/manage_access_granted_email.html.erb
+++ b/app/views/collections_mailer/manage_access_granted_email.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>You have been invited to be a Manager of the <%= @collection_version.name %> collection in the
    Stanford Digital Repository. Managers have the ability to manage global settings for the collection,

--- a/app/views/collections_mailer/manage_access_removed_email.html.erb
+++ b/app/views/collections_mailer/manage_access_removed_email.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>A Manager of the <%= @collection_version.name %> collection has updated the permissions
    for this collection and removed you as a Manager. You no longer have permission

--- a/app/views/collections_mailer/participants_changed_email.html.erb
+++ b/app/views/collections_mailer/participants_changed_email.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>Members have been either added to or removed from the <%= @collection_version.name %> collection. Please see the
    history section at the bottom of the collection details page to see the changes made.</p>

--- a/app/views/collections_mailer/review_access_granted_email.html.erb
+++ b/app/views/collections_mailer/review_access_granted_email.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>You have been invited to review new deposits to the <%= @collection_version.name %> collection in the
    Stanford Digital Repository. When a Depositor submits a deposit, you will receive an email

--- a/app/views/collections_mailer/review_access_removed_email.html.erb
+++ b/app/views/collections_mailer/review_access_removed_email.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>A Manager of the <%= @collection_version.name %> collection has updated the permissions for this
    collection and removed you as a Reviewer. You no longer have permission to review deposits

--- a/app/views/collections_mailer/version_draft_created.html.erb
+++ b/app/views/collections_mailer/version_draft_created.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>The Depositor <%= @depositor.name %> has started a new version in the <%= @collection_version.name %> collection.</p>
 

--- a/app/views/reviewers_mailer/submitted_email.html.erb
+++ b/app/views/reviewers_mailer/submitted_email.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>The Depositor <%= @work.depositor_name %> has submitted the deposit "<%= @work_version.title %>" for
   review in the <%= @work.collection_name %> collection. You can access this item directly at <%= link_to work_url(@work), work_url(@work) %></p>

--- a/app/views/works_mailer/approved_email.html.erb
+++ b/app/views/works_mailer/approved_email.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>Congratulations! Your deposit, “<%= @work_version.title %>” to the <%= @work.collection_name %> collection
   in the Stanford Digital Repository, has been approved and is now published

--- a/app/views/works_mailer/deposited_email.html.erb
+++ b/app/views/works_mailer/deposited_email.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>Your deposit, “<%= @work_version.title %>” is now published in the <%= @work.collection_name %> collection
   in the Stanford Digital Repository. The persistent URL (PURL) for this deposit is

--- a/app/views/works_mailer/first_draft_reminder_email.html.erb
+++ b/app/views/works_mailer/first_draft_reminder_email.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>We noticed you haven’t finished submitting your deposit. When you are ready to
   complete your deposit submission, click <%= link_to edit_work_url(@work), edit_work_url(@work) %>

--- a/app/views/works_mailer/new_version_deposited_email.html.erb
+++ b/app/views/works_mailer/new_version_deposited_email.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>A new version of your deposit, “<%= @work_version.title %>” is now published in the <%= @work.collection_name %> collection
   in the Stanford Digital Repository. The persistent URL (PURL) for this deposit is

--- a/app/views/works_mailer/new_version_reminder_email.html.erb
+++ b/app/views/works_mailer/new_version_reminder_email.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>We noticed you haven’t finished the new version of your deposit. When you are ready to
   complete your deposit submission, click <%= link_to edit_work_url(@work), edit_work_url(@work) %>

--- a/app/views/works_mailer/reject_email.html.erb
+++ b/app/views/works_mailer/reject_email.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>Your deposit, “<%= @work_version.title %>” to the <%= @work.collection_name %>
   collection in the Stanford Digital Repository, has been returned to you with the following comments:</p>

--- a/app/views/works_mailer/submitted_email.html.erb
+++ b/app/views/works_mailer/submitted_email.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @user.name %>,</p>
+<p>Dear <%= @user.first_name %>,</p>
 
 <p>Your deposit, “<%= @work_version.title %>” to the <%= @work.collection_name %>
   collection in the Stanford Digital Repository, is now waiting for review by a collection Manager.</p>

--- a/config/initializers/devise_remote_user.rb
+++ b/config/initializers/devise_remote_user.rb
@@ -12,5 +12,8 @@ DeviseRemoteUser.configure do |config|
   config.logout_url = '/Shibboleth.sso/Logout'
   config.auto_create = true
   config.auto_update = true
-  config.attribute_map = { name: Settings.name_header }
+  config.attribute_map = {
+    name: Settings.full_name_header,
+    first_name: Settings.first_name_header
+  }
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,7 +35,8 @@ external_links:
 allow_sdr_content_changes: true
 
 authorization_group_header: HTTP_X_GROUPS
-name_header: HTTP_X_PERSON_NAME
+first_name_header: HTTP_X_PERSON_NAME
+full_name_header: HTTP_X_PERSON_FORMAL_NAME
 
 # mappings from authorization role to workgroup name
 authorization_workgroup_names:

--- a/db/migrate/20210827165420_add_first_name_to_users.rb
+++ b/db/migrate/20210827165420_add_first_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddFirstNameToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :first_name, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -537,7 +537,8 @@ CREATE TABLE public.users (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     name character varying,
-    last_work_terms_agreement timestamp without time zone
+    last_work_terms_agreement timestamp without time zone,
+    first_name character varying
 );
 
 
@@ -1299,6 +1300,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210719185721'),
 ('20210721164925'),
 ('20210802203252'),
-('20210816133101');
+('20210816133101'),
+('20210827165420');
 
 

--- a/spec/mailers/collections_mailer_spec.rb
+++ b/spec/mailers/collections_mailer_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
   let(:collection_version) { build_stubbed(:collection_version, collection: collection) }
   let(:collection_name) { collection_version.name }
   let(:collection) { build_stubbed(:collection) }
+  let(:a_user) { build_stubbed(:user, name: 'Al Dente', first_name: 'Fred') }
 
   describe '#invitation_to_deposit_email for new user with no name' do
     let(:user) { collection.depositors.first }
@@ -18,7 +19,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
       expect(mail.from).to eq ['no-reply@sdr.stanford.edu']
     end
 
-    it 'renders the body' do
+    it 'renders the body with salutation of default name' do
       expect(mail.body.encoded).to match('Dear New SDR User,')
       expect(mail.body.encoded).to match("You have been invited to deposit to the #{collection_name} collection")
     end
@@ -29,7 +30,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
     let(:mail) { described_class.with(user: user, collection_version: collection_version).invitation_to_deposit_email }
     let(:collection) { build_stubbed(:collection, :with_depositors) }
 
-    before { user.update(name: 'Smart Person') }
+    before { user.update(name: 'Smart Person', first_name: 'Maxwell') }
 
     it 'renders the headers' do
       expect(mail.subject).to eq "Invitation to deposit to the #{collection_name} collection in the SDR"
@@ -37,14 +38,14 @@ RSpec.describe CollectionsMailer, type: :mailer do
       expect(mail.from).to eq ['no-reply@sdr.stanford.edu']
     end
 
-    it 'renders the body' do
-      expect(mail.body.encoded).to match('Dear Smart Person,')
+    it 'renders the body with salutation of first name' do
+      expect(mail.body.encoded).to match('Dear Maxwell,')
       expect(mail.body.encoded).to match("You have been invited to deposit to the #{collection_name} collection")
     end
   end
 
   describe '#deposit_access_removed_email' do
-    let(:user) { build(:user) }
+    let(:user) { a_user }
     let(:mail) { described_class.with(user: user, collection_version: collection_version).deposit_access_removed_email }
 
     it 'renders the headers' do
@@ -57,10 +58,15 @@ RSpec.describe CollectionsMailer, type: :mailer do
     it 'renders the body' do
       expect(mail.body.encoded).to match("A Manager of the #{collection_name} collection has updated the permissions")
     end
+
+    it 'salutation uses user.first_name' do
+      expect(mail.body).to include("Dear #{user.first_name},")
+      expect(mail.body).not_to include("Dear #{user.name},")
+    end
   end
 
   describe '#manage_access_granted_email' do
-    let(:user) { build(:user) }
+    let(:user) { a_user }
     let(:mail) { described_class.with(user: user, collection_version: collection_version).manage_access_granted_email }
     let(:collection) { build(:collection) }
 
@@ -75,10 +81,15 @@ RSpec.describe CollectionsMailer, type: :mailer do
       expect(mail.body.encoded).to match('You have been invited to be a Manager ' \
                                          "of the #{collection_name} collection")
     end
+
+    it 'salutation uses user.first_name' do
+      expect(mail.body).to include("Dear #{user.first_name},")
+      expect(mail.body).not_to include("Dear #{user.name},")
+    end
   end
 
   describe '#manage_access_removed_email' do
-    let(:user) { build(:user) }
+    let(:user) { a_user }
     let(:mail) { described_class.with(user: user, collection_version: collection_version).manage_access_removed_email }
     let(:collection) { build(:collection) }
 
@@ -92,10 +103,15 @@ RSpec.describe CollectionsMailer, type: :mailer do
     it 'renders the body' do
       expect(mail.body.encoded).to match("A Manager of the #{collection_name} collection has updated the permissions")
     end
+
+    it 'salutation uses user.first_name' do
+      expect(mail.body).to include("Dear #{user.first_name},")
+      expect(mail.body).not_to include("Dear #{user.name},")
+    end
   end
 
   describe '#review_access_granted_email' do
-    let(:user) { build(:user) }
+    let(:user) { a_user }
     let(:mail) { described_class.with(user: user, collection_version: collection_version).review_access_granted_email }
     let(:collection) { build(:collection) }
 
@@ -110,10 +126,15 @@ RSpec.describe CollectionsMailer, type: :mailer do
       expect(mail.body.encoded).to match('You have been invited to review new deposits ' \
                                          "to the #{collection_name} collection")
     end
+
+    it 'salutation uses user.first_name' do
+      expect(mail.body).to include("Dear #{user.first_name},")
+      expect(mail.body).not_to include("Dear #{user.name},")
+    end
   end
 
   describe '#review_access_removed_email' do
-    let(:user) { build(:user) }
+    let(:user) { a_user }
     let(:mail) { described_class.with(user: user, collection_version: collection_version).review_access_removed_email }
     let(:collection) { build(:collection) }
 
@@ -127,11 +148,16 @@ RSpec.describe CollectionsMailer, type: :mailer do
     it 'renders the body' do
       expect(mail.body.encoded).to match("A Manager of the #{collection_name} collection has updated the permissions")
     end
+
+    it 'salutation uses user.first_name' do
+      expect(mail.body).to include("Dear #{user.first_name},")
+      expect(mail.body).not_to include("Dear #{user.name},")
+    end
   end
 
   describe '#first_draft_created' do
-    let(:user) { build(:user) }
-    let(:depositor) { build(:user, name: 'Audre Lorde') }
+    let(:user) { a_user }
+    let(:depositor) { build(:user, name: 'Audre Lorde', first_name: 'Queueueue') }
 
     let(:mail) do
       described_class.with(user: user, collection_version: collection_version,
@@ -149,11 +175,16 @@ RSpec.describe CollectionsMailer, type: :mailer do
       expect(mail.body.encoded).to match "The Depositor #{depositor.name} has created a draft"
       expect(mail.body.encoded).to match "in the #{collection_name} collection"
     end
+
+    it 'salutation uses user.first_name' do
+      expect(mail.body).to include("Dear #{user.first_name},")
+      expect(mail.body).not_to include("Dear #{user.name},")
+    end
   end
 
   describe '#item_deposited' do
-    let(:user) { build(:user) }
-    let(:depositor) { build(:user, name: 'Audre Lorde') }
+    let(:user) { a_user }
+    let(:depositor) { build(:user, name: 'Audre Lorde', first_name: 'Queueueue') }
 
     let(:mail) do
       described_class.with(user: user, collection_version: collection_version, depositor: depositor).item_deposited
@@ -170,10 +201,15 @@ RSpec.describe CollectionsMailer, type: :mailer do
       expect(mail.body.encoded).to match "The Depositor #{depositor.name} has submitted a deposit"
       expect(mail.body.encoded).to match "in the #{collection_name} collection"
     end
+
+    it 'salutation uses user.first_name' do
+      expect(mail.body).to include("Dear #{user.first_name},")
+      expect(mail.body).not_to include("Dear #{user.name},")
+    end
   end
 
   describe '#version_draft_created' do
-    let(:user) { build(:user) }
+    let(:user) { a_user }
     let(:depositor) { build(:user, name: 'Audre Lorde') }
 
     let(:mail) do
@@ -192,10 +228,15 @@ RSpec.describe CollectionsMailer, type: :mailer do
       expect(mail.body.encoded).to match "The Depositor #{depositor.name} has started a new version"
       expect(mail.body.encoded).to match "in the #{collection_name} collection"
     end
+
+    it 'salutation uses user.first_name' do
+      expect(mail.body).to include("Dear #{user.first_name},")
+      expect(mail.body).not_to include("Dear #{user.name},")
+    end
   end
 
   describe '#participants_changed_email' do
-    let(:user) { build(:user) }
+    let(:user) { a_user }
     let(:mail) { described_class.with(user: user, collection_version: collection_version).participants_changed_email }
     let(:collection) { build(:collection) }
 
@@ -208,6 +249,11 @@ RSpec.describe CollectionsMailer, type: :mailer do
     it 'renders the body' do
       expect(mail.body.encoded).to match 'Members have been either added to or removed from the ' \
                                          "#{collection_name} collection."
+    end
+
+    it 'salutation uses user.first_name' do
+      expect(mail.body).to include("Dear #{user.first_name},")
+      expect(mail.body).not_to include("Dear #{user.name},")
     end
   end
 end

--- a/spec/mailers/reviewers_mailer_spec.rb
+++ b/spec/mailers/reviewers_mailer_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ReviewersMailer, type: :mailer do
   describe 'submitted_email' do
-    let(:user) { build(:user, name: 'Al Dente') }
+    let(:user) { build(:user, name: 'Al Dente', first_name: 'Fred') }
     let(:mail) { described_class.with(user: user, work_version: work_version).submitted_email }
     let(:work) { build_stubbed(:work, collection: collection, depositor: user) }
     let(:work_version) { build_stubbed(:work_version, :pending_approval, work: work, title: 'Test title') }
@@ -15,6 +15,11 @@ RSpec.describe ReviewersMailer, type: :mailer do
       expect(mail.subject).to eq 'New deposit activity in the small batch organic collection'
       expect(mail.to).to eq [user.email]
       expect(mail.from).to eq ['no-reply@sdr.stanford.edu']
+    end
+
+    it 'salutation uses user.first_name' do
+      expect(mail.body).to include("Dear #{user.first_name},")
+      expect(mail.body).not_to include("Dear #{user.name},")
     end
 
     it 'renders the reason' do

--- a/spec/mailers/works_mailer_spec.rb
+++ b/spec/mailers/works_mailer_spec.rb
@@ -3,8 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe WorksMailer, type: :mailer do
+  let(:work_depositor) { build_stubbed(:user, email: work.depositor.email, name: 'Al Dente', first_name: 'Fred') }
+  let(:a_user) { build(:user, name: 'Al Dente', first_name: 'Fred') }
+
   describe 'reject_email' do
-    let(:user) { work.depositor }
+    let(:user) { work_depositor }
     let(:mail) { described_class.with(user: user, work_version: work_version).reject_email }
     let(:work) do
       create(:work, collection: collection,
@@ -23,10 +26,15 @@ RSpec.describe WorksMailer, type: :mailer do
     it 'renders the reason' do
       expect(mail.body.encoded).to match('Add something to make it pop.')
     end
+
+    it 'salutation uses user.first_name' do
+      expect(mail.body).to include("Dear #{user.first_name},")
+      expect(mail.body).not_to include("Dear #{user.name},")
+    end
   end
 
   describe 'deposited_email' do
-    let(:user) { work.depositor }
+    let(:user) { work_depositor }
     let(:mail) { described_class.with(user: user, work_version: work_version).deposited_email }
     let(:work) { build_stubbed(:work, collection: collection, druid: 'druid:bc123df4567', doi: '10.001/bc123df4567') }
     let(:work_version) { build_stubbed(:work_version, :deposited, title: 'Photo booth activated charcoal', work: work) }
@@ -44,10 +52,15 @@ RSpec.describe WorksMailer, type: :mailer do
       expect(mail.body.encoded).to have_content('gastropub humblebrag taiyaki collection')
       expect(mail.body.encoded).to have_content('https://doi.org/10.001/bc123df4567')
     end
+
+    it 'salutation uses user.first_name' do
+      expect(mail.body).to include("Dear #{user.first_name},")
+      expect(mail.body).not_to include("Dear #{user.name},")
+    end
   end
 
   describe 'new_version_deposited_email' do
-    let(:user) { work.depositor }
+    let(:user) { work_depositor }
     let(:mail) { described_class.with(user: user, work_version: work_version).new_version_deposited_email }
     let(:work) { build_stubbed(:work, collection: collection, druid: 'druid:bc123df4567', doi: '10.001/bc123df4567') }
     let(:work_version) { build_stubbed(:work_version, :deposited, title: 'twee retro man braid', work: work) }
@@ -65,10 +78,15 @@ RSpec.describe WorksMailer, type: :mailer do
       expect(mail.body.encoded).to have_content('listicle fam ramps flannel')
       expect(mail.body.encoded).to have_content('https://doi.org/10.001/bc123df4567')
     end
+
+    it 'salutation uses user.first_name' do
+      expect(mail.body).to include("Dear #{user.first_name},")
+      expect(mail.body).not_to include("Dear #{user.name},")
+    end
   end
 
   describe 'approved_email' do
-    let(:user) { work.depositor }
+    let(:user) { work_depositor }
     let(:mail) { described_class.with(user: user, work_version: work_version).approved_email }
     let(:work) { build_stubbed(:work, collection: collection, druid: 'druid:bc123df4567', doi: '10.001/bc123df4567') }
     let(:work_version) { build_stubbed(:work_version, :deposited, title: 'Hammock kombucha mustache', work: work) }
@@ -86,10 +104,15 @@ RSpec.describe WorksMailer, type: :mailer do
       expect(mail.body.encoded).to have_content('Farm-to-table beard aesthetic collection')
       expect(mail.body.encoded).to have_content('https://doi.org/10.001/bc123df4567')
     end
+
+    it 'salutation uses user.first_name' do
+      expect(mail.body).to include("Dear #{user.first_name},")
+      expect(mail.body).not_to include("Dear #{user.name},")
+    end
   end
 
   describe 'submitted_email' do
-    let(:user) { build(:user, name: 'Al Dente') }
+    let(:user) { a_user }
     let(:mail) { described_class.with(user: user, work_version: work_version).submitted_email }
     let(:work) { build_stubbed(:work, collection: collection, depositor: user) }
     let(:work_version) do
@@ -110,10 +133,15 @@ RSpec.describe WorksMailer, type: :mailer do
                                          "small batch organic\r\n  collection in the Stanford Digital Repository, " \
                                          'is now waiting for review by a collection Manager.'
     end
+
+    it 'salutation uses user.first_name' do
+      expect(mail.body).to include("Dear #{user.first_name},")
+      expect(mail.body).not_to include("Dear #{user.name},")
+    end
   end
 
   describe 'first_draft_reminder_email' do
-    let(:work) { build_stubbed(:work, collection: collection) }
+    let(:work) { build_stubbed(:work, collection: collection, depositor: a_user) }
     let(:work_version) { build_stubbed(:work_version, work: work) }
     let(:mail) { described_class.with(work_version: work_version).first_draft_reminder_email }
     let(:collection) { build_stubbed(:collection, head: collection_version) }
@@ -128,10 +156,15 @@ RSpec.describe WorksMailer, type: :mailer do
     it 'renders a link to edit the draft in the body' do
       expect(mail.body).to match("http://#{Socket.gethostname}/works/#{work.id}/edit")
     end
+
+    it 'salutation uses work.depositor.first_name' do
+      expect(mail.body).to include("Dear #{work.depositor.first_name},")
+      expect(mail.body).not_to include("Dear #{work.depositor.name},")
+    end
   end
 
   describe 'new_version_reminder_email' do
-    let(:work) { build_stubbed(:work, collection: collection) }
+    let(:work) { build_stubbed(:work, collection: collection, depositor: a_user) }
     let(:work_version) { build_stubbed(:work_version, work: work) }
     let(:mail) { described_class.with(work_version: work_version).new_version_reminder_email }
     let(:collection) { build_stubbed(:collection, head: collection_version) }
@@ -143,6 +176,11 @@ RSpec.describe WorksMailer, type: :mailer do
       expect(mail.subject).to eq exp_subj
       expect(mail.to).to eq [work.depositor.email]
       expect(mail.from).to eq ['no-reply@sdr.stanford.edu']
+    end
+
+    it 'salutation uses work.depositor.first_name' do
+      expect(mail.body).to include("Dear #{work.depositor.first_name},")
+      expect(mail.body).not_to include("Dear #{work.depositor.name},")
     end
 
     it 'renders a link to edit the draft in the body' do


### PR DESCRIPTION
~~HOLD for PO sign off from deployed instance.~~

## Why was this change made?

Fixes #685
Fixes #2033

To keep the user's full name in all contexts except for email salutations.

Note that puppet names of headers can be changed if desired, e.g. https://github.com/sul-dlss/puppet/blob/production/hieradata/node/sul-h2-stage.stanford.edu.eyaml#L225-L226

![image](https://user-images.githubusercontent.com/96775/131176162-c472617f-3904-47be-b44f-56fa4cb2ea7b.png)

i.e. the full name can be X-Person-Name, and the first name could be X-Person-First-Name or whatever is desired.  The Settings.yml lines are well labeled:

```
first_name_header: HTTP_X_PERSON_NAME
full_name_header: HTTP_X_PERSON_FORMAL_NAME
```

and I used "least changes" approach for the User model, leaving full name for the `name` attribute and adding a `first_name` attribute.

## How was this change tested?

unit tests and PO sign off  ~~🤞🏻~~  ✅ 


## Which documentation and/or configurations were updated?



