### PR TITLE
use today's date in pacific time zone for embargoes

### DIFF
--- a/app/validators/embargo_date_validator.rb
+++ b/app/validators/embargo_date_validator.rb
@@ -16,7 +16,7 @@ class EmbargoDateValidator < ActiveModel::EachValidator
   def valid_embargo_collection(collection, record, attribute, value)
     year_match = collection.release_duration.match(/(\d+)/)
     year_label = year_match[0].to_i < 2 ? 'year' : 'years'
-    future_date = Time.zone.today + year_match[0].to_i.years
+    future_date = current_date + year_match[0].to_i.years
     error_message = "must be less than #{year_match[0]} #{year_label} in the future"
     if value > future_date
       record.errors.add attribute, error_message
@@ -26,10 +26,16 @@ class EmbargoDateValidator < ActiveModel::EachValidator
   end
 
   def valid_embargo_value(record, attribute, value)
-    if value > Time.zone.today + 3.years
+    if value > current_date + 3.years
       record.errors.add attribute, 'must be less than 3 years in the future'
-    elsif value <= Time.zone.today
+    elsif value <= current_date
       record.errors.add attribute, 'must be in the future'
     end
+  end
+
+  # the current date in the Pacific Time Zone, which is what embargo uses
+  #  this is important if you want to ensure that you can set tomorrow's date and it is late in the day pacific
+  def current_date
+    Time.now.in_time_zone('Pacific Time (US & Canada)').to_date
   end
 end

--- a/spec/validators/embargo_date_validator_spec.rb
+++ b/spec/validators/embargo_date_validator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe EmbargoDateValidator do
   let(:validator) { described_class.new(options) }
   let(:collection) { create(:collection, release_option: 'depositor-selects', release_duration: '3 years') }
   let(:work) { create(:work, collection: collection) }
-
+  let(:current_date) { Time.now.in_time_zone('Pacific Time (US & Canada)').to_date }
   let(:work_version) { create(:work_version, work: work) }
   let(:record) { WorkForm.new(work_version: work_version, work: work) }
 
@@ -17,7 +17,6 @@ RSpec.describe EmbargoDateValidator do
 
   context 'when no date is provided' do
     let(:attribute) { :embargo_date }
-    # let(:value) { Time.zone.today + 2.years }
     let(:value) { nil }
 
     it 'has no errors' do
@@ -27,16 +26,25 @@ RSpec.describe EmbargoDateValidator do
 
   context 'with a date in the past' do
     let(:attribute) { :embargo_date }
-    let(:value) { Time.zone.today - 1.day }
+    let(:value) { current_date - 2.days }
+
+    it 'has errors' do
+      expect(record.errors.full_messages).to eq ['Embargo date must be in the future']
+    end
+  end
+
+  context 'with a date of tomorrow' do
+    let(:attribute) { :embargo_date }
+    let(:value) { current_date + 1.day }
 
     it 'has no errors' do
-      expect(record.errors.full_messages).to eq ['Embargo date must be in the future']
+      expect(record.errors).to be_empty
     end
   end
 
   context 'with a date 2 years in the future' do
     let(:attribute) { :embargo_date }
-    let(:value) { Time.zone.today + 2.years }
+    let(:value) { current_date + 2.years }
 
     it 'has no errors' do
       expect(record.errors).to be_empty
@@ -45,7 +53,7 @@ RSpec.describe EmbargoDateValidator do
 
   context 'with a date more than 3 years in the future' do
     let(:attribute) { :embargo_date }
-    let(:value) { Time.zone.today + 3.years + 1.day }
+    let(:value) { current_date + 3.years + 1.day }
 
     it 'has errors' do
       expect(record.errors.full_messages).to eq ['Embargo date must be less than 3 years in the future']
@@ -55,7 +63,7 @@ RSpec.describe EmbargoDateValidator do
   context 'with a date more than the collection release_duration' do
     let(:collection) { create(:collection, release_option: 'depositor-selects', release_duration: '1 year') }
     let(:attribute) { :embargo_date }
-    let(:value) { Time.zone.today + 2.years }
+    let(:value) { current_date + 2.years }
 
     it 'has errors' do
       expect(record.errors.full_messages).to eq ['Embargo date must be less than 1 year in the future']


### PR DESCRIPTION
## Why was this change made?

Fixes #2168 - use Pacific Time Zone when computing today's date, so you can set an embargo date of tomorrow even if it's late in the day pacific (after 4pm, UTC will say it's tomorrow)

I think this should work fine with our current release process, because when it runs, it will see the date has passed and release it that night.

## How was this change tested?

Updated tests

## Which documentation and/or configurations were updated?



