### PR TITLE
Remove extra modal class tag causing modal not to close properly

### DIFF
--- a/app/components/works/purl_reservation_modal_component.html.erb
+++ b/app/components/works/purl_reservation_modal_component.html.erb
@@ -1,5 +1,5 @@
 <div class="modal fade" id="purlReservationModal" tabindex="-1" aria-labelledby="content-type-prompt" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal">
+  <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="content-type-prompt"><label for="purl-reservation-title">Enter a title for this deposit</label></h5>


### PR DESCRIPTION
## Why was this change made?

Fixes #2040 

The extra modal was removing the ability for the normal data-close action to be linked to the appropriate div.

## How was this change tested?



## Which documentation and/or configurations were updated?



