### PR TITLE
add structure for getting admin dashboard breadcrumb nav

### DIFF
--- a/app/components/breadcrumb_nav_component.rb
+++ b/app/components/breadcrumb_nav_component.rb
@@ -2,8 +2,9 @@
 
 # Displays the top bread crumb navigation
 class BreadcrumbNavComponent < ApplicationComponent
-  def initialize(breadcrumbs: [])
+  def initialize(breadcrumbs: [], admin: false)
     @orig_breadcrumbs = breadcrumbs
+    @admin = admin
   end
 
   def full_title(breadcrumb)
@@ -26,10 +27,12 @@ class BreadcrumbNavComponent < ApplicationComponent
   end
 
   def breadcrumbs
-    [{ title: 'Dashboard', link: '/dashboard' }] + orig_breadcrumbs
+    dashboard = [{ title: 'Dashboard', link: '/dashboard' }]
+    dashboard << { title: 'Admin Dashboard', link: '/admin' } if admin
+    dashboard + orig_breadcrumbs
   end
 
   private
 
-  attr_accessor :orig_breadcrumbs
+  attr_accessor :orig_breadcrumbs, :admin
 end

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -1,3 +1,6 @@
+<% content_for :breadcrumbs do %>
+  <%= render BreadcrumbNavComponent.new(admin: true)%>
+<% end %>
 <main id="content">
   <div class="container" id="dashboard">
     <h1>Admin dashboard</h1>

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -21,6 +21,8 @@ CREATE TYPE public.work_access AS ENUM (
 
 SET default_tablespace = '';
 
+SET default_table_access_method = heap;
+
 --
 -- Name: abstract_contributors; Type: TABLE; Schema: public; Owner: -
 --


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2327 - setup component to easily add breadcrumbs to admin functions

For future admin views, just need to add something like this (same as the rest of the app).  The new `admin: true` param will add the `Admin Dashboard` link to the breadcrumbs.

```
<% content_for :breadcrumbs do %>
  <%= render BreadcrumbNavComponent.new(admin: true,
    breadcrumbs: [ { title: 'Some admin function', link: '/link_desired' } ]) %>
<% end %>
```

## How was this change tested? 🤨

Localhost

