### PR TITLE
set default time zone for the app to Pacific; revert embargo changes

### DIFF
--- a/app/validators/embargo_date_validator.rb
+++ b/app/validators/embargo_date_validator.rb
@@ -16,7 +16,7 @@ class EmbargoDateValidator < ActiveModel::EachValidator
   def valid_embargo_collection(collection, record, attribute, value)
     year_match = collection.release_duration.match(/(\d+)/)
     year_label = year_match[0].to_i < 2 ? 'year' : 'years'
-    future_date = current_date + year_match[0].to_i.years
+    future_date = Time.zone.today + year_match[0].to_i.years
     error_message = "must be less than #{year_match[0]} #{year_label} in the future"
     if value > future_date
       record.errors.add attribute, error_message
@@ -26,16 +26,10 @@ class EmbargoDateValidator < ActiveModel::EachValidator
   end
 
   def valid_embargo_value(record, attribute, value)
-    if value > current_date + 3.years
+    if value > Time.zone.today + 3.years
       record.errors.add attribute, 'must be less than 3 years in the future'
-    elsif value <= current_date
+    elsif value <= Time.zone.today
       record.errors.add attribute, 'must be in the future'
     end
-  end
-
-  # the current date in the Pacific Time Zone, which is what embargo uses
-  #  this is important if you want to ensure that you can set tomorrow's date and it is late in the day pacific
-  def current_date
-    Time.now.in_time_zone('Pacific Time (US & Canada)').to_date
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,8 @@ module HappyHeron
     # Currently 90 minutes is based on most 10G uploads on slow connections taking just under 1.5 hours
     config.active_storage.service_urls_expire_in = 90.minutes
 
+    config.time_zone = 'Pacific Time (US & Canada)'
+
     console do
       Honeybadger.configure do |config|
         config.report_data = false

--- a/spec/validators/embargo_date_validator_spec.rb
+++ b/spec/validators/embargo_date_validator_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe EmbargoDateValidator do
   let(:validator) { described_class.new(options) }
   let(:collection) { create(:collection, release_option: 'depositor-selects', release_duration: '3 years') }
   let(:work) { create(:work, collection: collection) }
-  let(:current_date) { Time.now.in_time_zone('Pacific Time (US & Canada)').to_date }
   let(:work_version) { create(:work_version, work: work) }
   let(:record) { WorkForm.new(work_version: work_version, work: work) }
 
@@ -26,7 +25,7 @@ RSpec.describe EmbargoDateValidator do
 
   context 'with a date in the past' do
     let(:attribute) { :embargo_date }
-    let(:value) { current_date - 2.days }
+    let(:value) { Time.zone.today - 2.days }
 
     it 'has errors' do
       expect(record.errors.full_messages).to eq ['Embargo date must be in the future']
@@ -35,7 +34,7 @@ RSpec.describe EmbargoDateValidator do
 
   context 'with a date of tomorrow' do
     let(:attribute) { :embargo_date }
-    let(:value) { current_date + 1.day }
+    let(:value) { Time.zone.today + 1.day }
 
     it 'has no errors' do
       expect(record.errors).to be_empty
@@ -44,7 +43,7 @@ RSpec.describe EmbargoDateValidator do
 
   context 'with a date 2 years in the future' do
     let(:attribute) { :embargo_date }
-    let(:value) { current_date + 2.years }
+    let(:value) { Time.zone.today + 2.years }
 
     it 'has no errors' do
       expect(record.errors).to be_empty
@@ -53,7 +52,7 @@ RSpec.describe EmbargoDateValidator do
 
   context 'with a date more than 3 years in the future' do
     let(:attribute) { :embargo_date }
-    let(:value) { current_date + 3.years + 1.day }
+    let(:value) { Time.zone.today + 3.years + 1.day }
 
     it 'has errors' do
       expect(record.errors.full_messages).to eq ['Embargo date must be less than 3 years in the future']
@@ -63,7 +62,7 @@ RSpec.describe EmbargoDateValidator do
   context 'with a date more than the collection release_duration' do
     let(:collection) { create(:collection, release_option: 'depositor-selects', release_duration: '1 year') }
     let(:attribute) { :embargo_date }
-    let(:value) { current_date + 2.years }
+    let(:value) { Time.zone.today + 2.years }
 
     it 'has errors' do
       expect(record.errors.full_messages).to eq ['Embargo date must be less than 1 year in the future']


### PR DESCRIPTION
## Why was this change made?

This reverts #2179 (use Pacific time for embargo dates), and instead just sets the application's default time zone to Pacific.  This will have the same effect as the reverted change for the embargo dates, and will also make the date displays for users show in the Pacific time zone.  This will prevent weird "from the future" things like below happening, where I edited an item on March 4 after 4pm, but it showed as last updated on March 5 (since anytime after 4pm Pacific is now the next day in UTC).  Since we display dates (and not timestamps) to users, I think this change should do the expected thing for anyone in North America.

![Screen Shot 2022-03-04 at 4 29 10 PM](https://user-images.githubusercontent.com/47137/156859993-ecdbfc5a-c0bb-42f6-9350-f31483616ecc.png)

## How was this change tested?

Tests and localhost browser.

## Which documentation and/or configurations were updated?



