### PR TITLE
Removes SDR as digital repository in cocina.

### DIFF
--- a/app/services/cocina_generator/description/collection_description_generator.rb
+++ b/app/services/cocina_generator/description/collection_description_generator.rb
@@ -49,18 +49,11 @@ module CocinaGenerator
 
       def access
         args = {
-          accessContact: access_contacts,
-          digitalRepository: repository
+          accessContact: access_contacts
         }.compact
         return if args.empty?
 
         Cocina::Models::DescriptiveAccessMetadata.new(args)
-      end
-
-      def repository
-        return unless collection_version.collection.purl
-
-        [{ value: 'Stanford Digital Repository' }]
       end
 
       def access_contacts

--- a/app/services/cocina_generator/description/generator.rb
+++ b/app/services/cocina_generator/description/generator.rb
@@ -3,7 +3,7 @@
 module CocinaGenerator
   module Description
     # This generates a RequestDRO Description for a work
-    class Generator # rubocop:disable Metrics/ClassLength
+    class Generator
       def self.generate(work_version:)
         new(work_version: work_version).generate
       end
@@ -144,18 +144,11 @@ module CocinaGenerator
 
       def access
         args = {
-          accessContact: access_contacts,
-          digitalRepository: repository
+          accessContact: access_contacts
         }.compact
         return if args.empty?
 
         Cocina::Models::DescriptiveAccessMetadata.new(args)
-      end
-
-      def repository
-        return unless work_version.work.purl
-
-        [{ value: 'Stanford Digital Repository' }]
       end
 
       def access_contacts

--- a/app/services/cocina_generator/description/related_links_generator.rb
+++ b/app/services/cocina_generator/description/related_links_generator.rb
@@ -38,10 +38,7 @@ module CocinaGenerator
       # This normalizes the PURL link to https (as it is currently the canonincal PURL)
       def purl_link(rel_link)
         resource_attrs = {
-          purl: rel_link.url.sub(/^https?/, 'https'),
-          access: Cocina::Models::DescriptiveAccessMetadata.new(
-            digitalRepository: [Cocina::Models::DescriptiveValue.new(value: 'Stanford Digital Repository')]
-          )
+          purl: rel_link.url.sub(/^https?/, 'https')
         }
         resource_attrs[:title] = [{ value: rel_link.link_title }] if rel_link.link_title.present?
         Cocina::Models::RelatedResource.new(resource_attrs)

--- a/spec/services/cocina_generator/collection_generator_spec.rb
+++ b/spec/services/cocina_generator/collection_generator_spec.rb
@@ -114,11 +114,6 @@ RSpec.describe CocinaGenerator::CollectionGenerator do
                   type: 'email',
                   displayLabel: 'Contact'
                 }
-              ],
-              digitalRepository: [
-                {
-                  value: 'Stanford Digital Repository'
-                }
               ]
             }
           },

--- a/spec/services/cocina_generator/description/related_links_generator_spec.rb
+++ b/spec/services/cocina_generator/description/related_links_generator_spec.rb
@@ -45,17 +45,11 @@ RSpec.describe CocinaGenerator::Description::RelatedLinksGenerator do
       expect(model).to eq([
                             Cocina::Models::RelatedResource.new({
                                                                   purl: 'https://purl.stanford.edu/tx853fp2857',
-                                                                  title: [{ value: 'My Awesome Research' }],
-                                                                  access: { digitalRepository: [
-                                                                    { value: 'Stanford Digital Repository' }
-                                                                  ] }
+                                                                  title: [{ value: 'My Awesome Research' }]
                                                                 }).to_h,
                             Cocina::Models::RelatedResource.new({
                                                                   purl: 'https://purl.stanford.edu/xy933bc2222',
-                                                                  title: [{ value: 'My Awesome Research' }],
-                                                                  access: { digitalRepository: [
-                                                                    { value: 'Stanford Digital Repository' }
-                                                                  ] }
+                                                                  title: [{ value: 'My Awesome Research' }]
                                                                 }).to_h,
                             Cocina::Models::RelatedResource.new({
                                                                   title: [{ value: 'My Awesome Research' }],

--- a/spec/services/cocina_generator/dro_generator_spec.rb
+++ b/spec/services/cocina_generator/dro_generator_spec.rb
@@ -184,7 +184,6 @@ RSpec.describe CocinaGenerator::DROGenerator do
               }
             ],
             form: types_form,
-            access: { digitalRepository: [{ value: 'Stanford Digital Repository' }] },
             purl: 'https://purl.stanford.edu/bk123gh4567',
             adminMetadata: admin_metadata
           },
@@ -247,7 +246,6 @@ RSpec.describe CocinaGenerator::DROGenerator do
               }
             ],
             form: types_form,
-            access: { digitalRepository: [{ value: 'Stanford Digital Repository' }] },
             purl: 'https://purl.stanford.edu/bk123gh4567',
             adminMetadata: admin_metadata
           },
@@ -464,7 +462,6 @@ RSpec.describe CocinaGenerator::DROGenerator do
                 }
               ],
               form: types_form,
-              access: { digitalRepository: [{ value: 'Stanford Digital Repository' }] },
               purl: 'https://purl.stanford.edu/bk123gh4567',
               adminMetadata: admin_metadata
             },


### PR DESCRIPTION
## Why was this change made?
Including this in cocina is no longer required.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



