### PR TITLE
fix collection version breadcrumb navigation

### DIFF
--- a/app/views/collection_versions/edit.html.erb
+++ b/app/views/collection_versions/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :breadcrumbs do %>
   <%= render BreadcrumbNavComponent.new(
-    breadcrumbs: [ { title: @form.model.name, link: collection_path(@form) },
+    breadcrumbs: [ { title: @form.model.name, link: collection_version_path(@form) },
                    { title: 'Edit', omit_title: true } ]) %>
 <% end %>
 <main class="mb-3 mb-md-5" id="content">


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2255 - breadcrumb nav for collection details is wrong (should go to collection_version controller and not collection controller)

Note: this bug may not be obvious in localhost, since if the collection and collection_version have the same ID, it will look like it is working just fine.


## How was this change tested? 🤨

Localhost browser