### PR TITLE
embargoed objects set to files to inaccessible

### DIFF
--- a/app/services/cocina_generator/structural/file_generator.rb
+++ b/app/services/cocina_generator/structural/file_generator.rb
@@ -74,8 +74,12 @@ module CocinaGenerator
         attached_file.hide?
       end
 
+      def embargoed?
+        work_version.embargo_date
+      end
+
       def access
-        if hidden_file?
+        if embargoed?
           { access: 'dark', download: 'none' }
         else
           { access: work_version.access, download: work_version.access }

--- a/spec/services/cocina_generator/structural/file_generator_spec.rb
+++ b/spec/services/cocina_generator/structural/file_generator_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe CocinaGenerator::Structural::FileGenerator do
       let(:work_version) { build(:work_version) }
       let(:attached_file) { create(:attached_file, :with_file, work_version: work_version, hide: true) }
 
+      it { is_expected.to eq Cocina::Models::FileAccess.new(access: 'world', download: 'world') }
+    end
+
+    context 'when object is embargoed' do
+      let(:work_version) { build(:work_version, :embargoed) }
+      let(:attached_file) { create(:attached_file, :with_file, work_version: work_version, hide: true) }
+
       it { is_expected.to eq Cocina::Models::FileAccess.new(access: 'dark', download: 'none') }
     end
   end


### PR DESCRIPTION
## Why was this change made?

Fixes #2072 and #2065

- objects that are embargoed will have all files set to "dark/none" access at the file level
- hidden files do not set "dark/none" access at the file level, but instead will have access restricted via the publish/preserve/shelve attribute in the administrative section of cocina 

Questions:
- how does embargo release change the file level settings or does it need to?

## How was this change tested?

Updated unit tests


## Which documentation and/or configurations were updated?



