### PR TITLE
sanitize abstract

### DIFF
--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -460,7 +460,7 @@ RSpec.describe 'Create a new work' do
           {
             title: 'Test title',
             work_type: 'text',
-            abstract: 'test abstract',
+            abstract: "test abstract\u0000", # bad unicode character will be stripped
             authors_attributes: authors,
             contact_emails_attributes: contact_emails,
             attached_files_attributes: files,


### PR DESCRIPTION
## Why was this change made? 🤔

Potential suggestion to deal with https://app.honeybadger.io/projects/77112/faults/85827019, user pasted in text from a PDF into the abstract field, which breaks in postgres upon submission.  Seems like there should be a more uniform way of doing this.

## How was this change tested? 🤨

Localhost


