### PR TITLE
Create a users.owner field that duplicates users.depositor

### DIFF
--- a/app/components/works/agreement_component.rb
+++ b/app/components/works/agreement_component.rb
@@ -15,8 +15,8 @@ module Works
       work_form.model.fetch(:work)
     end
 
-    delegate :depositor, to: :work
-    delegate :agreed_to_terms_recently?, :last_work_terms_agreement, to: :depositor
+    delegate :owner, to: :work
+    delegate :agreed_to_terms_recently?, :last_work_terms_agreement, to: :owner
 
     attr_reader :form
   end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -27,7 +27,7 @@ class DashboardsController < ApplicationController
       approvals: WorkVersion.awaiting_review_by(current_user),
       in_progress: WorkVersion.with_state(:first_draft, :version_draft, :rejected, :purl_reserved)
                      .joins(:work)
-                     .where('works.depositor' => current_user),
+                     .where('works.owner' => current_user),
       collection_managers_in_progress: CollectionVersion.with_state(:first_draft, :version_draft)
                                          .joins(:collection).left_outer_joins(collection: :managed_by)
                                          .where('managers.user_id' => current_user)

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -7,7 +7,7 @@ class ReservationsController < ObjectsController
   verify_authorized except: %i[delete_button edit_button]
 
   def create
-    work = Work.new(collection_id: params[:collection_id], depositor: current_user)
+    work = Work.new(collection_id: params[:collection_id], depositor: current_user, owner: current_user)
     work_version = WorkVersion.new(work: work)
 
     authorize! work_version

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -10,7 +10,7 @@ class WorksController < ObjectsController
   def new
     validate_work_types!
     collection = Collection.find(params[:collection_id])
-    work = Work.new(collection: collection, depositor: current_user)
+    work = Work.new(collection: collection, owner: current_user)
     work_version = WorkVersion.new(work_type: params[:work_type], subtype: params[:subtype], work: work)
     authorize! work_version
 
@@ -19,7 +19,7 @@ class WorksController < ObjectsController
   end
 
   def create
-    work = Work.new(collection_id: params[:collection_id], depositor: current_user)
+    work = Work.new(collection_id: params[:collection_id], depositor: current_user, owner: current_user)
     work_version = WorkVersion.new(work: work)
 
     authorize! work_version

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,10 +17,10 @@ class User < ApplicationRecord
             }
 
   has_many :notifications, dependent: :destroy
-  has_many :deposits, class_name: 'Work',
-                      foreign_key: 'depositor_id',
-                      inverse_of: :depositor,
-                      dependent: :destroy
+  has_many :owned_works, class_name: 'Work',
+                         foreign_key: 'owner_id',
+                         inverse_of: :owner,
+                         dependent: :destroy
 
   has_and_belongs_to_many :reviews_collections, class_name: 'Collection', join_table: 'reviewers'
   has_and_belongs_to_many :manages_collections, class_name: 'Collection', join_table: 'managers'

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -6,6 +6,8 @@ class Work < ApplicationRecord
 
   belongs_to :collection
   belongs_to :depositor, class_name: 'User'
+  # When created the owner is the depositor, but this can be changed so that someone else can manage the work.
+  belongs_to :owner, class_name: 'User'
   belongs_to :head, class_name: 'WorkVersion', optional: true
 
   has_many :events, as: :eventable, dependent: :destroy

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -133,16 +133,16 @@ class WorkVersion < ApplicationRecord
   # the terms agreement checkbox value is not persisted in the database with the work and the value is instead:
   #  false if (a) never previously accepted or (b) not accepted in the last year; it is true otherwise
   def agree_to_terms
-    work.depositor.agreed_to_terms_recently?
+    work.owner.agreed_to_terms_recently?
   end
 
   # the terms agreement checkbox value is not persisted in the database with the work but instead at the user level
   def agree_to_terms=(value)
-    return if value == false || value == '0' || work.depositor.agreed_to_terms_recently?
+    return if value == false || value == '0' || work.owner.agreed_to_terms_recently?
 
     # update the last time the terms of agreement was accepted for this depositor
     #  if it has not been accepted within the defined timeframe and the checkbox was checked
