### PR TITLE
Update auto generated citation when changing order of authors

### DIFF
--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -73,13 +73,13 @@
       <%= form.hidden_field :weight %>
       <div>
         <%= button_tag type: 'button', class: 'btn btn-sm', aria: { label: 'Move up' },
-                       data: { action: "click->ordered-nested-form#moveUp" } do %>
+                       data: { action: "click->ordered-nested-form#moveUp auto-citation#updateDisplay" } do %>
           <span class="fas fa-arrow-up"></span>
         <% end %>
       </div>
       <div>
         <%= button_tag type: 'button', class: 'btn btn-sm', aria: { label: 'Move down' },
-                       data: { action: "click->ordered-nested-form#moveDown" } do %>
+                       data: { action: "click->ordered-nested-form#moveDown auto-citation#updateDisplay" } do %>
           <span class="fas fa-arrow-down"></span>
         <% end %>
       </div>


### PR DESCRIPTION
## Why was this change made?

Fixes #2041 

Currently the order of authors is not retained when changed during an edit. This triggers the display update and persistence of authors when order is changed.

## How was this change tested?



## Which documentation and/or configurations were updated?



