### PR TITLE
Validate the contributors on the form not on the model

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,7 @@ Metrics/BlockLength:
     - config/routes.rb
   IgnoredMethods:
     - state_machine
+    - class_methods
 
 Metrics/ClassLength:
   Max: 150
@@ -36,7 +37,10 @@ Metrics/MethodLength:
   Max: 15
 
 Naming/PredicateName:
-  ForbiddenPrefixes: is_
+  NamePrefix:
+    - is_
+  ForbiddenPrefixes:
+    - is_
 
 RSpec/DescribeClass:
   Exclude:

--- a/app/forms/contributor_form.rb
+++ b/app/forms/contributor_form.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Provides nested contributor and author forms for works and drafts
+module ContributorForm
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def has_contributors(validate:)
+      has_generic_contributors(validate: validate)
+      has_authors(validate: validate)
+    end
+
+    def has_generic_contributors(validate:)
+      collection :contributors,
+                 populator: ContributorPopulator.new(:contributors, Contributor),
+                 prepopulator: ->(*) { contributors << Contributor.new if contributors.blank? },
+                 on: :work_version,
+                 &form_properties(validate: validate)
+    end
+
+    def has_authors(validate:)
+      collection :authors,
+                 populator: ContributorPopulator.new(:authors, Author),
+                 prepopulator: ->(*) { authors << Author.new if authors.blank? },
+                 on: :work_version,
+                 &form_properties(validate: validate)
+    end
+
+    # rubocop:disable Metrics/AbcSize
+    def form_properties(validate:)
+      lambda { |*_args|
+        property :id, type: Dry::Types['params.nil'] | Dry::Types['params.integer']
+        property :first_name
+        property :last_name
+        property :full_name
+        property :orcid
+        property :role_term
+        property :_destroy, virtual: true, type: Dry::Types['params.nil'] | Dry::Types['params.bool']
+        property :weight, type: Dry::Types['params.nil'] | Dry::Types['params.integer']
+
+        if validate
+          validates :first_name, presence: true, if: -> { role_term.start_with?('person') }
+          validates :last_name, presence: true, if: -> { role_term.start_with?('person') }
+          validates :full_name, presence: true, unless: -> { role_term.start_with?('person') }
+        end
+      }
+    end
+    # rubocop:enable Metrics/AbcSize
+  end
+end

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -7,6 +7,7 @@ class DraftWorkForm < Reform::Form
   feature Edtf
   feature EmbargoDate
   include Composition
+  include ContributorForm
   feature Coercion # Casts properties to a specific type
 
   property :work_type, on: :work_version
@@ -82,28 +83,7 @@ class DraftWorkForm < Reform::Form
     params['license'] = collection.required_license
   end
 
-  contributor = lambda { |*|
-    property :id, type: Dry::Types['params.nil'] | Dry::Types['params.integer']
-    property :first_name
-    property :last_name
-    property :full_name
-    property :orcid
-    property :role_term
-    property :_destroy, virtual: true, type: Dry::Types['params.nil'] | Dry::Types['params.bool']
-    property :weight, type: Dry::Types['params.nil'] | Dry::Types['params.integer']
-  }
-
-  collection :contributors,
-             populator: ContributorPopulator.new(:contributors, Contributor),
-             prepopulator: ->(*) { contributors << Contributor.new if contributors.blank? },
-             on: :work_version,
-             &contributor
-
-  collection :authors,
-             populator: ContributorPopulator.new(:authors, Author),
-             prepopulator: ->(*) { authors << Author.new if authors.blank? },
-             on: :work_version,
-             &contributor
+  has_contributors(validate: false)
 
   collection :attached_files,
              populator: AttachedFilesPopulator.new(:attached_files, AttachedFile),

--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -18,6 +18,8 @@ class WorkForm < DraftWorkForm
   validates :embargo_date, embargo_date: true, if: :availability_component_present?
   validates :agree_to_terms, presence: true
 
+  has_contributors(validate: true)
+
   # Copies form properties to the model. Called internally by reform prior to save.
   def sync(*)
     maybe_assign_doi

--- a/app/models/abstract_contributor.rb
+++ b/app/models/abstract_contributor.rb
@@ -54,10 +54,6 @@ class AbstractContributor < ApplicationRecord
 
   belongs_to :work_version
 
-  validates :first_name, presence: true, if: :person?
-  validates :last_name, presence: true, if: :person?
-  validates :full_name, presence: true, unless: :person?
-
   validates :contributor_type, presence: true, inclusion: { in: %w[person organization] }
 
   validates :orcid, format: { with: Orcid::REGEX }, allow_nil: true, if: :person?

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -231,6 +231,84 @@ RSpec.describe 'Create a new work' do
         end
       end
 
+      context 'when saving a draft that has an incomplete author' do
+        let(:collection) do
+          create(:collection, :depositor_selects_access, depositors: [user])
+        end
+        let(:params) do
+          {
+            'work' => {
+              'work_type' => 'text',
+              'title' => 'Test publication',
+              'contact_emails_attributes' => { '0' => {
+                'email' => 'foo@hotmail.com',
+                '_destroy' => ''
+              } },
+              'authors_attributes' => { '0' => {
+                'role_term' => 'person|Author',
+                'with_orcid' => 'false',
+                'first_name' => 'Camille ',
+                'last_name' => '',
+                'orcid' => '',
+                'full_name' => '',
+                '_destroy' => '',
+                'weight' => '0'
+              } },
+              'contributors_attributes' => { '0' => {
+                'role_term' => 'person|Author',
+                'with_orcid' => 'false',
+                'first_name' => '',
+                'last_name' => '',
+                'orcid' => '',
+                'full_name' => '',
+                '_destroy' => ''
+              } },
+              'published(1i)' => '',
+              'published(2i)' => '',
+              'published(3i)' => '',
+              'created_type' => 'single',
+              'created(1i)' => '',
+              'created(2i)' => '',
+              'created(3i)' => '',
+              'abstract' => '',
+              'keywords_attributes' => { '0' => {
+                'label' => '',
+                'uri' => '',
+                'cocina_type' => '',
+                '_destroy' => ''
+              } },
+              'default_citation' => 'true',
+              'citation' => '',
+              'citation_auto' => 'Zappa, F. (2020). Test publication yy/mm date in past. ' \
+                                 'Stanford Digital Repository. Available at :link:',
+              'related_works_attributes' => { '0' => {
+                'citation' => '',
+                '_destroy' => ''
+              } },
+              'related_links_attributes' => { '0' => {
+                'link_title' => '',
+                '_destroy' => '',
+                'url' => ''
+              } },
+              'license' => 'CC-BY-NC-4.0'
+            },
+            'commit' => 'Save as draft',
+            'controller' => 'works',
+            'action' => 'create',
+            'collection_id' => collection.id
+          }
+        end
+
+        before { create(:collection_version_with_collection, collection: collection) }
+
+        it 'saves the draft' do
+          post "/collections/#{collection.id}/works", params: params
+          expect(response).to have_http_status(:found)
+          work_version = Work.last.head
+          expect(work_version.authors.size).to eq 1
+        end
+      end
+
       context 'with a minimal set' do
         let(:collection) do
           create(:collection, :depositor_selects_access, depositors: [user])


### PR DESCRIPTION


## Why was this change made? 🤔

Because in a draft you should be allowed to save an incomplete contributor

Fixes #2385 



## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