-    work.depositor.update(last_work_terms_agreement: Time.zone.now)
+    work.owner.update(last_work_terms_agreement: Time.zone.now)
   end
 
   # Ensure that EDTF dates get an EDTF serialization

--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -7,18 +7,18 @@ class WorkPolicy < ApplicationPolicy
   # Return the relation defining the collections you can view.
   scope_for :relation do |relation|
     relation.where(collection_id: user.manages_collection_ids + user.reviews_collection_ids).or(
-      relation.where(depositor: user)
+      relation.where(owner: user)
     )
   end
 
   def destroy?
-    (allowed_to?(:review?, collection) || depositor_of_the_work?) && record.persisted? && record.head.deleteable?
+    (allowed_to?(:review?, collection) || owner_of_the_work?) && record.persisted? && record.head.deleteable?
   end
 
   delegate :administrator?, to: :user_with_groups
   delegate :collection, to: :record
 
-  def depositor_of_the_work?
-    record.depositor == user
+  def owner_of_the_work?
+    record.owner == user
   end
 end

--- a/app/policies/work_version_policy.rb
+++ b/app/policies/work_version_policy.rb
@@ -9,7 +9,7 @@ class WorkVersionPolicy < ApplicationPolicy
     if administrator?
       scope
     else
-      scope.where(depositor: user)
+      scope.where(owner: user)
            .or(scope.where(collection_id: [user.manages_collection_ids + user.reviews_collection_ids]))
     end
   end
@@ -39,7 +39,7 @@ class WorkVersionPolicy < ApplicationPolicy
     return false unless record.updatable?
     return true if allowed_to?(:review?, collection)
 
-    depositor_of_the_work? && !record.pending_approval?
+    owner_of_the_work? && !record.pending_approval?
   end
 
   # Can show a work iff any one of the following is true:
@@ -48,7 +48,7 @@ class WorkVersionPolicy < ApplicationPolicy
   #   3. The user is a manager of the collection the work is in
   #   4. The user is a reviewer of the collection the work is in
   def show?
-    depositor_of_the_work? || allowed_to?(:review?, collection)
+    owner_of_the_work? || allowed_to?(:review?, collection)
   end
 
   # The collection reviewers can review a work
@@ -58,7 +58,7 @@ class WorkVersionPolicy < ApplicationPolicy
   end
 
   def destroy?
-    (allowed_to?(:review?, collection) || depositor_of_the_work?) && record.persisted? && record.draft?
+    (allowed_to?(:review?, collection) || owner_of_the_work?) && record.persisted? && record.draft?
   end
 
   private
@@ -69,7 +69,7 @@ class WorkVersionPolicy < ApplicationPolicy
     record.work.collection
   end
 
-  def depositor_of_the_work?
-    record.work.depositor == user
+  def owner_of_the_work?
+    record.work.owner == user
   end
 end

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -6,7 +6,7 @@
 
 <% cache [current_user, @work] do %>
   <style>
-    <% if current_user != @work.depositor %>
+    <% if current_user != @work.owner %>
       .visible-to-depositor {
         display: none;
       }

--- a/db/migrate/20220808221011_add_owner_to_works.rb
+++ b/db/migrate/20220808221011_add_owner_to_works.rb
@@ -1,0 +1,7 @@
+class AddOwnerToWorks < ActiveRecord::Migration[7.0]
+  def change
+    change_table(:works) do |t|
+      t.references :owner, foreign_key: { to_table: :users }
+    end
+  end
+end

--- a/db/migrate/20220808222722_populate_owner.rb
+++ b/db/migrate/20220808222722_populate_owner.rb
@@ -1,0 +1,6 @@
+class PopulateOwner < ActiveRecord::Migration[7.0]
+  def up
+    Work.update_all("owner_id = depositor_id")
+    change_column_null(:works, :owner_id, false)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -585,7 +585,8 @@ CREATE TABLE public.works (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     assign_doi boolean DEFAULT true NOT NULL,
-    doi character varying
+    doi character varying,
+    owner_id bigint NOT NULL
 );
 
 
@@ -1053,6 +1054,13 @@ CREATE INDEX index_works_on_head_id ON public.works USING btree (head_id);
 
 
 --
+-- Name: index_works_on_owner_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_works_on_owner_id ON public.works USING btree (owner_id);
+
+
+--
 -- Name: events fk_rails_0cb5590091; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1074,6 +1082,14 @@ ALTER TABLE ONLY public.related_works
 
 ALTER TABLE ONLY public.works
     ADD CONSTRAINT fk_rails_3aa29f8d19 FOREIGN KEY (head_id) REFERENCES public.work_versions(id);
+
+
+--
+-- Name: works fk_rails_6d81a5f2b3; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.works
+    ADD CONSTRAINT fk_rails_6d81a5f2b3 FOREIGN KEY (owner_id) REFERENCES public.users(id);
 
 
 --
@@ -1233,6 +1249,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210816133101'),
 ('20210827165420'),
 ('20220113144801'),
-('20220808145502');
+('20220808145502'),
+('20220808221011'),
+('20220808222722');
 
 

--- a/spec/components/dashboard/collection_component_spec.rb
+++ b/spec/components/dashboard/collection_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Dashboard::CollectionComponent, type: :component do
   let(:collection_version) { build_stubbed(:collection_version) }
   let(:user_with_groups) { UserWithGroups.new(user: user, groups: []) }
   let(:user) { create(:user) }
-  let(:work_path) { Rails.application.routes.url_helpers.work_path(user.deposits.first) }
+  let(:work_path) { Rails.application.routes.url_helpers.work_path(user.owned_works.first) }
 
   before do
     allow(controller).to receive_messages(
@@ -53,7 +53,7 @@ RSpec.describe Dashboard::CollectionComponent, type: :component do
     let(:collection_version) { create(:collection_version_with_collection) }
 
     before do
-      create(:work_version_with_work, collection: collection, depositor: user, title: 'my work')
+      create(:work_version_with_work, collection: collection, owner: user, title: 'my work')
       create(:work_version_with_work, collection: collection, title: 'not mine')
     end
 
@@ -80,7 +80,7 @@ RSpec.describe Dashboard::CollectionComponent, type: :component do
 
     before do
       4.times do
-        work = create(:work, collection: collection, depositor: user)
+        work = create(:work, collection: collection, owner: user)
         version = create(:work_version, work: work)
         work.update(head: version)
       end
@@ -98,7 +98,7 @@ RSpec.describe Dashboard::CollectionComponent, type: :component do
 
     before do
       5.times do
-        work = create(:work, collection: collection, depositor: user)
+        work = create(:work, collection: collection, owner: user)
         version = create(:work_version, work: work)
         work.update(head: version)
       end
@@ -112,7 +112,7 @@ RSpec.describe Dashboard::CollectionComponent, type: :component do
   context 'with a work that has a druid' do
     let(:collection) { collection_version.collection }
     let(:collection_version) { create(:collection_version_with_collection) }
-    let(:work) { create(:work, collection: collection, depositor: user, druid: 'druid:yq268qt4607') }
+    let(:work) { create(:work, collection: collection, owner: user, druid: 'druid:yq268qt4607') }
 
     before do
       version = create(:work_version, work: work)

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -25,9 +25,9 @@ FactoryBot.define do
       factory :work_version_with_work do
         transient do
           collection { nil }
-          depositor { association(:user) }
+          owner { association(:user) }
         end
-        work { association :work, collection: collection, depositor: depositor }
+        work { association :work, collection: collection, owner: owner }
 
         after(:create) do |work_version, _evaluator|
           work_version.work.update(head: work_version)

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :work do
     depositor { association(:user) }
+    owner { association(:user) }
     head { nil }
     created_at { Time.zone.parse('2007-02-10 15:30:45') }
     collection

--- a/spec/features/delete_draft_work_spec.rb
+++ b/spec/features/delete_draft_work_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 
 RSpec.describe 'Delete a draft work', js: true do
   let(:collection) { create(:collection, :with_depositors, depositor_count: 1) }
-  let(:work) { create(:work, collection: collection, depositor: user) }
+  let(:work) { create(:work, collection: collection, owner: user) }
   let(:work_version) { create(:work_version, title: 'Delete me', work: work) }
-  let(:work_pending_approval) { create(:work, collection: collection, depositor: user) }
+  let(:work_pending_approval) { create(:work, collection: collection, owner: user) }
   let(:work_version_pending_approval) do
     create(:work_version, :pending_approval, title: 'Pending Approval - Delete me', work: work_pending_approval)
   end
-  let(:work_rejected) { create(:work, collection: collection, depositor: user) }
+  let(:work_rejected) { create(:work, collection: collection, owner: user) }
   let(:work_version_rejected) { create(:work_version, :rejected, title: 'Rejected - Delete me', work: work_rejected) }
   let(:user) { collection.depositors.first }
 

--- a/spec/features/edit_draft_work_spec.rb
+++ b/spec/features/edit_draft_work_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Edit a draft work', js: true do
                                                                                     head: collection_version)
   end
   let(:collection_version) { create(:collection_version, :deposited) }
