### PR TITLE
add breadcrumb nav to admin search for user

### DIFF
--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,3 +1,6 @@
+<% content_for :breadcrumbs do %>
+  <%= render BreadcrumbNavComponent.new(admin: true, breadcrumbs: [ { title: 'Search for user' } ])%>
+<% end %>
 <main id="content">
   <div class="container" id="dashboard">
     <h1>Search for user</h1>


### PR DESCRIPTION
## Why was this change made? 🤔

Missing the breadcrumb nav on one of the new admin pages.  Added (see below)

![Screen Shot 2022-08-17 at 1 45 59 PM](https://user-images.githubusercontent.com/47137/185239778-d3133c88-1df9-42f0-86fb-ea5de23241ca.png)


## How was this change tested? 🤨

Localhost


