### PR TITLE
add some HB context for when deposit jobs fail

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -412,3 +412,16 @@ RSpec/SubjectDeclaration: # new in 2.5
   Enabled: true
 RSpec/FactoryBot/SyntaxMethods: # new in 2.7
   Enabled: true
+
+Lint/RefinementImportMethods: # new in 1.27
+  Enabled: true
+Security/CompoundHash: # new in 1.28
+  Enabled: true
+Style/FetchEnvVar: # new in 1.28
+  Enabled: true
+Style/ObjectThen: # new in 1.28
+  Enabled: true
+Style/RedundantInitialize: # new in 1.27
+  Enabled: true
+RSpec/VerifiedDoubleReference: # new in 2.10.0
+  Enabled: true

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,7 +40,7 @@ class ApplicationController < ActionController::Base
   def groups_from_request_env
     session['groups'] = begin
       raw_header = request.env[Settings.authorization_group_header]
-      raw_header = ENV['ROLES'] if Rails.env.development? # rubocop:disable Rails/EnvironmentVariableAccess
+      raw_header = ENV.fetch('ROLES', nil) if Rails.env.development? # rubocop:disable Rails/EnvironmentVariableAccess
       logger.debug("Roles are #{raw_header}")
       raw_header&.split(';') || []
     end

--- a/app/jobs/deposit_job.rb
+++ b/app/jobs/deposit_job.rb
@@ -4,7 +4,11 @@
 class DepositJob < BaseDepositJob
   queue_as :default
 
+  # rubocop:disable Metrics/AbcSize:
   def perform(work_version)
+    Honeybadger.context({ work_version_id: work_version.id, druid: work_version.work.druid,
+                          work_id: work_version.work.id, depositor_sunet: work_version.work.depositor.sunetid })
+
     request_dro = CocinaGenerator::DROGenerator.generate_model(work_version: work_version)
     blobs = work_version.attached_files.map { |af| af.file.attachment.blob }
 
@@ -21,6 +25,7 @@ class DepositJob < BaseDepositJob
       update(new_request_dro)
     end
   end
+  # rubocop:enable Metrics/AbcSize:
 
   private
 

--- a/config/initializers/devise_remote_user.rb
+++ b/config/initializers/devise_remote_user.rb
@@ -2,7 +2,7 @@
 
 DeviseRemoteUser.configure do |config|
   config.env_key = lambda do |env|
-    if Rails.env.development? && ENV['REMOTE_USER']
+    if Rails.env.development? && ENV.fetch('REMOTE_USER', nil)
       ENV['REMOTE_USER']
     else
       # Return the first non-blank value of a remote user header, or return nil (unauthenticated)


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2217 - when a DepositJob fails, we can add some HB context (like druid, depositor, work id) to help debug.

Also -- add new rubocop cops and autofix errors.


## How was this change tested? 🤨

It was not, but this is a pretty minor change.