### PR TITLE
Embargo is considered released on today's date

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -43,7 +43,7 @@ class Work < ApplicationRecord
   end
 
   def already_embargo_released?
-    head&.deposited? && head.embargo_date.present? && head.embargo_date < Time.zone.today
+    head&.deposited? && head.embargo_date.present? && head.embargo_date <= Time.zone.today
   end
 
   delegate :name, to: :depositor, prefix: true

--- a/spec/components/works/embargo_component_spec.rb
+++ b/spec/components/works/embargo_component_spec.rb
@@ -84,6 +84,14 @@ RSpec.describe Works::EmbargoComponent do
     end
   end
 
+  context 'when the collection has been deposited and embargo date is today' do
+    let(:work_version) { build(:work_version, work: work, state: 'deposited', embargo_date: Time.zone.today) }
+
+    it 'renders the component' do
+      expect(rendered.to_html).to include 'This item has been released from embargo.'
+    end
+  end
+
   context 'when the collection has been deposited and embargo has not elapsed' do
     let(:collection) { build(:collection, :depositor_selects_access, release_option: 'depositor-selects') }
     let(:work_version) { build(:work_version, work: work, state: 'deposited', embargo_date: Time.zone.today + 1.month) }


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2366. Shows embargo as already released if the embargo date is today. 

## How was this change tested? 🤨
Unit

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


