### PR TITLE
Fix bug:  agree_to_terms? is true when User.last_work_terms_agreement is nil (which should be impossible)

### DIFF
--- a/app/components/works/agreement_component.html.erb
+++ b/app/components/works/agreement_component.html.erb
@@ -4,7 +4,7 @@
     <div class="form-check col-auto">
       <% if agree_to_terms? %>
         You agreed to the <%= link_to 'SDR Terms of Deposit', '#termsOfDepositModal', data: { bs_toggle: 'modal', bs_target: '#termsOfDepositModal'} %>
-        <%= time_ago_in_words form.object.model.fetch(:work).depositor.last_work_terms_agreement %> ago.
+        <%= time_ago_in_words date_last_agreed %> ago.
       <% else %>
         <%= form.check_box :agree_to_terms, required: true, class: 'form-check-input' %>
         <%= form.label :agree_to_terms,

--- a/app/components/works/agreement_component.rb
+++ b/app/components/works/agreement_component.rb
@@ -11,6 +11,10 @@ module Works
       form.object.agree_to_terms
     end
 
+    def date_last_agreed
+      form.object.date_last_agreed
+    end
+
     attr_reader :form
   end
 end

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -21,7 +21,6 @@ class DraftWorkForm < Reform::Form
   property :access, on: :work_version
   property :license, on: :work_version
   property :agree_to_terms, on: :work_version
-  property :date_last_agreed, on: :work_version
   property :created_type, virtual: true, prepopulator: (proc do |*|
     self.created_type = created_edtf.is_a?(EDTF::Interval) ? 'range' : 'single' unless created_type
   end)
@@ -158,6 +157,10 @@ class DraftWorkForm < Reform::Form
 
   def work
     model[:work]
+  end
+
+  def date_last_agreed
+    model[:work].depositor.last_work_terms_agreement
   end
 
   def description

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -42,6 +42,7 @@ class DraftWorkForm < Reform::Form
   validates :work_type, presence: true, work_type: true
 
   delegate :user_can_set_availability?, to: :collection
+  delegate :date_last_agreed, to: :work_version
 
   def deserialize!(params)
     # Choose between using the user provided citation and the auto-generated citation

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -21,6 +21,7 @@ class DraftWorkForm < Reform::Form
   property :access, on: :work_version
   property :license, on: :work_version
   property :agree_to_terms, on: :work_version
+  property :date_last_agreed, on: :work_version
   property :created_type, virtual: true, prepopulator: (proc do |*|
     self.created_type = created_edtf.is_a?(EDTF::Interval) ? 'range' : 'single' unless created_type
   end)
@@ -42,7 +43,6 @@ class DraftWorkForm < Reform::Form
   validates :work_type, presence: true, work_type: true
 
   delegate :user_can_set_availability?, to: :collection
-  delegate :date_last_agreed, to: :work_version
 
   def deserialize!(params)
     # Choose between using the user provided citation and the auto-generated citation

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -116,6 +116,11 @@ class WorkVersion < ApplicationRecord
     update!(citation: citation.gsub(LINK_TEXT, work.purl))
   end
 
+  # the date the user last agreed to the terms (could be nil)
+  def date_last_agreed
+    work.depositor.last_work_terms_agreement
+  end
+
   # the terms agreement checkbox value is not persisted in the database with the work and the value is instead:
   #  false if (a) never previously accepted or (b) not accepted in the last year; it is true otherwise
   def agree_to_terms


### PR DESCRIPTION
## Why was this change made? 🤔

Occasional HB issue occurring: https://app.honeybadger.io/projects/77112/faults/85235636

Speculation about activerecord caching inconsistencies 

Related to #2235

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


