### PR TITLE
Parsing of dates in cocina

### DIFF
--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -116,18 +116,6 @@ class WorkVersion < ApplicationRecord
     update!(citation: citation.gsub(LINK_TEXT, work.purl))
   end
 
-  # Ensure that EDTF dates get an EDTF serialization
-  def created_edtf=(edtf)
-    case edtf
-    when nil, EDTF::Interval
-      super
-    when Date
-      super(edtf.to_edtf)
-    else
-      raise TypeError, 'Expected a Date or EDTF::Interval'
-    end
-  end
-
   # the terms agreement checkbox value is not persisted in the database with the work and the value is instead:
   #  false if (a) never previously accepted or (b) not accepted in the last year; it is true otherwise
   def agree_to_terms
@@ -153,6 +141,19 @@ class WorkVersion < ApplicationRecord
     end
   end
 
+  # Ensure that EDTF dates get an EDTF serialization
+  def created_edtf=(edtf)
+    case edtf
+    when nil, EDTF::Interval
+      super
+    when Date
+      super(edtf.to_edtf)
+    else
+      raise TypeError, 'Expected a Date or EDTF::Interval'
+    end
+  end
+
+  # see https://github.com/inukshuk/edtf-ruby for details on the parsing gem used
   def published_edtf
     EDTF.parse(super)
   end

--- a/app/services/cocina_generator/description/generator.rb
+++ b/app/services/cocina_generator/description/generator.rb
@@ -134,7 +134,7 @@ module CocinaGenerator
         {
           type: type,
           qualifier: date.uncertain? ? 'approximate' : nil,
-          value: date.to_s
+          value: date.uncertain? ? date.to_s : date.edtf
         }.compact
       end
 

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -40,6 +40,14 @@ FactoryBot.define do
     published_edtf { EDTF.parse('2020-02-14') }
   end
 
+  trait :published_with_year_only do
+    published_edtf { EDTF.parse('2021') }
+  end
+
+  trait :published_with_year_month_only do
+    published_edtf { EDTF.parse('2021-04') }
+  end
+
   trait :embargoed do
     embargo_date { 30.months.from_now }
   end
@@ -60,6 +68,14 @@ FactoryBot.define do
 
   trait :with_creation_date do
     created_edtf { EDTF.parse('2020-03-08') }
+  end
+
+  trait :with_creation_date_year_only do
+    created_edtf { EDTF.parse('2020') }
+  end
+
+  trait :with_creation_date_year_month_only do
+    created_edtf { EDTF.parse('2020-06') }
   end
 
   trait :with_approximate_creation_date do

--- a/spec/services/cocina_generator/description/generator_spec.rb
+++ b/spec/services/cocina_generator/description/generator_spec.rb
@@ -482,6 +482,98 @@ RSpec.describe CocinaGenerator::Description::Generator do
       )
     end
 
+    context 'when publication date of year only' do
+      let(:work_version) do
+        build(:work_version, :published_with_year_only)
+      end
+
+      it 'creates event of type publication with year only date' do
+        expect(model[:event]).to eq(
+          [
+            {
+              type: 'publication',
+              date: [
+                {
+                  encoding: { code: 'edtf' },
+                  value: '2021',
+                  type: 'publication'
+                }
+              ]
+            }
+          ]
+        )
+      end
+    end
+
+    context 'when publication date of year and month only' do
+      let(:work_version) do
+        build(:work_version, :published_with_year_month_only)
+      end
+
+      it 'creates event of type publication with year and month only date' do
+        expect(model[:event]).to eq(
+          [
+            {
+              type: 'publication',
+              date: [
+                {
+                  encoding: { code: 'edtf' },
+                  value: '2021-04',
+                  type: 'publication'
+                }
+              ]
+            }
+          ]
+        )
+      end
+    end
+
+    context 'when creation date of year only' do
+      let(:work_version) do
+        build(:work_version, :with_creation_date_year_only)
+      end
+
+      it 'creates event of type creation with year only date' do
+        expect(model[:event]).to eq(
+          [
+            {
+              type: 'creation',
+              date: [
+                {
+                  encoding: { code: 'edtf' },
+                  value: '2020',
+                  type: 'creation'
+                }
+              ]
+            }
+          ]
+        )
+      end
+    end
+
+    context 'when creation date of year and month only' do
+      let(:work_version) do
+        build(:work_version, :with_creation_date_year_month_only)
+      end
+
+      it 'creates event of type creation with year and month only date' do
+        expect(model[:event]).to eq(
+          [
+            {
+              type: 'creation',
+              date: [
+                {
+                  encoding: { code: 'edtf' },
+                  value: '2020-06',
+                  type: 'creation'
+                }
+              ]
+            }
+          ]
+        )
+      end
+    end
+
     context 'when approximate creation date' do
       let(:work_version) do
         build(:work_version, :with_approximate_creation_date)


### PR DESCRIPTION
## Why was this change made?

Fixes #2066 - dates that are year only or year/month only are getting parsed to include the month and/or day when added to cocina, this makes the display wrong to the user ... this allows the parsing to return the expected display values when generating cocina descriptive 

## How was this change tested?

Added new tests, existing tests

## Which documentation and/or configurations were updated?



