### PR TITLE
Adds deposit date into cocina description.

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -11,7 +11,7 @@ class Work < ApplicationRecord
   belongs_to :head, class_name: 'WorkVersion', optional: true
 
   has_many :events, as: :eventable, dependent: :destroy
-  has_many :work_versions, dependent: :destroy
+  has_many :work_versions, -> { order version: :asc }, dependent: :destroy, inverse_of: 'work'
 
   def broadcast_update
     broadcast_replace_to self

--- a/app/services/cocina_generator/description/date_generator.rb
+++ b/app/services/cocina_generator/description/date_generator.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module CocinaGenerator
+  module Description
+    # Generator for Cocina dates encoded as EDTF
+    class DateGenerator
+      # @param [EDTF::*|ActiveSupport::TimeWithZone] date
+      # @param [type] type for date
+      # @param [boolean] primary - whether status is primary
+      # @return [Hash] the props for the date
+      def self.generate(date:, type: nil, primary: false)
+        new(date: date, type: type, primary: primary).generate
+      end
+
+      def initialize(date:, type:, primary:)
+        @date = date
+        @type = type
+        @primary = primary
+      end
+
+      def generate
+        {
+          encoding: { code: 'edtf' },
+          type: type,
+          status: primary ? 'primary' : nil
+        }.compact.merge(date_props)
+      end
+
+      private
+
+      attr_reader :date, :type, :primary
+
+      def date_props
+        case @date
+        when EDTF::Interval
+          interval_props(date)
+        when ActiveSupport::TimeWithZone
+          time_with_zone_props(date)
+        else
+          edtf_date_props(date)
+        end
+      end
+
+      def interval_props(interval_date)
+        {
+          structuredValue: interval_structured_values(interval_date)
+        }.tap do |props|
+          if interval_date.from&.uncertain? || interval_date.to&.uncertain?
+            props[:qualifier] = 'approximate'
+            props[:structuredValue].each { |struct_date_val| struct_date_val.delete(:qualifier) }
+          end
+        end.compact
+      end
+
+      def interval_structured_values(interval_date)
+        [].tap do |structured_values|
+          structured_values << edtf_date_props(interval_date.from, type: 'start') if interval_date.from
+          structured_values << edtf_date_props(interval_date.to, type: 'end') if interval_date.to
+        end
+      end
+
+      def edtf_date_props(edtf_date, type: nil)
+        {
+          qualifier: edtf_date.uncertain? ? 'approximate' : nil,
+          value: edtf_date.edtf.chomp('?'),
+          type: type
+        }.compact
+      end
+
+      def time_with_zone_props(zone_date)
+        {
+          value: zone_date.strftime('%Y-%m-%d')
+        }
+      end
+    end
+  end
+end

--- a/app/services/cocina_generator/description/events_generator.rb
+++ b/app/services/cocina_generator/description/events_generator.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module CocinaGenerator
+  module Description
+    # This generates Events for a work
+    class EventsGenerator
+      def self.generate(work_version:)
+        new(work_version: work_version).generate
+      end
+
+      def initialize(work_version:)
+        @work_version = work_version
+      end
+
+      def generate
+        events = deposit_events + Array(created_date_event)
+        events += publisher_events.presence || Array(published_date_event)
+        events
+      end
+
+      private
+
+      attr_reader :work_version
+
+      def publisher_events
+        @publisher_events ||= ContributorsGenerator.events_from_publisher_contributors(work_version: work_version,
+                                                                                       pub_date: published_date_event)
+      end
+
+      def published_date_event
+        event_for_date(date: work_version.published_edtf, event_type: 'publication', date_type: 'publication',
+                       primary: true)
+      end
+
+      def created_date_event
+        event_for_date(date: work_version.created_edtf, event_type: 'creation', date_type: 'creation')
+      end
+
+      def deposit_events
+        return [] if deposit_versions.blank?
+
+        Array(deposit_publication_event) + deposit_modification_events
+      end
+
+      def deposit_publication_event
+        event_for_work_version(work_version: deposit_publication_version, event_type: 'deposit',
+                               date_type: 'publication')
+      end
+
+      def deposit_modification_events
+        deposit_modification_versions.map do |deposit_version|
+          event_for_work_version(work_version: deposit_version, event_type: 'deposit', date_type: 'modification')
+        end
+      end
+
+      def deposit_versions
+        # Treating this version as a deposit version
+        @deposit_versions ||= work_version.work.work_versions.filter do |check_work_version|
+          check_work_version.deposited? || check_work_version == work_version
+        end
+      end
+
+      def deposit_publication_version
+        deposit_versions.first
+      end
+
+      def deposit_modification_versions
+        deposit_versions.slice(1..-1)
+      end
+
+      def event_for_date(date:, event_type:, date_type:, primary: false)
+        return unless date
+
+        Cocina::Models::Event.new({
+                                    type: event_type,
+                                    date: [DateGenerator.generate(date: date, type: date_type, primary: primary)]
+                                  })
+      end
+
+      def event_for_work_version(work_version:, event_type:, date_type:)
+        date = work_version.published_at || work_version.updated_at
+        event_for_date(date: date, event_type: event_type, date_type: date_type)
+      end
+    end
+  end
+end

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     access { 'world' }
     state { 'first_draft' }
     description { 'initial version' }
