### PR TITLE
Default years to the max value

### DIFF
--- a/app/components/works/dates_component.html.erb
+++ b/app/components/works/dates_component.html.erb
@@ -26,7 +26,11 @@
         <div class="year">
           <label for="<%= prefix %>_created_year" class="visually-hidden">Created year</label>
           <%= number_field_tag "#{prefix}[created(1i)]", created_year,
-              data: { date_validation_target: 'year', action: 'date-validation#change' },
+              data: {
+                date_validation_target: 'year',
+                action: 'date-validation#change year-field#change',
+                controller: 'year-field'
+              },
               id: "#{prefix}_created_year",
               placeholder: 'year',
               class: "form-control", min: min_year, max: max_year %>

--- a/app/components/works/dates_component.rb
+++ b/app/components/works/dates_component.rb
@@ -17,7 +17,8 @@ module Works
                          date_validation_target: 'year',
                          date_range_target: 'startYear',
                          action: 'date-range#change clear->date-validation#clearValidations ' \
-                                 'validate->date-validation#validate'
+                                 'validate->date-validation#validate year-field#change',
+                         controller: 'year-field'
                        },
                        id: 'work_created_range_start_year',
                        placeholder: 'year',
@@ -30,7 +31,8 @@ module Works
                          date_validation_target: 'year',
                          date_range_target: 'endYear',
                          action: 'date-range#change clear->date-validation#clearValidations ' \
-                                 'validate->date-validation#validate'
+                                 'validate->date-validation#validate year-field#change',
+                         controller: 'year-field'
                        },
                        id: 'work_created_range_end_year',
                        placeholder: 'year',

--- a/app/components/works/publication_date_component.rb
+++ b/app/components/works/publication_date_component.rb
@@ -56,7 +56,8 @@ module Works
       number_field_tag "#{prefix}[published(1i)]", published_year,
                        data: {
                          date_validation_target: 'year',
-                         action: 'date-validation#change'
+                         action: 'date-validation#change year-field#change',
+                         controller: 'year-field'
                        },
                        id: "#{prefix}_published_year",
                        placeholder: 'year',

--- a/app/javascript/controllers/year_field_controller.js
+++ b/app/javascript/controllers/year_field_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+//   static targets = ["year", "month", "day", "error"]
+
+  connect() {
+    this.hasChanged = false
+  }
+
+  // On the first change, if they press the arrow keys or arrow buttons (on the page),
+  // Then default it to the max value.  The default behavior is to default to the minimum value.
+  change(evt) {
+    if (this.hasChanged)
+        return // nothing to do
+
+    if (evt.inputType === "insertReplacementText") // So that typing in digits doesn't do this, only arrow keys or the arrow buttons
+    evt.target.value = evt.target.max
+    this.hasChanged = true
+  }
+}


### PR DESCRIPTION


## Why was this change made? 🤔

When the up button is first pressed, set the value to the max value of the field rather than the minimum (default).

Fixes #2357

## How was this change tested? 🤨
Tested locally.
