### PR TITLE
Unpin ViewComponent now that the bug introduced in 2.51.0 has been fixed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,6 @@ gem 'sidekiq', '~> 6.1'
 gem 'sneakers', '~> 2.11' # rabbitMQ background processing
 gem 'state_machines-activerecord'
 gem 'turbo-rails', '~> 1.0'
-# TODO: Figure out why the 2.51.0 ViewComponent update broke the collections show detail header component spec
-gem 'view_component', '~> 2.50.0' # Previously pinned to '~> 2.18'
+gem 'view_component', '~> 2.52'
 gem 'whenever'
 gem 'zipline', '~> 1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,7 +460,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.1.0)
-    view_component (2.50.0)
+    view_component (2.52.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     warden (1.2.9)
@@ -548,7 +548,7 @@ DEPENDENCIES
   state_machines-graphviz
   super_diff
   turbo-rails (~> 1.0)
-  view_component (~> 2.50.0)
+  view_component (~> 2.52)
   web-console (>= 3.3.0)
   webmock
   whenever


### PR DESCRIPTION
## Why was this change made? 🤔

No need to pin the dependency at patch-level now that the bug is fixed.

## How was this change tested? 🤨

CI
