### PR TITLE
Switch from sprockets to propshaft

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
+gem 'rails', '~> 7.0.1'
+
 group :development, :test do
   gem 'byebug'
   gem 'factory_bot_rails'
@@ -61,7 +63,7 @@ gem 'jsbundling-rails', '~> 0.1.9'
 gem 'lograge', '~> 0.11.2'
 gem 'okcomputer'
 gem 'pg'
-gem 'rails', '~> 7.0.1'
+gem 'propshaft'
 gem 'redis', '~> 4.0'
 # TODO: Deal with this
 # pinned because 2.6.0 broke the build: [Reform] Your :populator did not return a Reform::Form instance for `authors`.
@@ -70,7 +72,6 @@ gem 'reform-rails', '~> 0.2.0'
 gem 'sdr-client', '~> 0.63'
 gem 'sidekiq', '~> 6.1'
 gem 'sneakers', '~> 2.11' # rabbitMQ background processing
-gem 'sprockets-rails'
 gem 'state_machines-activerecord'
 gem 'turbo-rails', '~> 1.0'
 gem 'view_component', '~> 2.56.2' # https://github.com/github/view_component/issues/1390

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,6 +317,11 @@ GEM
     patience_diff (1.2.0)
       optimist (~> 3.0)
     pg (1.4.2)
+    propshaft (0.6.4)
+      actionpack (>= 7.0.0)
+      activesupport (>= 7.0.0)
+      rack
+      railties (>= 7.0.0)
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -458,13 +463,6 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (4.1.1)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
-    sprockets-rails (3.4.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
-      sprockets (>= 3.0.0)
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -558,6 +556,7 @@ DEPENDENCIES
   multi_json
   okcomputer
   pg
+  propshaft
   puma (~> 5.6, >= 5.6.4)
   rails (~> 7.0.1)
   redis (~> 4.0)
@@ -576,7 +575,6 @@ DEPENDENCIES
   sneakers (~> 2.11)
   spring
   spring-watcher-listen (~> 2.0.0)
-  sprockets-rails
   state_machines-activerecord
   state_machines-graphviz
   super_diff

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,6 @@ require 'active_job/railtie'
 require 'active_record/railtie'
 require 'active_storage/engine'
 # require 'rails/test_unit/railtie'
-require 'sprockets/railtie'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION

## Why was this change made? 🤔

We don't need the transpiling capabilities of sprockets because we're using node based tools for that now. Propshaft is a much lighter dependency.

## How was this change tested? 🤨
deployed to qa