-  let(:work) { create(:work, depositor: depositor, collection: collection) }
+  let(:work) { create(:work, owner: depositor, collection: collection) }
 
   context 'when a user has previously accepted the terms of agreement less than 1 year ago' do
     before do

--- a/spec/features/mediated_deposit_versioning_spec.rb
+++ b/spec/features/mediated_deposit_versioning_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Edit a new version of a work in a collection using mediated depo
   # Work, WorkVersion, and Collection need to exist before user hits dashboard
   let!(:work_version) { create(:valid_deposited_work_version, work: work) }
   let(:work) do
-    create(:work, druid: 'druid:bc123df4567', depositor: depositor, collection: collection_version.collection)
+    create(:work, druid: 'druid:bc123df4567', owner: depositor, collection: collection_version.collection)
   end
 
   before do
@@ -40,6 +40,7 @@ RSpec.describe 'Edit a new version of a work in a collection using mediated depo
       click_link 'Return to dashboard'
       sleep(2)
       click_link new_work_title
+
       expect(page).to have_text 'Your deposit has been sent for approval.'
 
       # A work submitted for approval should not be editable.

--- a/spec/features/purl_reservation_spec.rb
+++ b/spec/features/purl_reservation_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'Reserve a PURL for a work in a deposited collection', js: true d
 
   describe 'setting the type for a reserved purl' do
     let!(:work_version) do
-      create(:work_version_with_work, :purl_reserved, collection: collection, depositor: user)
+      create(:work_version_with_work, :purl_reserved, collection: collection, owner: user)
     end
 
     it 'from the dashboard' do

--- a/spec/features/revert_work_to_previous_version_spec.rb
+++ b/spec/features/revert_work_to_previous_version_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Delete a draft work', js: true do
   let(:work) { create(:work, collection: collection) }
   let!(:version1) { create(:work_version, :deposited, version: 1, work: work) }
   let(:version2) { create(:work_version, :version_draft, version: 2, work: work) }
-  let(:user) { work.depositor }
+  let(:user) { work.owner }
 
   before do
     work.update(head: version2)

--- a/spec/policies/work_policy_spec.rb
+++ b/spec/policies/work_policy_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe WorkPolicy do
 
   describe_rule :destroy? do
     context 'when persisted and deletable' do
-      failed 'when user is not a depositor, reviewer or manager for the collection'
+      failed 'when user is not the owner, reviewer or manager for the collection'
 
       # `succeed` is `context` + `specify`, which checks
       # that the result of application wasn't successful
-      succeed 'when user is a depositor' do
-        before { record.depositor = user }
+      succeed 'when user is the owner' do
+        before { record.owner = user }
       end
 
       succeed 'when user is a collection manager' do
@@ -49,10 +49,10 @@ RSpec.describe WorkPolicy do
     context 'when deposited (and thus not deletable)' do
       before { work_version.state = 'deposited' }
 
-      failed 'when user is neither a depositor, reviewer or manager for the collection'
+      failed 'when user is neither the owner, reviewer or manager for the collection'
 
-      failed 'when user is a depositor' do
-        before { record.depositor = user }
+      failed 'when user is the owner' do
+        before { record.owner = user }
       end
 
       failed 'when user is a collection manager' do
@@ -71,10 +71,10 @@ RSpec.describe WorkPolicy do
     context 'when not persisted' do
       let(:work) { Work.new(attributes_for(:work).merge(collection: collection)) }
 
