### PR TITLE
Include the orcid in contributor parameters

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -195,7 +195,7 @@ class WorksController < ObjectsController
                      subtype: [],
                      attached_files_attributes: %i[_destroy id label hide file],
                      authors_attributes: %i[_destroy id full_name first_name last_name role_term weight orcid],
-                     contributors_attributes: %i[_destroy id full_name first_name last_name role_term],
+                     contributors_attributes: %i[_destroy id full_name first_name last_name role_term weight orcid],
                      contact_emails_attributes: %i[_destroy id email],
                      keywords_attributes: %i[_destroy id label uri cocina_type],
                      related_works_attributes: %i[_destroy id citation],


### PR DESCRIPTION
## Why was this change made?

Fixes #2091 

The weight and orcid parameters were missing from contributors in the works controller.

![Screen Shot 2021-10-26 at 2 20 32 PM](https://user-images.githubusercontent.com/2294288/138963947-59f54de6-45e4-4665-82d6-7684babb8f24.png)

## How was this change tested?

@amyehodge  has tested and verified on stage.

## Which documentation and/or configurations were updated?



