### PR TITLE
show dates in local time zone

### DIFF
--- a/app/components/collections/work_row_component.html.erb
+++ b/app/components/collections/work_row_component.html.erb
@@ -6,7 +6,7 @@
   </td>
   <td><%= work.depositor.sunetid %></td>
   <td><%= render Works::StateDisplayComponent.new(work_version: work_version) %></td>
-  <td><%= I18n.l(work.updated_at.to_date, format: :abbr_month) %></td>
+  <td><%= render LocalTimeComponent.new(datetime: work.updated_at, show_time: false) %></td>
   <td><%= attached_files.count %></td>
   <td><%= size %></td>
   <td><%= link_to work.purl, work.purl if work.purl %></td>

--- a/app/components/dashboard/all_collections_row_component.html.erb
+++ b/app/components/dashboard/all_collections_row_component.html.erb
@@ -7,5 +7,5 @@
   <td><%= state_count('pending_approval') %></td>
   <td><%= state_count('rejected') %></td>
   <td><%= state_count('purl_reserved') %></td>
-  <td><%= I18n.l(collection.updated_at.to_date, format: :abbr_month) %></td>
+  <td><%= render LocalTimeComponent.new(datetime: collection.updated_at, show_time: false) %></td>
 </tr>

--- a/app/components/dashboard/approvals_component.html.erb
+++ b/app/components/dashboard/approvals_component.html.erb
@@ -18,7 +18,7 @@
         <td><%= submission.work.depositor.sunetid %></td>
         <td><%= render Collections::LinkToShowComponent.new(collection_version: submission.work.collection.head) %></td>
         <td><%= render Works::StateDisplayComponent.new(work_version: submission) %></td>
-        <td><%= I18n.l(submission.updated_at.to_date, format: :abbr_month) %></td>
+        <td><%= render LocalTimeComponent.new(datetime: submission.updated_at, show_time: false) %></td>
       </tr>
     <% end %>
     </tbody>

--- a/app/components/dashboard/in_progress_row_component.html.erb
+++ b/app/components/dashboard/in_progress_row_component.html.erb
@@ -6,5 +6,5 @@
   </td>
   <td><%= show_collection_link %></td>
   <td><%= render Works::StateDisplayComponent.new(work_version: work_version) %></td>
-  <td><%= I18n.l(work_version.updated_at.to_date, format: :abbr_month) %></td>
+  <td><%= render LocalTimeComponent.new(datetime: work_version.updated_at, show_time: false) %></td>
 </tr>

--- a/app/components/local_time_component.rb
+++ b/app/components/local_time_component.rb
@@ -2,17 +2,14 @@
 
 # Draws a custom element for https://github.com/github/time-elements
 class LocalTimeComponent < ApplicationComponent
-  def initialize(datetime:)
+  def initialize(datetime:, show_time: true)
     @datetime = datetime
+    @show_time = show_time
   end
 
   def call
-    tag.local_time(datetime: @datetime.iso8601,
-                   month: 'short',
-                   day: 'numeric',
-                   year: 'numeric',
-                   hour: 'numeric',
-                   minute: 'numeric',
-                   'time-zone-name': 'short')
+    options = { datetime: @datetime.iso8601, month: 'short', day: 'numeric', year: 'numeric' }
+    options.merge!(hour: 'numeric', minute: 'numeric', 'time-zone-name': 'short') if @show_time
+    tag.local_time(**options)
   end
 end

--- a/app/views/dashboards/_collection_summary_row.html.erb
+++ b/app/views/dashboards/_collection_summary_row.html.erb
@@ -6,7 +6,7 @@
   </td>
   <td><%= render Works::StateDisplayComponent.new(work_version: work.head) %></td>
   <td class="visible-to-reviewer-<%= work.collection.id %>"><%= work.depositor.sunetid %></td>
-  <td><%= I18n.l(work.updated_at.to_date, format: :abbr_month) %></td>
+  <td><%= render LocalTimeComponent.new(datetime: work.updated_at, show_time: false) %></td>
   <td>
     <% if work.purl %>
       <%= link_to work.purl, work.purl %>


### PR DESCRIPTION
## Why was this change made?

Modify the component for display of local times to also display local dates (skip time display option) and use it instead of showing UTC based dates. Note that the date format is not going to be localized with `i18n` anymore but our display format is like this `Mar 4 2022`, which is not ambiguous.  In place of #2181 

~~Holding for reverting of that PR: #2183~~

## How was this change tested?

Existing tests
Localhost browser

## Which documentation and/or configurations were updated?



