### PR TITLE
Bump sidekiq to 6.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,7 +426,7 @@ GEM
     serverengine (2.1.1)
       sigdump (~> 0.2.2)
     set (1.0.2)
-    sidekiq (6.4.0)
+    sidekiq (6.4.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)


### PR DESCRIPTION
Silence redis.pipeline deprecation warnings in cron emails

