### PR TITLE
Revert "set default time zone for the app to Pacific; revert embargo changes"

### DIFF
--- a/app/validators/embargo_date_validator.rb
+++ b/app/validators/embargo_date_validator.rb
@@ -16,7 +16,7 @@ class EmbargoDateValidator < ActiveModel::EachValidator
   def valid_embargo_collection(collection, record, attribute, value)
     year_match = collection.release_duration.match(/(\d+)/)
     year_label = year_match[0].to_i < 2 ? 'year' : 'years'
-    future_date = Time.zone.today + year_match[0].to_i.years
+    future_date = current_date + year_match[0].to_i.years
     error_message = "must be less than #{year_match[0]} #{year_label} in the future"
     if value > future_date
       record.errors.add attribute, error_message
@@ -26,10 +26,16 @@ class EmbargoDateValidator < ActiveModel::EachValidator
   end
 
   def valid_embargo_value(record, attribute, value)
-    if value > Time.zone.today + 3.years
+    if value > current_date + 3.years
       record.errors.add attribute, 'must be less than 3 years in the future'
-    elsif value <= Time.zone.today
+    elsif value <= current_date
       record.errors.add attribute, 'must be in the future'
     end
+  end
+
+  # the current date in the Pacific Time Zone, which is what embargo uses
+  #  this is important if you want to ensure that you can set tomorrow's date and it is late in the day pacific
+  def current_date
+    Time.now.in_time_zone('Pacific Time (US & Canada)').to_date
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,8 +44,6 @@ module HappyHeron
     # Currently 90 minutes is based on most 10G uploads on slow connections taking just under 1.5 hours
     config.active_storage.service_urls_expire_in = 90.minutes
 
-    config.time_zone = 'Pacific Time (US & Canada)'
-
     console do
       Honeybadger.configure do |config|
         config.report_data = false

--- a/spec/validators/embargo_date_validator_spec.rb
+++ b/spec/validators/embargo_date_validator_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe EmbargoDateValidator do
   let(:validator) { described_class.new(options) }
   let(:collection) { create(:collection, release_option: 'depositor-selects', release_duration: '3 years') }
   let(:work) { create(:work, collection: collection) }
+  let(:current_date) { Time.now.in_time_zone('Pacific Time (US & Canada)').to_date }
   let(:work_version) { create(:work_version, work: work) }
   let(:record) { WorkForm.new(work_version: work_version, work: work) }
 
@@ -25,7 +26,7 @@ RSpec.describe EmbargoDateValidator do
 
   context 'with a date in the past' do
     let(:attribute) { :embargo_date }
-    let(:value) { Time.zone.today - 2.days }
+    let(:value) { current_date - 2.days }
 
     it 'has errors' do
       expect(record.errors.full_messages).to eq ['Embargo date must be in the future']
@@ -34,7 +35,7 @@ RSpec.describe EmbargoDateValidator do
 
   context 'with a date of tomorrow' do
     let(:attribute) { :embargo_date }
-    let(:value) { Time.zone.today + 1.day }
+    let(:value) { current_date + 1.day }
 
     it 'has no errors' do
       expect(record.errors).to be_empty
@@ -43,7 +44,7 @@ RSpec.describe EmbargoDateValidator do
 
   context 'with a date 2 years in the future' do
     let(:attribute) { :embargo_date }
-    let(:value) { Time.zone.today + 2.years }
+    let(:value) { current_date + 2.years }
 
     it 'has no errors' do
       expect(record.errors).to be_empty
@@ -52,7 +53,7 @@ RSpec.describe EmbargoDateValidator do
 
   context 'with a date more than 3 years in the future' do
     let(:attribute) { :embargo_date }
-    let(:value) { Time.zone.today + 3.years + 1.day }
+    let(:value) { current_date + 3.years + 1.day }
 
     it 'has errors' do
       expect(record.errors.full_messages).to eq ['Embargo date must be less than 3 years in the future']
@@ -62,7 +63,7 @@ RSpec.describe EmbargoDateValidator do
   context 'with a date more than the collection release_duration' do
     let(:collection) { create(:collection, release_option: 'depositor-selects', release_duration: '1 year') }
     let(:attribute) { :embargo_date }
-    let(:value) { Time.zone.today + 2.years }
+    let(:value) { current_date + 2.years }
 
     it 'has errors' do
       expect(record.errors.full_messages).to eq ['Embargo date must be less than 1 year in the future']


### PR DESCRIPTION
Reverts sul-dlss/happy-heron#2181

Potentially may cause unwanted side effects, see https://github.com/sul-dlss/happy-heron/pull/2181#issuecomment-1059692039

Follow on PR: #2184