### PR TITLE
check the depositor agreement directly instead of going through the form

### DIFF
--- a/app/components/works/agreement_component.html.erb
+++ b/app/components/works/agreement_component.html.erb
@@ -2,9 +2,7 @@
   <header>Terms of Deposit *</header>
   <div class="row">
     <div class="form-check col-auto">
-      <%# TODO: create a method for form.object.model.fetch(:work).depositor.last_work_terms_agreement
-      and/or determine why we have to check it separately to avoid potential nil error if embargo release date is invalid (e.g. June 31) %>
-      <% if agree_to_terms? && form.object.model.fetch(:work).depositor.last_work_terms_agreement %>
+      <% if agreed_to_terms_recently?  %>
         You agreed to the <%= link_to 'SDR Terms of Deposit', '#termsOfDepositModal', data: { bs_toggle: 'modal', bs_target: '#termsOfDepositModal'} %>
         <%= time_ago_in_words last_work_terms_agreement %> ago.
       <% else %>

--- a/app/components/works/agreement_component.rb
+++ b/app/components/works/agreement_component.rb
@@ -7,10 +7,6 @@ module Works
       @form = form
     end
 
-    def agree_to_terms?
-      work_form.agree_to_terms
-    end
-
     def work_form
       form.object
     end
@@ -20,7 +16,7 @@ module Works
     end
 
     delegate :depositor, to: :work
-    delegate :last_work_terms_agreement, to: :depositor
+    delegate :agreed_to_terms_recently?, :last_work_terms_agreement, to: :depositor
 
     attr_reader :form
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Based on work done in #2241 and #2242, this fixes the underlying cause of the bug identified in #2235.

Also 

Fixes #2243 (add a new test for this edge case)

The issue is that the `agree_to_terms` property on the work form was overloaded and could refer to the value of the existing HTML form checkbox as well as the custom derived property we were hoping to use (which did some lookup on the user in the database).  So in cases where the form was re-rendered with an error message and the value of the HTML checkbox was unchecked, the `agree_to_terms` property was returning a "0" instead of `false`, triggering our exception.  The fix is to just bypass the form property and delegate this check straight to the user model, which is what we were originally trying to do anyway.  This lets us avoid the extra check in the component view.

## How was this change tested? 🤨

Localhost browser and new test