### PR TITLE
Provides version description when updating deposit.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem 'redis', '~> 4.0'
 # pinned because 2.6.0 broke the build: [Reform] Your :populator did not return a Reform::Form instance for `authors`.
 gem 'reform', '~> 2.5.0'
 gem 'reform-rails', '~> 0.2.0'
-gem 'sdr-client', '~> 0.63'
+gem 'sdr-client', '~> 0.91'
 gem 'sidekiq', '~> 6.1'
 gem 'sneakers', '~> 2.11' # rabbitMQ background processing
 gem 'state_machines-activerecord'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,7 +430,7 @@ GEM
     ruby-next-core (0.15.2)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    sdr-client (0.90.0)
+    sdr-client (0.91.0)
       activesupport
       cocina-models (~> 0.83.0)
       dry-monads
@@ -568,7 +568,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
-  sdr-client (~> 0.63)
+  sdr-client (~> 0.91)
   sidekiq (~> 6.1)
   simplecov
   sneakers (~> 2.11)

--- a/app/jobs/deposit_job.rb
+++ b/app/jobs/deposit_job.rb
@@ -22,7 +22,7 @@ class DepositJob < BaseDepositJob
     when Cocina::Models::RequestDRO
       create(new_request_dro, work_version)
     when Cocina::Models::DRO
-      update(new_request_dro)
+      update(new_request_dro, work_version)
     end
   end
   # rubocop:enable Metrics/AbcSize:
@@ -47,10 +47,11 @@ class DepositJob < BaseDepositJob
                                            connection: connection)
   end
 
-  def update(new_request_dro)
+  def update(new_request_dro, work_version)
     SdrClient::Deposit::UpdateResource.run(metadata: new_request_dro,
                                            logger: Rails.logger,
-                                           connection: connection)
+                                           connection: connection,
+                                           version_description: work_version.description.presence)
   end
 
   def upload_responses(blobs)


### PR DESCRIPTION
closes #2090

## Why was this change made? 🤔
More helpful than SDR API default version description.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit