### PR TITLE
start with blank version description for new versions

### DIFF
--- a/app/controllers/collection_versions_controller.rb
+++ b/app/controllers/collection_versions_controller.rb
@@ -69,9 +69,9 @@ class CollectionVersionsController < ObjectsController
 
   # Create the next CollectionVersion for this Collection
   def create_new_version(previous_version)
-    previous_version.dup.tap do |work_version|
-      work_version.state = 'version_draft'
-      work_version.version = previous_version.version + 1
+    previous_version.dup.tap do |collection_version|
+      collection_version.state = 'version_draft'
+      collection_version.version = previous_version.version + 1
     end
   end
 

--- a/app/forms/draft_collection_version_form.rb
+++ b/app/forms/draft_collection_version_form.rb
@@ -6,7 +6,8 @@ class DraftCollectionVersionForm < Reform::Form
 
   property :name, on: :collection_version
   property :description, on: :collection_version
-  property :version_description, on: :collection_version
+  property :version_description, on: :collection_version,
+                                 prepopulator: ->(*) { self.version_description = '' if deposited? }
 
   collection :contact_emails, populator: ContactEmailsPopulator.new(:contact_emails, ContactEmail),
                               prepopulator: ->(*) { contact_emails << ContactEmail.new if contact_emails.blank? },
@@ -34,5 +35,5 @@ class DraftCollectionVersionForm < Reform::Form
   end
 
   # Required so that rails knows this is an update and uses the PATCH method for the form.
-  delegate :persisted?, to: :model
+  delegate :persisted?, :deposited?, to: :model
 end

--- a/spec/factories/collection_versions.rb
+++ b/spec/factories/collection_versions.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
     state { 'first_draft' }
     collection
 
+    trait :with_version_description do
+      version_description { 'really important changes' }
+    end
+
     factory :collection_version_with_collection do
       transient do
         depositors { [] }

--- a/spec/requests/edit_collection_version_spec.rb
+++ b/spec/requests/edit_collection_version_spec.rb
@@ -18,13 +18,28 @@ RSpec.describe 'Updating an existing collection version' do
       sign_in user
     end
 
-    describe 'show the form for an existing object' do
+    describe 'show the form for an existing object in first draft' do
       let(:collection_version) do
-        create(:collection_version_with_collection, :version_draft, :with_contact_emails, collection: collection)
+        create(:collection_version_with_collection, :version_draft, :with_contact_emails, :with_version_description,
+               collection: collection)
       end
 
-      it 'allows GETs to /collection_versions/{id}/edit' do
+      it 'allows GETs to /collection_versions/{id}/edit and shows saved version description' do
         get "/collection_versions/#{collection_version.id}/edit"
+        expect(response.body).to include('really important changes')
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe 'show the form for an existing already deposited object' do
+      let(:collection_version) do
+        create(:collection_version_with_collection, :with_contact_emails, :with_version_description,
+               collection: collection)
+      end
+
+      it 'allows GETs to /collection_versions/{id}/edit and shows blank version description' do
+        get "/collection_versions/#{collection_version.id}/edit"
+        expect(response.body).not_to include('really important changes')
         expect(response).to have_http_status(:ok)
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2256 - start from blank description for new collection versions

also, rename some variables to be more clear


## How was this change tested? 🤨

Localhost and added/updated tests