-      failed 'when user is not a depositor, reviewer or manager for the collection'
+      failed 'when user is not the owner, reviewer or manager for the collection'
 
-      failed 'when user is a depositor' do
-        before { record.depositor = user }
+      failed 'when user is the owner' do
+        before { record.owner = user }
       end
 
       failed 'when user is a collection manager' do

--- a/spec/policies/work_version_policy_spec.rb
+++ b/spec/policies/work_version_policy_spec.rb
@@ -45,20 +45,20 @@ RSpec.describe WorkVersionPolicy do
   end
 
   describe_rule :update? do
-    failed 'when user is not the depositor'
+    failed 'when user is not the owner'
 
-    succeed 'when user is the depositor and status is not pending_approval' do
-      let(:work) { build_stubbed :work, collection: collection, depositor: user }
+    succeed 'when user is the owner and status is not pending_approval' do
+      let(:work) { build_stubbed :work, collection: collection, owner: user }
       let(:record) { build_stubbed :work_version, work: work }
     end
 
-    failed 'when user is a depositor and status is pending_approval' do
-      let(:work) { build_stubbed :work, collection: collection, depositor: user }
+    failed 'when user is the owner and status is pending_approval' do
+      let(:work) { build_stubbed :work, collection: collection, owner: user }
       let(:record) { build_stubbed :work_version, :pending_approval, work: work }
     end
 
-    failed 'when user is a depositor and status is depositing' do
-      let(:work) { build_stubbed :work, collection: collection, depositor: user }
+    failed 'when user is the owner and status is depositing' do
+      let(:work) { build_stubbed :work, collection: collection, owner: user }
       let(:record) { build_stubbed :work_version, :depositing, work: work }
     end
 
@@ -102,10 +102,10 @@ RSpec.describe WorkVersionPolicy do
   end
 
   describe_rule :show? do
-    failed 'when user is not the depositor'
+    failed 'when user is not the owner'
 
-    succeed 'when user is the depositor' do
-      let(:work) { build_stubbed :work, depositor: user }
+    succeed 'when user is the owner' do
+      let(:work) { build_stubbed :work, owner: user }
       let(:record) { build_stubbed :work_version, work: work }
     end
 
@@ -155,12 +155,12 @@ RSpec.describe WorkVersionPolicy do
     context 'when persisted and version_draft' do
       before { record.state = 'version_draft' }
 
-      failed 'when user is not a depositor, reviewer or manager for the collection'
+      failed 'when user is not an owner, reviewer or manager for the collection'
 
       # `succeed` is `context` + `specify`, which checks
       # that the result of application wasn't successful
-      succeed 'when user is a depositor' do
-        let(:work) { build_stubbed :work, depositor: user }
+      succeed 'when user is an owner' do
+        let(:work) { build_stubbed :work, owner: user }
       end
 
       succeed 'when user is a collection manager' do
@@ -179,12 +179,12 @@ RSpec.describe WorkVersionPolicy do
     context 'when persisted and first_draft' do
       before { record.state = 'first_draft' }
 
-      failed 'when user is not a depositor, reviewer or manager for the collection'
+      failed 'when user is not an owner, reviewer or manager for the collection'
 
       # `succeed` is `context` + `specify`, which checks
       # that the result of application wasn't successful
-      succeed 'when user is a depositor' do
-        let(:work) { build_stubbed :work, depositor: user }
+      succeed 'when user is an owner' do
+        let(:work) { build_stubbed :work, owner: user }
       end
 
       succeed 'when user is a collection manager' do
@@ -203,10 +203,10 @@ RSpec.describe WorkVersionPolicy do
     context 'when deposited (and thus not deletable)' do
       before { record.state = 'deposited' }
 
-      failed 'when user is neither a depositor, reviewer or manager for the collection'
+      failed 'when user is neither the owner, reviewer or manager for the collection'
 
-      failed 'when user is a depositor' do
-        let(:work) { build_stubbed :work, depositor: user }
+      failed 'when user is the owner' do
+        let(:work) { build_stubbed :work, owner: user }
       end
 
       failed 'when user is a collection manager' do
@@ -225,10 +225,10 @@ RSpec.describe WorkVersionPolicy do
     context 'when not persisted' do
       let(:record) { WorkVersion.new(attributes_for(:work_version).merge(work: work)) }
 
