### PR TITLE
parse approximate dates in the same way as non-approximate dates

### DIFF
--- a/app/services/cocina_generator/description/generator.rb
+++ b/app/services/cocina_generator/description/generator.rb
@@ -134,7 +134,7 @@ module CocinaGenerator
         {
           type: type,
           qualifier: date.uncertain? ? 'approximate' : nil,
-          value: date.uncertain? ? date.to_s : date.edtf
+          value: date.edtf.chomp('?')
         }.compact
       end
 

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -82,6 +82,14 @@ FactoryBot.define do
     created_edtf { EDTF.parse('2020-03-08?') }
   end
 
+  trait :with_approximate_creation_date_year_only do
+    created_edtf { EDTF.parse('2020?') }
+  end
+
+  trait :with_approximate_creation_date_year_month_only do
+    created_edtf { EDTF.parse('2020-06?') }
+  end
+
   trait :with_keywords do
     transient do
       keywords_count { 3 }

--- a/spec/services/cocina_generator/description/generator_spec.rb
+++ b/spec/services/cocina_generator/description/generator_spec.rb
@@ -598,6 +598,54 @@ RSpec.describe CocinaGenerator::Description::Generator do
       end
     end
 
+    context 'when approximate creation date of year only' do
+      let(:work_version) do
+        build(:work_version, :with_approximate_creation_date_year_only)
+      end
+
+      it 'creates event of type creation with approximate year only date' do
+        expect(model[:event]).to eq(
+          [
+            {
+              type: 'creation',
+              date: [
+                {
+                  encoding: { code: 'edtf' },
+                  value: '2020',
+                  type: 'creation',
+                  qualifier: 'approximate'
+                }
+              ]
+            }
+          ]
+        )
+      end
+    end
+
+    context 'when approximate creation date of year and month only date' do
+      let(:work_version) do
+        build(:work_version, :with_approximate_creation_date_year_month_only)
+      end
+
+      it 'creates event of type creation with approximate year and month only date' do
+        expect(model[:event]).to eq(
+          [
+            {
+              type: 'creation',
+              date: [
+                {
+                  encoding: { code: 'edtf' },
+                  value: '2020-06',
+                  type: 'creation',
+                  qualifier: 'approximate'
+                }
+              ]
+            }
+          ]
+        )
+      end
+    end
+
     context 'when approximate creation date range' do
       let(:work_version) do
         build(:work_version, :with_approximate_creation_date_range)


### PR DESCRIPTION
## Why was this change made?

Fixes #2139 - approximate dates should be parsed in the same way as non-approximate dates when added to cocina, they just get a qualifier added to the cocina metadata

## How was this change tested?

Added new fixtures and tests (confirmed they failed before my code change and passed after it)


## Which documentation and/or configurations were updated?



