### PR TITLE
changes around sunet validation and entry on collection edit form

### DIFF
--- a/app/components/collections/settings_component.html.erb
+++ b/app/components/collections/settings_component.html.erb
@@ -72,7 +72,7 @@
   <section id="participants">
     <header>Collection participants *</header>
     <div class="mb-3 row">
-      <p class="col-sm-12">Enter SUNet IDs of participants. Separate each one with a comma and a space. (e.g. janelath, lelandst)</p>
+      <p class="col-sm-12">Select the appropriate option below to add a manager or depositor. Enter one participant SUNet ID per box and then click "Add" to save the entry.</p>
     </div>
 
     <%= render Collections::Update::ManagersComponent.new(form: form) %>

--- a/app/components/collections/update/depositors_component.html.erb
+++ b/app/components/collections/update/depositors_component.html.erb
@@ -17,18 +17,18 @@
 
       <div data-collection-participant-form-target="control" style="position: relative">
         <input aria-label="lookup SunetID" class="form-control" style="width:40%"
-          data-action="collection-participant-form#search"
+          data-action="input->collection-participant-form#search keypress->collection-participant-form#preventEnter blur->collection-participant-form#clear"
           data-collection-participant-form-target="lookup">
         <div data-collection-participant-form-target="result" class="participant-overlay">
           <div data-collection-participant-form-target="resultOne">
             <div class="mb-2"><strong>Search results for "<span data-collection-participant-form-target="queryValue"></span>"</strong></div>
 
-            <span data-collection-participant-form-target="resultName"></span>
+            <span data-collection-participant-form-target="resultName"></span> -
             <span data-collection-participant-form-target="resultDescription"></span>
             <%= button_tag 'Add', type: 'button', class: "btn btn-outline-primary", data: { action: "collection-participant-form#addAssociation" } %>
           </div>
           <div data-collection-participant-form-target="resultNone">
-            <strong>No search results found for "<span data-collection-participant-form-target="queryValue"></span>"</strong>
+            <strong>No search results found for "<span data-collection-participant-form-target="queryValue"></span>" - enter an exact SUNetID only and try again</strong>
           </div>
         </div>
       </div>

--- a/app/components/collections/update/managers_component.html.erb
+++ b/app/components/collections/update/managers_component.html.erb
@@ -19,18 +19,18 @@
 
       <div data-collection-participant-form-target="control" style="position: relative">
         <input aria-label="lookup SunetID" class="form-control" style="width:40%"
-          data-action="collection-participant-form#search"
+          data-action="input->collection-participant-form#search keypress->collection-participant-form#preventEnter blur->collection-participant-form#clear"
           data-collection-participant-form-target="lookup">
         <div data-collection-participant-form-target="result" class="participant-overlay">
           <div data-collection-participant-form-target="resultOne">
             <div class="mb-2"><strong>Search results for "<span data-collection-participant-form-target="queryValue"></span>"</strong></div>
 
-            <span data-collection-participant-form-target="resultName"></span>
+            <span data-collection-participant-form-target="resultName"></span> -
             <span data-collection-participant-form-target="resultDescription"></span>
             <%= button_tag 'Add', type: 'button', class: "btn btn-outline-primary", data: { action: "collection-participant-form#addAssociation" } %>
           </div>
           <div data-collection-participant-form-target="resultNone">
-            <strong>No search results found for "<span data-collection-participant-form-target="queryValue"></span>"</strong>
+            <strong>No search results found for "<span data-collection-participant-form-target="queryValue"></span>" - enter an exact SUNetID only and try again</strong>
           </div>
         </div>
       </div>

--- a/app/components/collections/update/reviewers_component.html.erb
+++ b/app/components/collections/update/reviewers_component.html.erb
@@ -1,5 +1,4 @@
-<p>Enter SUNet IDs of reviewers.</p>
-
+<p>Enter one reviewer SUNet ID per box and then click "Add" to save the entry.</p>
 
 <fieldset>
   <legend class="participant-type" style="font-size: 1rem; width: 5rem; float: left">Additional Reviewers</legend>
@@ -22,6 +21,7 @@
 
       <div data-collection-participant-form-target="control" style="position: relative">
         <input aria-label="lookup SunetID" class="form-control" style="width:40%"
+          data-action="input->collection-participant-form#search keypress->collection-participant-form#preventEnter blur->collection-participant-form#clear"
           data-action="collection-participant-form#search"
           data-collection-participant-form-target="lookup"
           data-review-workflow-target="reviewers">
@@ -29,12 +29,12 @@
           <div data-collection-participant-form-target="resultOne">
             <div class="mb-2"><strong>Search results for "<span data-collection-participant-form-target="queryValue"></span>"</strong></div>
 
-            <span data-collection-participant-form-target="resultName"></span>
+            <span data-collection-participant-form-target="resultName"></span> -
             <span data-collection-participant-form-target="resultDescription"></span>
             <%= button_tag 'Add', type: 'button', class: "btn btn-outline-primary", data: { action: "collection-participant-form#addAssociation" } %>
           </div>
           <div data-collection-participant-form-target="resultNone">
-            <strong>No search results found for "<span data-collection-participant-form-target="queryValue"></span>"</strong>
+            <strong>No search results found for "<span data-collection-participant-form-target="queryValue"></span>" - enter an exact SUNetID only and try again</strong>
           </div>
         </div>
       </div>

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -15,7 +15,7 @@ class AccountsController < ApplicationController
   # Does a lookup from the account service in production mode, otherwise returns a stub value
   def lookup
     return AccountService.new.fetch(params[:id]) if Rails.env.production?
-    return {} if params[:id].size < 6
+    return {} unless params[:id].start_with?('jcoyne85')
 
     {
       'name' => 'Coyne, Justin Michael',

--- a/app/javascript/controllers/collection_participant_form_controller.js
+++ b/app/javascript/controllers/collection_participant_form_controller.js
@@ -12,7 +12,7 @@ export default class extends Controller {
 
   addAssociation(event) {
     if(event) event.preventDefault()
-    const sunetid = this.lookupTarget.value
+    const sunetid = this.sunet
     const name = this.resultNameTarget.innerHTML
     const elemtn =  this.buildNewRowFromTemplate(sunetid, name)
     this.controlTarget.insertAdjacentElement('beforebegin', elemtn)
@@ -60,14 +60,17 @@ export default class extends Controller {
     this.lookupTarget.value = ''
   }
 
-
   search(e) {
-    if(e.target.value === '') {
+    // only execute a search if the user has entered at least 3 characters that doesn't start with a number
+    if(e.target.value.length < 3 || /^\d/.test(e.target.value)) {
       this.resultTarget.hidden = true
       return
     }
 
     this.resultTarget.hidden = false
+
+    // remove non-letters/numbers, and truncate after 8 characters
+    e.target.value = e.target.value.replace(/[^a-zA-Z0-9]/g, '').substring(0,8)
     fetch('/accounts/' + e.target.value)
       .then(response => response.json())
       .then(data => {
@@ -78,10 +81,19 @@ export default class extends Controller {
       })
   }
 
+  clear(e) {
+    this.sunet = e.target.value
+    if (!this.hasResults) { this.closeLookup() }
+  }
+
+  preventEnter(e) {
+    if (e.keyCode == 13) { e.preventDefault() }
+  }
   noResults(query) {
     this.resultOneTarget.hidden = true
     this.resultNoneTarget.hidden = false
     this.queryValueTargets.forEach(target => target.innerHTML = query)
+    this.hasResults = false
   }
 
   showResult(query, data) {
@@ -90,5 +102,6 @@ export default class extends Controller {
     this.queryValueTargets.forEach(target => target.innerHTML = query)
     this.resultNameTarget.innerHTML = data.name
     this.resultDescriptionTarget.innerHTML = data.description
+    this.hasResults = true
   }
 }

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Accounts', type: :request do
       end
 
       it 'displays the data' do
-        get '/accounts/fred12345'
+        get '/accounts/jcoyne85'
         expect(response).to have_http_status(:ok)
         expect(response.body).to eq '{"name":"Coyne, Justin Michael",' \
                                     '"description":"Digital Library Systems and Services, ' \


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2278 and fixes #2279

Changes:

- Updated instruction text above entry form
- Updated message shown when no results are found
- Clear sunet entry text box when focus is lost (unless there is a found search result)
- Hide search result modal when focus is lost (unless there is a found search result)
- Prevent return from being pressed in text box (stops form from being prematurely saved if the user has not clicked the "Add" button)
- Stop user from entering text that does not look like a sunet (must be between 3-8 characters, no special characters, doesn't start with a number)
- Double check that values are not saved unless you click the "Add" button first

New error message when results not found:

![Screen Shot 2022-08-18 at 10 31 00 AM](https://user-images.githubusercontent.com/47137/185461356-e96b575b-5c3e-4d0f-87d7-1fae900d09d9.png)



## How was this change tested? 🤨

Localhost


