### PR TITLE
attempt to fix a flaky spec by waiting

### DIFF
--- a/spec/features/mediated_deposit_versioning_spec.rb
+++ b/spec/features/mediated_deposit_versioning_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Edit a new version of a work in a collection using mediated depo
 
       click_link 'Return to dashboard'
       click_link new_work_title
-      expect(page).to have_text 'Your deposit has been sent for approval.'
+      expect(page).to have_text('Your deposit has been sent for approval.', wait: 3)
 
       # A work submitted for approval should not be editable.
       expect(page).not_to have_css("a[aria-label='Edit #{new_work_title}']", wait: 0)


### PR DESCRIPTION
## Why was this change made?

Adding specific wait time to this spec seems to make it much less flaky (haven't seen it fail yet)


## How was this change tested?



## Which documentation and/or configurations were updated?