-      failed 'when user is not a depositor, reviewer or manager for the collection'
+      failed 'when user is not the owner, reviewer or manager for the collection'
 
-      failed 'when user is a depositor' do
-        let(:work) { build_stubbed :work, depositor: user }
+      failed 'when user is the owner' do
+        let(:work) { build_stubbed :work, owner: user }
       end
 
       failed 'when user is a collection manager' do
@@ -256,9 +256,9 @@ RSpec.describe WorkVersionPolicy do
       it { is_expected.to be_empty }
     end
 
-    context 'when the user is the depositor' do
+    context 'when the user is the owner' do
       let(:user) { create(:user) }
-      let(:work) { create(:work, collection: collection, depositor: user) }
+      let(:work) { create(:work, collection: collection, owner: user) }
 
       it { is_expected.to include(work) }
     end

--- a/spec/requests/dashboard_collection_spec.rb
+++ b/spec/requests/dashboard_collection_spec.rb
@@ -8,17 +8,17 @@ RSpec.describe 'Dashboard collection requests' do
   context 'when user has in progress deposits in different states' do
     let(:user) { collection.depositors.first }
     let(:collection) { create(:collection, :with_depositors, depositor_count: 1) }
-    let(:work1) { create(:work, depositor: user, collection: collection) }
+    let(:work1) { create(:work, owner: user, collection: collection) }
     let(:work_version1) { create(:work_version, state: 'first_draft', title: 'I am a first draft', work: work1) }
-    let(:work2) { create(:work, depositor: user, collection: collection) }
+    let(:work2) { create(:work, owner: user, collection: collection) }
     let(:work_version2) { create(:work_version, state: 'version_draft', title: 'I am a version draft', work: work2) }
-    let(:work3) { create(:work, depositor: user, collection: collection) }
+    let(:work3) { create(:work, owner: user, collection: collection) }
     let(:work_version3) { create(:work_version, state: 'rejected', title: 'I am rejected', work: work3) }
-    let(:work4) { create(:work, depositor: user, collection: collection) }
+    let(:work4) { create(:work, owner: user, collection: collection) }
     let(:work_version4) { create(:work_version, state: 'deposited', title: 'I am deposited', work: work4) }
-    let(:work5) { create(:work, depositor: user, collection: collection) }
+    let(:work5) { create(:work, owner: user, collection: collection) }
     let(:work_version5) { create(:work_version, state: 'depositing', title: 'I am depositing', work: work5) }
-    let(:work6) { create(:work, depositor: user, collection: collection) }
+    let(:work6) { create(:work, owner: user, collection: collection) }
     let(:work_version6) do
       create(:work_version, state: 'pending_approval', title: 'I am a pending approval', work: work6)
     end

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Dashboard requests' do
   context 'when user has deposits' do
     let(:user) { collection.depositors.first }
     let(:collection) { create(:collection, :with_depositors, depositor_count: 1) }
-    let(:work1) { create(:work, depositor: user, collection: collection) }
+    let(:work1) { create(:work, owner: user, collection: collection) }
     let(:work_version1) { create(:work_version, title: 'Happy little title', work: work1) }
     let(:work_version2) { create(:work_version, title: 'Secret') }
 
@@ -31,7 +31,7 @@ RSpec.describe 'Dashboard requests' do
   context 'when user has a draft deposit with no title' do
     let(:user) { collection.depositors.first }
     let(:collection) { create(:collection, :with_depositors, depositor_count: 1) }
-    let(:work1) { create(:work, depositor: user, collection: collection) }
+    let(:work1) { create(:work, owner: user, collection: collection) }
     let(:work_version1) { create(:work_version, title: '', work: work1) }
     let(:work_version2) { create(:work_version, title: 'Secret') }
 
@@ -74,21 +74,21 @@ RSpec.describe 'Dashboard requests' do
   context 'when user has in progress deposits in different states' do
     let(:user) { collection.depositors.first }
     let(:collection) { create(:collection, :with_depositors, depositor_count: 1) }
-    let(:work1) { create(:work, depositor: user, collection: collection) }
+    let(:work1) { create(:work, owner: user, collection: collection) }
     let(:work_version1) { create(:work_version, state: 'first_draft', title: 'I am a first draft', work: work1) }
