### PR TITLE
Use the original work.created_at instead of the work_version.created_at

### DIFF
--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -65,7 +65,7 @@ module Works
     end
 
     def created_at
-      render LocalTimeComponent.new(datetime: work_version.created_at)
+      render LocalTimeComponent.new(datetime: work_version.work.created_at)
     end
 
     def updated_at


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2356 

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


