### PR TITLE
Change relationship declaration to contributor model to match author model

### DIFF
--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -6,7 +6,7 @@ class WorkVersion < ApplicationRecord
 
   belongs_to :work
   has_many :contributors, dependent: :destroy, class_name: 'Contributor'
-  has_many :authors, -> { order(weight: :asc) }, inverse_of: :work_version, dependent: :destroy, class_name: 'Author'
+  has_many :authors, -> { order(weight: :asc) }, dependent: :destroy, class_name: 'Author'
   before_destroy do
     # Unfortunately the STI relationships above, don't delete everything.
     # I first tried this approach, but it didn't work either


### PR DESCRIPTION
## Why was this change made? 🤔

~~Another attempt to fix https://github.com/sul-dlss/happy-heron/issues/2240 which causes https://app.honeybadger.io/projects/77112/faults/85307350 .... basically a contributor model being saved before the associated work version is saved, throwing a null violation constraint.~~

This change just makes the relationship declaration on both associated models match.  `inverse_of` should be inferred for authors as it is for contributors.

## How was this change tested? 🤨

Existing tests. 