-    let(:work2) { create(:work, depositor: user, collection: collection) }
+    let(:work2) { create(:work, owner: user, collection: collection) }
     let(:work_version2) { create(:work_version, state: 'version_draft', title: 'I am a version draft', work: work2) }
-    let(:work3) { create(:work, depositor: user, collection: collection) }
+    let(:work3) { create(:work, owner: user, collection: collection) }
     let(:work_version3) { create(:work_version, state: 'rejected', title: 'I am rejected', work: work3) }
-    let(:work4) { create(:work, depositor: user, collection: collection) }
+    let(:work4) { create(:work, owner: user, collection: collection) }
     let(:work_version4) { create(:work_version, state: 'deposited', title: 'I am deposited', work: work4) }
-    let(:work5) { create(:work, depositor: user, collection: collection) }
+    let(:work5) { create(:work, owner: user, collection: collection) }
     let(:work_version5) { create(:work_version, state: 'depositing', title: 'I am depositing', work: work5) }
-    let(:work6) { create(:work, depositor: user, collection: collection) }
+    let(:work6) { create(:work, owner: user, collection: collection) }
     let(:work_version6) do
       create(:work_version, state: 'pending_approval', title: 'I am a pending approval', work: work6)
     end
-    let(:work7) { create(:work, depositor: user, collection: collection) }
+    let(:work7) { create(:work, owner: user, collection: collection) }
     let(:work_version7) { create(:work_version, state: 'purl_reserved', title: 'I am reserved purl', work: work6) }
 
     before do
@@ -131,17 +131,17 @@ RSpec.describe 'Dashboard requests' do
   context 'when user is an application admin' do
     let(:workful_collection) { create(:collection, creator: user) }
     let(:workless_collection) { create(:collection, creator: user) }
-    let(:work1) { create(:work, depositor: user, collection: workful_collection) }
+    let(:work1) { create(:work, owner: user, collection: workful_collection) }
     let(:work_version1) { create(:work_version, state: 'deposited', work: work1) }
-    let(:work2) { create(:work, depositor: user, collection: workful_collection) }
+    let(:work2) { create(:work, owner: user, collection: workful_collection) }
     let(:work_version2) { create(:work_version, state: 'first_draft', work: work2) }
-    let(:work3) { create(:work, depositor: user, collection: workful_collection) }
+    let(:work3) { create(:work, owner: user, collection: workful_collection) }
     let(:work_version3) { create(:work_version, state: 'version_draft', work: work3) }
-    let(:work4) { create(:work, depositor: user, collection: workful_collection) }
+    let(:work4) { create(:work, owner: user, collection: workful_collection) }
     let(:work_version4) { create(:work_version, state: 'pending_approval', work: work4) }
-    let(:work5) { create(:work, depositor: user, collection: workful_collection) }
+    let(:work5) { create(:work, owner: user, collection: workful_collection) }
     let(:work_version5) { create(:work_version, state: 'rejected', work: work5) }
-    let(:work6) { create(:work, depositor: user, collection: workful_collection) }
+    let(:work6) { create(:work, owner: user, collection: workful_collection) }
     let(:work_version6) { create(:work_version, state: 'purl_reserved', work: work6) }
 
     before do
@@ -193,7 +193,7 @@ RSpec.describe 'Dashboard requests' do
   context 'when user is a depositor in a collection without reviewers' do
     let(:collection) { create(:collection, :with_depositors) }
     let(:user) { collection.depositors.first }
-    let(:work) { create(:work, depositor: user) }
+    let(:work) { create(:work, owner: user) }
 
     before do
       create(:collection_version_with_collection, collection: collection)
@@ -214,11 +214,11 @@ RSpec.describe 'Dashboard requests' do
     let(:collection) { create(:collection, :with_reviewers, :with_depositors) }
     let(:user) { collection.depositors.first }
 
-    let(:work1) { create(:work, depositor: user, collection: collection) }
+    let(:work1) { create(:work, owner: user, collection: collection) }
     let(:work_version1) { create(:work_version, :pending_approval, title: 'To Review', work: work1) }
