### PR TITLE
There is no need to require view_components explicity

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,6 @@ require 'active_record/railtie'
 require 'active_storage/engine'
 # require 'rails/test_unit/railtie'
 require 'sprockets/railtie'
-require 'view_component/engine'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION


## Why was this change made?
doing so raises a deprecation warning


## How was this change tested?



## Which documentation and/or configurations were updated?



