### PR TITLE
Update turbo-rails to released version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem 'sdr-client', '~> 0.60'
 gem 'sidekiq', '~> 6.1'
 gem 'sneakers', '~> 2.11' # rabbitMQ background processing
 gem 'state_machines-activerecord'
-gem 'turbo-rails', '~> 7.1'
+gem 'turbo-rails', '~> 0.8.2'
 gem 'view_component', '~> 2.18'
 gem 'whenever'
 gem 'zipline', '~> 1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,7 +470,7 @@ GEM
       diff-lcs
       patience_diff
     thor (1.1.0)
-    turbo-rails (7.1.1)
+    turbo-rails (0.8.3)
       rails (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -563,7 +563,7 @@ DEPENDENCIES
   state_machines-activerecord
   state_machines-graphviz
   super_diff
-  turbo-rails (~> 7.1)
+  turbo-rails (~> 0.8.2)
   view_component (~> 2.18)
   web-console (>= 3.3.0)
   webmock


### PR DESCRIPTION
## Why was this change made?
Revert `turbo-rails` to released version.


## How was this change tested?



## Which documentation and/or configurations were updated?
Gemfile


