### PR TITLE
Require license at model level to match database constraint

### DIFF
--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -23,7 +23,7 @@ class WorkVersion < ApplicationRecord
   has_many :keywords, dependent: :destroy
 
   validates :state, presence: true
-  validates :license, inclusion: { in: License.license_list(include_displayable: true) }, allow_nil: true
+  validates :license, inclusion: { in: License.license_list(include_displayable: true) }
   validates :subtype, work_subtype: true
   validates :work_type, presence: true, work_type: true
 

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -174,8 +174,8 @@ RSpec.describe WorkVersion do
     context 'with a nil license' do
       let(:work_version) { build(:work_version, license: nil) }
 
-      it 'validates' do
-        expect(work_version).to be_valid
+      it 'does not validate' do
+        expect(work_version).not_to be_valid
       end
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

More investigation into #2240

Results:
- license is allowed to be nil on `work_version` in the rails validations (https://github.com/sul-dlss/happy-heron/blob/main/app/models/work_version.rb#L26), but we have a database constraint that prevents the model from being saved if nil (https://github.com/sul-dlss/happy-heron/blob/main/db/structure.sql#L578)
- while the last instance of the HB exception in #2240 does not appear to be because of a nil license, I was able to reproduce the exception on the rails console by trying to save a contributor associated with a draft work version that had a nil license
- it's unclear to me if a user is ever able to actually select a nil license, so I'm wondering why we allow this to be valid -- suggest we make the rails validation match the database constraint (as is done in this PR)

## How was this change tested? 🤨

Existing tests (had to update one), and localhost


