### PR TITLE
Sort works by date in descending order by default.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :development do
   gem 'faker'
   gem 'listen', '~> 3.2'
   gem 'multi_json', require: false # needed to update RBIs after adding reform-rails
-  gem 'puma', '~> 5.5'
+  gem 'puma', '~> 5.6', '>= 5.6.4'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'state_machines-graphviz'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,7 +292,7 @@ GEM
       optimist (~> 3.0)
     pg (1.3.4)
     public_suffix (4.0.6)
-    puma (5.6.2)
+    puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
@@ -527,7 +527,7 @@ DEPENDENCIES
   multi_json
   okcomputer
   pg
-  puma (~> 5.5)
+  puma (~> 5.6, >= 5.6.4)
   rails (~> 6.1)
   redis (~> 4.0)
   reform (~> 2.5.0)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Self-Deposit for the Stanford Digital Repository (SDR)
 
-happy-heron, or H2 (from "Hydrus 2.0"), is a Rails web application enabling users to deposit scholarly content into the SDR. It will replace [Hydrus](https://github.com/sul-dlss/hydrus).
+happy-heron, or H2 (from "Hydrus 2.0"), is a Rails web application enabling users to deposit scholarly content into the SDR. It replaced [Hydrus](https://github.com/sul-dlss/hydrus).
 
 ## UX Design
 

--- a/app/components/collections/works_component.html.erb
+++ b/app/components/collections/works_component.html.erb
@@ -5,7 +5,7 @@
       <th><span class="visually-hidden"><%= I18n.t 'collection.actions' %></span></th>
       <th width="10%"><%= I18n.t 'collection.depositor' %></th>
       <th><%= I18n.t 'collection.deposit_status' %></th>
-      <th data-type="date" data-format="MMM DD, YYYY"><%= I18n.t 'collection.last_modified' %></th>
+      <th data-type="date" data-format="MMM D, YYYY"><%= I18n.t 'collection.last_modified' %></th>
       <th><%= I18n.t 'collection.number_of_files' %></th>
       <th><%= I18n.t 'collection.deposit_size' %></th>
       <th><%= I18n.t 'collection.persistent_link' %></th>

--- a/app/components/dashboard/all_collections_component.html.erb
+++ b/app/components/dashboard/all_collections_component.html.erb
@@ -25,7 +25,7 @@
         <th>Pending</th>
         <th>Returned</th>
         <th>Reserved</th>
-        <th data-type="date" data-format="MMM DD, YYYY">Last modified</th>
+        <th data-type="date" data-format="MMM D, YYYY">Last modified</th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
## Why was this change made? 🤔

The works need to be sorted by date in descending order by default. There was a very small problem with the date format being used with simple-datatables. I noticed that the Collections list was broken in a similar way, and adjusted it there too.

Also bundled in this change is version upgrade to puma because of ﻿﻿https://github.com/puma/puma/security/advisories/GHSA-h99w-9q5r-gjq9

## How was this change tested? 🤨

Tested on https://sul-h2-qa.stanford.edu/ @amyehodge tested in Stage and gave her approval.

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


