### PR TITLE
flaky test fix - wait before clicking on item link

### DIFF
--- a/spec/features/mediated_deposit_versioning_spec.rb
+++ b/spec/features/mediated_deposit_versioning_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'Edit a new version of a work in a collection using mediated depo
       expect(page).to have_content 'You have successfully submitted your deposit'
 
       click_link 'Return to dashboard'
+      sleep(2)
       click_link new_work_title
       expect(page).to have_text 'Your deposit has been sent for approval.'
 


### PR DESCRIPTION
## Why was this change made?

Another attempt to fix the flaky test (attempt 1 was #2081).  Examining the HTML when the test fails shows that the link to the work was never clicked and the failure is because we are still on the dashboard (which doesn't show the alert we are expecting to find on the next line of the test).  It appears the link to the work is turbo-streamed on the dashboard (https://github.com/sul-dlss/happy-heron/blob/main/app/views/dashboards/show.html.erb#L15-L20), so perhaps it just isn't there yet and the "click_link" directive is not waiting for it to appear (the same way that expectations for finding content are).  Anecdotally I haven't seen it fail with this wait (yet) after running about 5 times locally (without it, it fails about 50% of the time).

## How was this change tested?



## Which documentation and/or configurations were updated?



