### PR TITLE
Persist the publiblished date

### DIFF
--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -50,7 +50,7 @@ class WorkVersion < ApplicationRecord
 
     after_transition WorkObserver.method(:after_transition)
     after_transition on: :begin_deposit do |work_version, transition|
-      work_version.published_at = DateTime.now.utc
+      work_version.update_attribute(:published_at, DateTime.now.utc) # rubocop:disable Rails/SkipsModelValidations
       WorkObserver.after_begin_deposit(work_version, transition)
     end
     after_transition on: :reserve_purl, do: WorkObserver.method(:after_begin_reserve)

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -308,7 +308,7 @@ RSpec.describe WorkVersion do
           .to('depositing')
           .and change(Event, :count).by(1)
         expect(DepositJob).to have_received(:perform_later).with(work_version)
-        expect(work_version.published_at).to be_kind_of ActiveSupport::TimeWithZone
+        expect(work_version.reload.published_at).to be_kind_of ActiveSupport::TimeWithZone
       end
 
       context 'with pending_approval on a work' do


### PR DESCRIPTION


## Why was this change made? 🤔

Upon testing it was revealed that the publish date was not persisted

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


