### PR TITLE
Displays owner on item detail page.

### DIFF
--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -53,6 +53,12 @@
         <th class="col-3" scope="row">Depositor</th>
         <td><%= depositor %></td>
       </tr>
+      <% if show_owner? %>
+        <tr>
+          <th class="col-3" scope="row">Owner</th>
+          <td><%= owner %></td>
+        </tr>
+      <% end %>
       <tr>
         <th class="col-3" scope="row">Version details</th>
         <td><%= version %></td>

--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -44,6 +44,14 @@ module Works
       "#{work.depositor.sunetid} (#{work.depositor.name})"
     end
 
+    def owner
+      "#{work.owner.sunetid} (#{work.owner.name})"
+    end
+
+    def show_owner?
+      work.owner != work.depositor
+    end
+
     def collection_name
       collection.head.name
     end

--- a/spec/requests/show_work_spec.rb
+++ b/spec/requests/show_work_spec.rb
@@ -48,6 +48,9 @@ RSpec.describe 'Show a work detail' do
     it 'displays the work' do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include work_version.title
+      # Owner is different than depositor, so displayed.
+      # Matching on "Owner" but not "Ownership".
+      expect(response.body).to match(/Owner(?!ship)/)
     end
 
     context 'when the work has a blank title' do
@@ -56,6 +59,17 @@ RSpec.describe 'Show a work detail' do
       it 'displays a default title for a work when it is blank' do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include 'No title'
+      end
+    end
+
+    context 'when work opener is same as depositor' do
+      let(:user) { create(:user) }
+
+      let(:work) { create(:work, collection: collection, owner: user, depositor: user) }
+
+      it 'does not display the owner' do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to match(/Owner(?!ship)/)
       end
     end
   end


### PR DESCRIPTION
closes #2314

## Why was this change made? 🤔
Part of adding support for an owner being a different role than depositor.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit
