### PR TITLE
Ensure that Chrome also defaults years to the max value

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,8 @@ end
 group :test do
   gem 'capybara', '~> 3.34'
   gem 'capybara-screenshot'
-  gem 'cuprite'
+  gem 'selenium-webdriver' # for js testing
+  gem 'webdrivers' # installs the chrome for selenium tests
 end
 
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,9 +149,6 @@ GEM
     crass (1.0.6)
     cssbundling-rails (0.2.8)
       railties (>= 6.0.0)
-    cuprite (0.14.3)
-      capybara (~> 3.0)
-      ferrum (~> 0.13.0)
     cypress-on-rails (1.14.0)
       rack
     cypress-rails (0.6.0)
@@ -246,11 +243,6 @@ GEM
     faraday-net_http (3.0.2)
     faraday-retry (2.2.0)
       faraday (~> 2.0)
-    ferrum (0.13)
-      addressable (~> 2.5)
-      concurrent-ruby (~> 1.1)
-      webrick (~> 1.7)
-      websocket-driver (>= 0.6, < 0.8)
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -473,6 +465,10 @@ GEM
       dry-monads
       faraday (>= 0.16)
       launchy
+    selenium-webdriver (4.10.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     serverengine (2.1.1)
       sigdump (~> 0.2.2)
     set (1.0.3)
@@ -538,11 +534,15 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (5.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -577,7 +577,6 @@ DEPENDENCIES
   capybara-screenshot
   config (~> 2.2)
   cssbundling-rails (~> 0.2.4)
-  cuprite
   cypress-on-rails (~> 1.0)
   cypress-rails
   devise (~> 4.7)
@@ -616,6 +615,7 @@ DEPENDENCIES
   rubocop-rspec
   rubyzip (~> 2.3)
   sdr-client (~> 2.0)
+  selenium-webdriver
   sidekiq (~> 7.0)
   simplecov
   sneakers (~> 2.11)
@@ -627,6 +627,7 @@ DEPENDENCIES
   turbo-rails (~> 1.0)
   view_component (~> 2.56.2)
   web-console (>= 3.3.0)
+  webdrivers
   webmock
   whenever
   zipline (~> 1.4)

--- a/app/javascript/controllers/year_field_controller.js
+++ b/app/javascript/controllers/year_field_controller.js
@@ -12,8 +12,10 @@ export default class extends Controller {
     if (this.hasChanged)
         return // nothing to do
 
-    if (evt.inputType === "insertReplacementText") // So that typing in digits doesn't do this, only arrow keys or the arrow buttons
-    evt.target.value = evt.target.max
+    // Be careful refactoring this because Firefox and Chrome send different event types when doing arrow buttons
+    // We prevent this behavior when typing or pasting, we only want it for arrow keys or the arrow buttons
+    if (evt.inputType !== "insertText" && evt.inputType !== "insertFromPaste")
+      evt.target.value = evt.target.max
     this.hasChanged = true
   }
 }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,7 +44,8 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(allow_localhost: true,
+                             allow: ['https://chromedriver.storage.googleapis.com'])
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -7,7 +7,7 @@ Capybara.javascript_driver = :headless_chrome
 
 Capybara.register_driver :headless_chrome do |app|
   Capybara::Selenium::Driver.load_selenium
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+  browser_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
     opts.args << '--headless'
     opts.args << '--disable-gpu'
     # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,12 +1,21 @@
 # frozen_string_literal: true
 
-require 'capybara/cuprite'
 require 'capybara/rails'
 require 'capybara/rspec'
 
-Capybara.javascript_driver = :cuprite
-Capybara.register_driver(:cuprite) do |app|
-  Capybara::Cuprite::Driver.new(app, window_size: [1200, 800], pending_connection_errors: false)
+Capybara.javascript_driver = :headless_chrome
+
+Capybara.register_driver :headless_chrome do |app|
+  Capybara::Selenium::Driver.load_selenium
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+    opts.args << '--headless'
+    opts.args << '--disable-gpu'
+    # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
+    opts.args << '--disable-site-isolation-trials'
+    opts.args << '--no-sandbox'
+    opts.args << '--window-size=1280,1696'
+  end
+  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: browser_options)
 end
 
 Capybara.disable_animation = true


### PR DESCRIPTION
This also switches from cuprite to selenium-webdriver for JS testing.  This is what we use in Argo.
## Why was this change made? 🤔

Fixes #2432

## How was this change tested? 🤨

Tested manually on different browsers.