-    let(:work2) { create(:work, depositor: user, collection: collection) }
+    let(:work2) { create(:work, owner: user, collection: collection) }
     let(:work_version2) { create(:work_version, :first_draft, title: 'No Review', work: work2) }
-    let(:work3) { create(:work, depositor: user, collection: collection) }
+    let(:work3) { create(:work, owner: user, collection: collection) }
     let(:work_version3) { create(:work_version, :rejected, title: 'Rejected Upon Review', work: work3) }
 
     before do

--- a/spec/requests/delete_work_version_spec.rb
+++ b/spec/requests/delete_work_version_spec.rb
@@ -6,14 +6,13 @@ RSpec.describe 'Deleting a version' do
   let(:work) { head_work_version.work }
   let(:head_work_version) { create(:work_version, state: :version_draft, version: head_version) }
   let(:head_version) { 1 }
+  let(:user) { work.owner }
 
   before do
     work.update(head: head_work_version)
   end
 
   context 'when first version' do
-    let(:user) { work.depositor }
-
     before do
       sign_in user, groups: ['dlss:hydrus-app-collection-creators']
     end
@@ -27,7 +26,6 @@ RSpec.describe 'Deleting a version' do
   end
 
   context 'when a subsequent version' do
-    let(:user) { work.depositor }
     let(:head_version) { 2 }
     let!(:first_version) { create(:work_version, version: 1, work: work) }
 

--- a/spec/requests/edit_work_spec.rb
+++ b/spec/requests/edit_work_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Updating an existing work' do
   end
 
   context 'with an authenticated user' do
-    let(:user) { work.depositor }
+    let(:user) { work.owner }
 
     before do
       sign_in user, groups: ['dlss:hydrus-app-collection-creators']
@@ -34,7 +34,6 @@ RSpec.describe 'Updating an existing work' do
         let(:collection) { create(:collection_version_with_collection).collection }
         let(:work) { create(:work, collection: collection) }
         let(:work_version) { create(:work_version, :deposited, :with_required_associations, work: work) }
-        let(:user) { work.depositor }
         let(:work_params) do
           {
             title: 'New title',
@@ -145,7 +144,6 @@ RSpec.describe 'Updating an existing work' do
         let(:collection) { create(:collection_version_with_collection).collection }
         let(:work) { create(:work, collection: collection) }
         let(:work_version) { create(:work_version, work: work) }
-        let(:user) { work.depositor }
         let(:work_params) do
           {
             title: '',

--- a/spec/requests/purl_reservation_spec.rb
+++ b/spec/requests/purl_reservation_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Reserve a PURL and flesh it out into a work (version)' do
     end
 
     describe 'choose a type for the reserved PURL' do
-      let(:work) { create(:work, depositor: user, collection: collection) }
+      let(:work) { create(:work, owner: user, collection: collection) }
 
       # have to set this here (?), artifact of the circular relationship between works and work_versions
       before { work.update(head: work_version) }

--- a/spec/requests/show_work_spec.rb
+++ b/spec/requests/show_work_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Show a work detail' do
   end
 
   context 'with an authorized user' do
-    let(:user) { work.depositor }
+    let(:user) { work.owner }
 
     before do
       sign_in user

--- a/spec/requests/zips_request_spec.rb
+++ b/spec/requests/zips_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Download a zip file of all attached files', type: :request do
   let(:rendered) { render_inline(described_class.new(work_version: work_version)) }
   let(:work_version) { create(:work_version, work: work) }
   let(:user) { create(:user) }
-  let(:work) { create(:work, depositor: user) }
+  let(:work) { create(:work, owner: user) }
   let(:work_id) { work.id }
 
   context 'with unauthenticated user' do

--- a/spec/validators/work_type_validator_spec.rb
+++ b/spec/validators/work_type_validator_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe WorkTypeValidator do
-  let(:work) { Work.new(depositor: build_stubbed(:user)) }
+  let(:work) { Work.new(owner: build_stubbed(:user)) }
   let(:record) { WorkForm.new(work: work, work_version: WorkVersion.new(work: work)) }
   let(:validator) { described_class.new({ attributes: ['stub'] }) }
 


### PR DESCRIPTION

## Why was this change made? 🤔
This will allow the owner of the object to be set to someone other than the depositor.
Fixes #2383



## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


