### PR TITLE
Stop using uppercase for Digital Repository

### DIFF
--- a/app/assets/stylesheets/suNavbar.scss
+++ b/app/assets/stylesheets/suNavbar.scss
@@ -29,7 +29,6 @@
     .digital-repo {
       @extend h4;
       padding-left: 1rem;
-      text-transform: uppercase;
     }
   }
 }


### PR DESCRIPTION


## Why was this change made?
Only larger units are permitted to do this.


## How was this change tested?



## Which documentation and/or configurations were updated?



