### PR TITLE
embargo release criteria should match what the user set

### DIFF
--- a/app/services/cocina_generator/access_generator.rb
+++ b/app/services/cocina_generator/access_generator.rb
@@ -32,7 +32,7 @@ module CocinaGenerator
       {
         access: 'citation-only',
         download: 'none',
-        embargo: { access: 'world', download: 'world', releaseDate: work_version.embargo_date.iso8601 }
+        embargo: regular_access.merge({ releaseDate: work_version.embargo_date.iso8601 })
       }
     end
 

--- a/spec/services/cocina_generator/access_generator_spec.rb
+++ b/spec/services/cocina_generator/access_generator_spec.rb
@@ -39,12 +39,26 @@ RSpec.describe CocinaGenerator::AccessGenerator do
   end
 
   context 'when embargoed' do
-    let(:work_version) { build(:work_version, :embargoed, access: 'stanford') }
+    let(:work_version) { build(:work_version, :embargoed, access: 'world') }
 
     it 'generates the model' do
       expect(model).to eq(access: 'citation-only',
                           download: 'none',
                           embargo: { releaseDate: work_version.embargo_date.to_s, access: 'world', download: 'world' },
+                          license: license_uri,
+                          useAndReproductionStatement: Settings.access.use_and_reproduction_statement)
+    end
+  end
+
+  context 'when embargoed for stanford release' do
+    let(:work_version) { build(:work_version, :embargoed, access: 'stanford') }
+
+    it 'generates the model' do
+      expect(model).to eq(access: 'citation-only',
+                          download: 'none',
+                          embargo: { releaseDate: work_version.embargo_date.to_s,
+                                     access: 'stanford',
+                                     download: 'stanford' },
                           license: license_uri,
                           useAndReproductionStatement: Settings.access.use_and_reproduction_statement)
     end


### PR DESCRIPTION
## Why was this change made?

Fixes #2069 - embargo release access rights should match what the user set to ensure when the object is released, it has the correct access

## How was this change tested?

Added new unit test


## Which documentation and/or configurations were updated?