+    published_at { Time.zone.parse('2019-01-01') }
     work
 
     factory :valid_work_version do
@@ -158,5 +159,17 @@ FactoryBot.define do
     citation { nil }
     license { 'none' }
     state { 'reserving_purl' }
+  end
+
+  trait :with_work do
+    transient do
+      collection { nil }
+      owner { association(:user) }
+    end
+    work { association :work, collection: collection, owner: owner, work_versions: [instance] }
+
+    after(:create) do |work_version, _evaluator|
+      work_version.work.update(head: work_version)
+    end
   end
 end

--- a/spec/services/cocina_generator/description/events_generator_spec.rb
+++ b/spec/services/cocina_generator/description/events_generator_spec.rb
@@ -1,0 +1,403 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CocinaGenerator::Description::EventsGenerator do
+  subject(:events) { normalize_events(described_class.generate(work_version: work_version)) }
+
+  let(:publisher_roles) do
+    [
+      {
+        value: 'publisher',
+        code: 'pbl',
+        uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+        source: {
+          code: 'marcrelator',
+          uri: 'http://id.loc.gov/vocabulary/relators/'
+        }
+      }
+    ]
+  end
+  let(:deposit_publication_event) do
+    {
+      type: 'deposit',
+      date: [
+        {
+          type: 'publication',
+          value: '2019-01-01',
+          encoding: { code: 'edtf' }
+        }
+      ]
+    }
+  end
+
+  context 'without published date' do
+    let(:work_version) do
+      build(:work_version, :with_work)
+    end
+
+    it 'created a deposit publication event' do
+      expect(events).to eq(normalize_events([
+                                              deposit_publication_event
+                                            ]))
+    end
+  end
+
+  context 'when work has multiple versions' do
+    let(:work) do
+      build(:work)
+    end
+    let(:work_version2) do
+      build(:valid_deposited_work_version, published_at: Time.zone.parse('2017-01-01'), work: work)
+    end
+    let!(:work_version3) do
+      build(:valid_deposited_work_version, published_at: Time.zone.parse('2018-01-01'), work: work)
+    end
+    let(:work_version) do
+      build(:valid_deposited_work_version, work: work)
+    end
+
+    before do
+      work.work_versions = [work_version2, work_version3, work_version]
+      work.head = work_version
+    end
+
+    it 'created a deposit publication event and deposit modification events' do
+      expect(events).to eq(normalize_events([
+                                              {
+                                                type: 'deposit',
+                                                date: [
+                                                  {
+                                                    type: 'publication',
+                                                    value: '2017-01-01',
+                                                    encoding: { code: 'edtf' }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                type: 'deposit',
+                                                date: [
+                                                  {
+                                                    type: 'modification',
+                                                    value: '2018-01-01',
+                                                    encoding: { code: 'edtf' }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                type: 'deposit',
+                                                date: [
+                                                  {
+                                                    type: 'modification',
+                                                    value: '2019-01-01',
+                                                    encoding: { code: 'edtf' }
+                                                  }
+                                                ]
+                                              }
+                                            ]))
+    end
+  end
+
+  # see https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_contributor.txt
+  #   example 12
+  context 'when publisher and publication date are entered by user' do
+    let(:contributor) { build(:org_contributor, role: 'Publisher') }
+    let(:work_version) do
+      build(:work_version, :with_work, :published, :with_contact_emails,
+            contributors: [contributor],
+            title: 'Test title')
+    end
+
+    it 'creates event of type publication with date' do
+      expect(events).to eq(normalize_events([
+                                              deposit_publication_event,
+                                              {
+                                                type: 'publication',
+                                                contributor: [
+                                                  {
+                                                    name: [{ value: contributor.full_name }],
+                                                    role: publisher_roles,
+                                                    type: 'organization'
+                                                  }
+                                                ],
+                                                date: [
+                                                  {
+                                                    encoding: { code: 'edtf' },
+                                                    value: '2020-02-14',
+                                                    type: 'publication',
+                                                    status: 'primary'
+                                                  }
+                                                ]
+                                              }
+                                            ]))
+    end
+  end
+
+  # see https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_contributor.txt
+  #   example 13
+  #   Note:  no top level contributor -- publisher is under event
+  context 'when publisher entered by user, no publication date' do
+    let(:contributor) { build(:org_contributor, role: 'Publisher') }
+    let(:work_version) do
+      build(:work_version, :with_work, :with_contact_emails,
+            contributors: [contributor], title: 'Test title')
+    end
+
+    it 'creates event of type publication without date' do
+      expect(events).to eq(normalize_events([
+                                              deposit_publication_event,
+                                              {
+                                                type: 'publication',
+                                                contributor: [
+                                                  {
+                                                    name: [{ value: contributor.full_name }],
+                                                    role: publisher_roles,
+                                                    type: 'organization'
+                                                  }
+                                                ]
+                                              }
+                                            ]))
+    end
+  end
+
+  context 'when author, publisher and publication date are entered by user' do
+    let(:person_author) { build(:person_author, role: 'Author') }
+    let(:pub_contrib) { build(:org_contributor, role: 'Publisher') }
+    let(:work_version) do
+      build(:work_version, :with_work, :published, :with_contact_emails,
+            authors: [person_author],
+            contributors: [pub_contrib], title: 'Test title')
+    end
+
+    it 'creates event of type publication with date' do
+      expect(events).to eq(normalize_events(
+                             [
+                               deposit_publication_event,
+                               {
+                                 type: 'publication',
+                                 contributor: [
+                                   {
+                                     name: [{ value: pub_contrib.full_name }],
+                                     role: publisher_roles,
+                                     type: 'organization'
+                                   }
+                                 ],
+                                 date: [
+                                   {
+                                     encoding: { code: 'edtf' },
+                                     value: '2020-02-14',
+                                     type: 'publication',
+                                     status: 'primary'
+                                   }
+                                 ]
+                               }
+                             ]
+                           ))
+    end
+  end
+
+  context 'when publication date of year only' do
+    let(:work_version) do
+      build(:work_version, :with_work, :published_with_year_only)
+    end
+
+    it 'creates event of type publication with year only date' do
+      expect(events).to eq(
+        normalize_events([
+                           deposit_publication_event,
+                           {
+                             type: 'publication',
+                             date: [
+                               {
+                                 encoding: { code: 'edtf' },
+                                 value: '2021',
+                                 type: 'publication',
+                                 status: 'primary'
+                               }
+                             ]
+                           }
+                         ])
+      )
+    end
+  end
+
+  context 'when publication date of year and month only' do
+    let(:work_version) do
+      build(:work_version, :with_work, :published_with_year_month_only)
+    end
+
+    it 'creates event of type publication with year and month only date' do
+      expect(events).to eq(normalize_events(
+                             [
+                               deposit_publication_event,
+                               {
+                                 type: 'publication',
+                                 date: [
+                                   {
+                                     encoding: { code: 'edtf' },
+                                     value: '2021-04',
+                                     type: 'publication',
+                                     status: 'primary'
+                                   }
+                                 ]
+                               }
+                             ]
+                           ))
+    end
+  end
+
+  context 'when creation date of year only' do
+    let(:work_version) do
+      build(:work_version, :with_work, :with_creation_date_year_only)
+    end
+
+    it 'creates event of type creation with year only date' do
+      expect(events).to eq(normalize_events(
+                             [
+                               deposit_publication_event,
+                               {
+                                 type: 'creation',
+                                 date: [
+                                   {
+                                     encoding: { code: 'edtf' },
+                                     value: '2020',
+                                     type: 'creation'
+                                   }
+                                 ]
+                               }
+                             ]
+                           ))
+    end
+  end
+
+  context 'when creation date of year and month only' do
+    let(:work_version) do
+      build(:work_version, :with_work, :with_creation_date_year_month_only)
+    end
+
+    it 'creates event of type creation with year and month only date' do
+      expect(events).to eq(normalize_events(
+                             [
+                               deposit_publication_event,
+                               {
+                                 type: 'creation',
+                                 date: [
+                                   {
+                                     encoding: { code: 'edtf' },
+                                     value: '2020-06',
+                                     type: 'creation'
+                                   }
+                                 ]
+                               }
+                             ]
+                           ))
+    end
+  end
+
+  context 'when approximate creation date' do
+    let(:work_version) do
+      build(:work_version, :with_work, :with_approximate_creation_date)
+    end
+
+    it 'creates event of type creation with approximate date' do
+      expect(events).to eq(normalize_events(
+                             [
+                               deposit_publication_event,
+                               {
+                                 type: 'creation',
+                                 date: [
+                                   {
+                                     encoding: { code: 'edtf' },
+                                     value: '2020-03-08',
+                                     type: 'creation',
+                                     qualifier: 'approximate'
+                                   }
+                                 ]
+                               }
+                             ]
+                           ))
+    end
+  end
+
+  context 'when approximate creation date of year only' do
+    let(:work_version) do
+      build(:work_version, :with_work, :with_approximate_creation_date_year_only)
+    end
+
+    it 'creates event of type creation with approximate year only date' do
+      expect(events).to eq(normalize_events(
+                             [
+                               deposit_publication_event,
+                               {
+                                 type: 'creation',
+                                 date: [
+                                   {
+                                     encoding: { code: 'edtf' },
+                                     value: '2020',
+                                     type: 'creation',
+                                     qualifier: 'approximate'
+                                   }
+                                 ]
+                               }
+                             ]
+                           ))
+    end
+  end
+
+  context 'when approximate creation date of year and month only date' do
+    let(:work_version) do
+      build(:work_version, :with_work, :with_approximate_creation_date_year_month_only)
+    end
+
+    it 'creates event of type creation with approximate year and month only date' do
+      expect(events).to eq(normalize_events(
+                             [
+                               deposit_publication_event,
+                               {
+                                 type: 'creation',
+                                 date: [
+                                   {
+                                     encoding: { code: 'edtf' },
+                                     value: '2020-06',
+                                     type: 'creation',
+                                     qualifier: 'approximate'
+                                   }
+                                 ]
+                               }
+                             ]
+                           ))
+    end
+  end
+
+  context 'when approximate creation date range' do
+    let(:work_version) do
+      build(:work_version, :with_work, :with_approximate_creation_date_range)
+    end
+
+    it 'creates event of type creation with approximate date' do
+      expect(events).to eq(normalize_events(
+                             [
+                               deposit_publication_event,
+                               {
+                                 type: 'creation',
+                                 date: [
+                                   {
+                                     encoding: { code: 'edtf' },
+                                     structuredValue: [
+                                       { value: '2020-03-04', type: 'start' },
+                                       { value: '2020-10-31', type: 'end' }
+                                     ],
+                                     qualifier: 'approximate',
+                                     type: 'creation'
+                                   }
+                                 ]
+                               }
+                             ]
+                           ))
+    end
+  end
+end
+
+def normalize_events(events)
+  events.map { |event| Cocina::Models::Event.new(event).to_h }
+end

--- a/spec/services/cocina_generator/dro_generator_spec.rb
+++ b/spec/services/cocina_generator/dro_generator_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe CocinaGenerator::DROGenerator do
             {
               value: '2007-02-10',
               encoding: {
-                code: 'w3cdtf'
+                code: 'edtf'
               }
             }
           ]


### PR DESCRIPTION
closes #2368

## Why was this change made? 🤔
So that item has complete descriptive metadata.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit
