### PR TITLE
Adds sign out to flaky features/mediated_deposit_versioning_spec.

### DIFF
--- a/spec/features/mediated_deposit_versioning_spec.rb
+++ b/spec/features/mediated_deposit_versioning_spec.rb
@@ -45,6 +45,9 @@ RSpec.describe 'Edit a new version of a work in a collection using mediated depo
 
       # A work submitted for approval should not be editable.
       expect(page).not_to have_css("a[aria-label='Edit #{new_work_title}']", wait: 0)
+      sign_out
+      # To address flakiness. Without sleep, sometimes the following are performed by the depositor, not the reviewer.
+      sleep(1)
 
       # Now acting as the collection reviewer
       sign_in reviewer


### PR DESCRIPTION
refs #2384

## Why was this change made? 🤔
Flaky bad.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


