### PR TITLE
Follow sdr-api's lead by upping the ActiveStorage service URI timeout

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,7 +41,8 @@ module HappyHeron
     config.action_mailer.default_url_options = { host: Settings.host }
 
     # Override the default (5.minutes), so that large files have enough time to upload
-    config.active_storage.service_urls_expire_in = 120.minutes
+    # Currently 90 minutes is based on most 10G uploads on slow connections taking just under 1.5 hours
+    config.active_storage.service_urls_expire_in = 90.minutes
 
     console do
       Honeybadger.configure do |config|

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,9 @@ module HappyHeron
 
     config.action_mailer.default_url_options = { host: Settings.host }
 
+    # Override the default (5.minutes), so that large files have enough time to upload
+    config.active_storage.service_urls_expire_in = 120.minutes
+
     console do
       Honeybadger.configure do |config|
         config.report_data = false


### PR DESCRIPTION
## Why was this change made?

To reduce timeouts occurring during large file uploads (> 5-10 minutes). 🤷🏻‍♂️ 

## How was this change tested?

Deployed it and uploaded a large file successfully

## Which documentation and/or configurations were updated?

n/a

