### PR TITLE
Fix order of link_to terms of service in email template

### DIFF
--- a/app/views/collections_mailer/invitation_to_deposit_email.html.erb
+++ b/app/views/collections_mailer/invitation_to_deposit_email.html.erb
@@ -7,7 +7,7 @@
 
 <p>In some cases a deposit requires review and approval before the PURL is available. <a href="https://library.stanford.edu/research/stanford-digital-repository/faqs/sdr-submission-workflows">Read about the approval process.</a>
 
-<p>Before you complete your deposit, you will need to accept the <%= link_to Settings.terms_url, "Terms of Deposit" %>.
+<p>Before you complete your deposit, you will need to accept the <%= link_to "Terms of Deposit", Settings.terms_url %>.
 
 <p>If you have any questions, contact the SDR team at: <%= link_to contact_form_url, contact_form_url %></p>
 


### PR DESCRIPTION
## Why was this change made?

Fixes #2047 

## How was this change tested?

@amyehodge tested in prod and signed off.

## Which documentation and/or configurations were updated?



