### PR TITLE
email admin list when a new collection is started

### DIFF
--- a/app/mailers/first_draft_collections_mailer.rb
+++ b/app/mailers/first_draft_collections_mailer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Sends email notifications about first_draft_collections
+class FirstDraftCollectionsMailer < ApplicationMailer
+  ADMIN_LIST = 'h2-administrators@lists.stanford.edu'
+  NEW_COLLECTION_SUBJECT = 'A new collection has been created'
+
+  def first_draft_created
+    @collection_version = params[:collection_version]
+    @creator = @collection_version.collection.creator
+
+    mail(to: ADMIN_LIST, subject: NEW_COLLECTION_SUBJECT)
+  end
+end

--- a/app/models/collection_version.rb
+++ b/app/models/collection_version.rb
@@ -40,6 +40,13 @@ class CollectionVersion < ApplicationRecord
       DepositCollectionJob.perform_later(collection_version)
     end
 
+    after_transition new: :first_draft do |collection_version|
+      if Settings.notify_admin_list
+        FirstDraftCollectionsMailer.with(collection_version: collection_version)
+                                   .first_draft_created.deliver_later
+      end
+    end
+
     event :begin_deposit do
       transition %i[first_draft version_draft] => :depositing
     end

--- a/app/views/first_draft_collections_mailer/first_draft_created.html.erb
+++ b/app/views/first_draft_collections_mailer/first_draft_created.html.erb
@@ -1,0 +1,8 @@
+<p>Dear Administrator,</p>
+
+<p>The following new collection has been created in H2:</p>
+
+<p><%= link_to @collection_version.name, collection_url(@collection_version.collection_id) %><br/>
+Created by <%= @creator.first_name %></p>
+
+<p>The Stanford Digital Repository Team</p>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -74,3 +74,6 @@ access:
 
 datacite:
   prefix: '10.80343'
+
+# set to true in prod to send email to 'h2-administrators@lists.stanford.edu' when, e.g., a new collection is started
+notify_admin_list: false

--- a/spec/mailers/first_draft_collections_mailer_spec.rb
+++ b/spec/mailers/first_draft_collections_mailer_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FirstDraftCollectionsMailer, type: :mailer do
+  let(:creator) { build_stubbed(:user, name: 'Peter Lorre', first_name: 'Snaaaaakes') }
+  let(:collection) { build_stubbed(:collection, creator: creator) }
+  let(:collection_version) { build_stubbed(:collection_version, collection: collection) }
+  let(:collection_name) { collection_version.name }
+
+  describe '#first_draft_created' do
+    let(:mail) do
+      described_class.with(collection_version: collection_version).first_draft_created
+    end
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq 'A new collection has been created'
+      expect(mail.to).to eq [described_class::ADMIN_LIST]
+      expect(mail.from).to eq ['no-reply@sdr.stanford.edu']
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to match 'Dear Administrator,'
+      expect(mail.body.encoded).to match 'The following new collection has been created in H2:'
+      expect(mail.body.encoded).to match "collections/#{collection_version.collection_id}\">#{collection_name}</a>"
+    end
+
+    it 'body uses creator.first_name' do
+      expect(mail.body.encoded).to match "Created by #{creator.first_name}"
+      expect(mail.body.encoded).not_to match "Created by #{creator.name}"
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

~~PROBLEM:  email is always set to `h2-administrators@lists.stanford.edu` for all environments.  Does this need to be a shared_configs setting?  And if so ... what is an email we can use that will not be spamful for anyone, including ops?~~

I added a setting, defaulting to false, to turn on these emails.  PR https://github.com/sul-dlss/shared_configs/pull/1834 turns it on in prod (and is harmless otherwise).

Fixes #2326

## How was this change tested? 🤨

locally.

From rails log:

```
17:16:59 web.1  | [ActiveJob] [ActionMailer::MailDeliveryJob] [5b9bde01-f055-45e6-a842-5c5a2f9d7a56] FirstDraftCollectionsMailer#first_draft_created: processed outbound mail in 256.2ms
17:16:59 web.1  | [ActiveJob] [ActionMailer::MailDeliveryJob] [5b9bde01-f055-45e6-a842-5c5a2f9d7a56] Delivered mail 62fd84fb4d01b_de209150284d0@li-dl-7477-7cf5.local.mail (20.0ms)
17:16:59 web.1  | [ActiveJob] [ActionMailer::MailDeliveryJob] [5b9bde01-f055-45e6-a842-5c5a2f9d7a56] Date: Wed, 17 Aug 2022 17:16:59 -0700
17:16:59 web.1  | From: no-reply@sdr.stanford.edu
17:16:59 web.1  | To: h2-administrators@lists.stanford.edu
17:16:59 web.1  | Message-ID: <62fd84fb4d01b_de209150284d0@li-dl-7477-7cf5.local.mail>
17:16:59 web.1  | Subject: A new collection has been created
17:16:59 web.1  | Mime-Version: 1.0
17:16:59 web.1  | Content-Type: text/html;
17:16:59 web.1  |  charset=UTF-8
17:16:59 web.1  | Content-Transfer-Encoding: 7bit
17:16:59 web.1  | 
17:16:59 web.1  | <!DOCTYPE html>
17:16:59 web.1  | <html>
17:16:59 web.1  |   <head>
17:16:59 web.1  |     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
17:16:59 web.1  |     <style>
17:16:59 web.1  |       /* Email styles need to be inline */
17:16:59 web.1  |       .red {
17:16:59 web.1  |         background-color: #8c1515;
17:16:59 web.1  |       }
17:16:59 web.1  |       .sul-logo {
17:16:59 web.1  |         margin: .5rem 1rem .2rem .5rem;
17:16:59 web.1  |       }
17:16:59 web.1  |       .sdr-logo {
17:16:59 web.1  |         margin-top: 1rem;
17:16:59 web.1  |       }
17:16:59 web.1  |       main {
17:16:59 web.1  |         margin-left: 1rem;
17:16:59 web.1  |       }
17:16:59 web.1  |     </style>
17:16:59 web.1  |   </head>
17:16:59 web.1  | 
17:16:59 web.1  |   <body>
17:16:59 web.1  |     <div class="red"><img height="32" class="sul-logo" alt="Stanford Libraries" src="/assets/StanfordLibraries-logo-whitetext-c444ff2cb8b5b5b3e48cb4108f08f02cb8090d83.png" /></div>
17:16:59 web.1  |     <main>
17:16:59 web.1  |       <div class="sdr-logo"><img height="32" alt="Stanford Digital Repository" src="/assets/sdr_color_logo-1fb808ba1c1c1c66fd2d15d171ad02881cff44f0.png" /></div>
17:16:59 web.1  |       <p>Dear Administrator,</p>
17:16:59 web.1  | 
17:16:59 web.1  | <p>The following new collection has been created in H2:</p>
17:16:59 web.1  | 
17:16:59 web.1  | <p><a href="http://localhost:3000/collections/1">asdf</a><br/>
17:16:59 web.1  | Created by </p>
17:16:59 web.1  | 
17:16:59 web.1  | <p>The Stanford Digital Repository Team</p>
17:16:59 web.1  | 
17:16:59 web.1  |     </main>
17:16:59 web.1  |   </body>
17:16:59 web.1  | </html>
17:16:59 web.1  | 
17:16:59 web.1  | [ActiveJob] [ActionMailer::MailDeliveryJob] [5b9bde01-f055-45e6-a842-5c5a2f9d7a56] Performed ActionMailer::MailDeliveryJob (Job ID: 5b9bde01-f055-45e6-a842-5c5a2f9d7a56) from Async(default) in 490.94ms
```


⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


