### PR TITLE
validate subtypes on draft form; improve error display

### DIFF
--- a/app/components/collections/update/settings_form_component.html.erb
+++ b/app/components/collections/update/settings_form_component.html.erb
@@ -7,8 +7,8 @@
     html: { class: 'needs-validation collection-editor', novalidate: true, multipart: true } do |form| %>
 
   <% if collection_form.errors.present? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(collection_form.errors.count, "error") %> prohibited this item from being saved:</h2>
+    <div id="error_explanation" class="alert alert-danger">
+      <h4><%= pluralize(collection_form.errors.count, "error") %> prohibited this item from being saved:</h4>
 
       <ul>
         <% collection_form.errors.each do |error| %>

--- a/app/components/works/form_component.html.erb
+++ b/app/components/works/form_component.html.erb
@@ -7,8 +7,8 @@
     },
     html: { class: "needs-validation work-editor", novalidate: true, multipart: true } do |f| %>
   <% if work_form.errors.present? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(work_form.errors.count, "error") %> prohibited this item from being saved:</h2>
+    <div id="error_explanation" class="alert alert-danger">
+      <h4><%= pluralize(work_form.errors.count, "error") %> prohibited this item from being saved:</h4>
 
       <ul>
         <% work_form.errors.each do |error| %>

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -38,6 +38,9 @@ class DraftWorkForm < Reform::Form
   validates_with CreatedDateParts,
                  if: proc { |form| form.created_type == 'range' }
 
+  validates :subtype, work_subtype: true
+  validates :work_type, presence: true, work_type: true
+
   delegate :user_can_set_availability?, to: :collection
 
   def deserialize!(params)

--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -9,8 +9,6 @@ class WorkForm < DraftWorkForm
   validates :attached_files, length: { minimum: 1, message: 'Please add at least one file.' }
   validates :contact_emails, length: { minimum: 1, message: 'Please add at least contact email.' }
   validates :license, presence: true, inclusion: { in: License.license_list }
-  validates :subtype, work_subtype: true
-  validates :work_type, presence: true, work_type: true
   validates :authors, length: { minimum: 1, message: 'Please add at least one author.' }
   validates :created_edtf, created_in_past: true
   validates :published_edtf, created_in_past: true

--- a/spec/forms/draft_work_form_spec.rb
+++ b/spec/forms/draft_work_form_spec.rb
@@ -13,4 +13,42 @@ RSpec.describe DraftWorkForm do
       expect(form.model_name.param_key).to eq 'work'
     end
   end
+
+  describe 'type validation' do
+    let(:errors) { form.errors.where(:work_type) }
+    let(:messages) { errors.map(&:message) }
+
+    it 'does not validate with an invalid work type' do
+      form.validate(work_type: 'a pile of something')
+      expect(form).not_to be_valid
+      expect(messages).to eq ['is not a valid work type']
+    end
+
+    it 'does not validate with a missing work type' do
+      form.validate(work_type: '')
+      expect(form).not_to be_valid
+      expect(messages).to eq ['can\'t be blank', 'is not a valid work type']
+    end
+  end
+
+  describe 'subtype validation' do
+    let(:errors) { form.errors.where(:subtype) }
+    let(:messages) { errors.map(&:message) }
+
+    it 'validates with a valid work_type and a "more" type' do
+      form.validate(work_type: 'data', subtype: ['Animation'])
+      expect(messages).to be_empty
+    end
+
+    it 'does not validate with a work_type that requires a user-supplied subtype and is empty' do
+      form.validate(work_type: 'other', subtype: [])
+      expect(form).not_to be_valid
+      expect(messages).to eq ['is not a valid subtype for work type other']
+    end
+
+    it 'validates with a valid subtype/work_type combo' do
+      form.validate(work_type: 'data', subtype: ['Documentation'])
+      expect(messages).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #2171 - validate subtypes on draft work form because if the user tries to save a draft work with an invalid subtype (e.g. they had selected "music" but then unselected any subtypes), the work will be in an inconsistent invalid state that cannot be saved to the database.  This is a pretty rare condition, as we already validate subtypes before you get to this form (in the modal when you create a new work), but it is possible to get past that form and then deselect subtypes and make the work version invalid.  This should prevent that from happening.

Also, improve error display for validation errors on draft work page so you don't miss them.  

**Before:**

![Screen Shot 2022-03-04 at 4 28 05 PM](https://user-images.githubusercontent.com/47137/156860324-7b13c6c5-750d-4c37-9bb7-851d5aa1fcb3.png)

**After:**

![Screen Shot 2022-03-04 at 4 27 38 PM](https://user-images.githubusercontent.com/47137/156860339-a2a0fd53-ade3-408e-b361-d77dcd337ba2.png)


## How was this change tested?

Localhost browser
Updated tests

## Which documentation and/or configurations were updated?



