### PR TITLE
Remove dlss-capistrano provided bundler2 config

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -52,9 +52,6 @@ set :sidekiq_systemd_use_hooks, true
 # Manage sneakers via systemd (from dlss-capistrano gem)
 set :sneakers_systemd_use_hooks, true
 
-# Use bundler 2-style configuration (from dlss-capistrano gem)
-set :bundler2_config_use_hook, true
-
 # Set Rails env to production in all Cap environments
 set :rails_env, 'production'
 


### PR DESCRIPTION


## Why was this change made?
This functionality is now handled by capistrano-bundler 2.0


## How was this change tested?



## Which documentation and/or configurations were updated?



