### PR TITLE
show client side validation for duplicate keyword entry

### DIFF
--- a/app/components/works/keywords_row_component.html.erb
+++ b/app/components/works/keywords_row_component.html.erb
@@ -3,7 +3,7 @@
     <%= form.label :label, 'Keyword', class: 'col-form-label sr-only' %>
     <div data-controller="keywords autocomplete autocomplete-edit" data-autocomplete-url-value="/autocomplete" data-autocomplete-min-length-value="3" class="dropdown">
       <%= form.text_field :label, { class: "form-control#{ 'is-invalid' if error?}", required: true, 'data-autocomplete-target': 'input', 'data-autocomplete-edit-target': 'input',
-                'data-action': 'blur->keywords#checkForDuplicates' } %>
+                'data-keywords-target': 'input', 'data-action': 'blur->keywords#checkForDuplicates' } %>
       <!-- This input is populated by autocomplete controller.-->
       <!-- That triggers the autocomplete-edit controller, which populates the uri and cocina type inputs. -->
       <input type="hidden" data-autocomplete-target="hidden" data-autocomplete-edit-target="value" data-action="autocomplete-edit#change" />

--- a/app/components/works/keywords_row_component.html.erb
+++ b/app/components/works/keywords_row_component.html.erb
@@ -1,15 +1,16 @@
-<div class="mb-3 row plain-container g-0">
+<div class="mb-3 row plain-container g-0 keyword-row">
   <div class="col-sm-6">
     <%= form.label :label, 'Keyword', class: 'col-form-label sr-only' %>
-    <div data-controller="autocomplete autocomplete-edit" data-autocomplete-url-value="/autocomplete" data-autocomplete-min-length-value="3" class="dropdown">
-      <%= form.text_field :label, { class: "form-control#{ 'is-invalid' if error?}", required: true, 'data-autocomplete-target': 'input', 'data-autocomplete-edit-target': 'input' } %>
+    <div data-controller="keywords autocomplete autocomplete-edit" data-autocomplete-url-value="/autocomplete" data-autocomplete-min-length-value="3" class="dropdown">
+      <%= form.text_field :label, { class: "form-control#{ 'is-invalid' if error?}", required: true, 'data-autocomplete-target': 'input', 'data-autocomplete-edit-target': 'input',
+                'data-action': 'blur->keywords#checkForDuplicates' } %>
       <!-- This input is populated by autocomplete controller.-->
       <!-- That triggers the autocomplete-edit controller, which populates the uri and cocina type inputs. -->
       <input type="hidden" data-autocomplete-target="hidden" data-autocomplete-edit-target="value" data-action="autocomplete-edit#change" />
       <%= form.hidden_field :uri, { required: true, 'data-autocomplete-edit-target': 'uri' }%>
       <%= form.hidden_field :cocina_type, { required: true, 'data-autocomplete-edit-target': 'type' }%>
       <ul class="show dropdown-menu" data-autocomplete-target="results"></ul>
-      <div class="invalid-feedback">Keyword must be filled in</div>
+      <div class="invalid-feedback">Keyword must be filled in and be unique</div>
     </div>
   </div>
   <div class="col-sm-1">

--- a/app/javascript/controllers/keywords_controller.js
+++ b/app/javascript/controllers/keywords_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  static targets = ["search", "container", "error", "selectedTemplate", "addItem"]
+  static targets = ["search", "container", "error", "selectedTemplate", "addItem", "input"]
 
   open(event) {
     this.searchTarget.focus()
@@ -24,15 +24,12 @@ export default class extends Controller {
   }
 
   checkForDuplicates(event) {
-    const input = event.target.closest('input[type="text"]')
-    const keywords = Array.from(document.querySelectorAll('.keyword-row:not([style*="display: none"]) input[type="text"]'), input => input.value)
-    const hasDuplicates = (new Set(keywords)).size !== keywords.length // a set cannot have duplicates, so this checks for dupes
-    if (hasDuplicates) {
-      input.classList.add('is-invalid')
+    if (this.hasDuplicateKeywords()) {
+      this.inputTarget.classList.add('is-invalid')
     }
     else
     {
-      input.classList.remove('is-invalid')
+      this.inputTarget.classList.remove('is-invalid')
     }
   }
 
@@ -41,5 +38,13 @@ export default class extends Controller {
     item.querySelector("input[name*='_destroy']").value = 1
     item.style.display = 'none'
     this.checkForDuplicates() // clear out the invalid selection class if there are no duplicates anymore
+  }
+
+  hasDuplicateKeywords() {
+    // determine if the user has entered duplicate keywords
+    const nodes = document.querySelectorAll('.keyword-row:not([style*="display: none"]) input[type="text"]')
+    const keywords = Array.from(nodes, target => target.value)
+    // a set cannot have duplicates but an array can, so if the set and array are different in size, we have dupes
+    return (new Set(keywords)).size !== keywords.length
   }
 }

--- a/app/javascript/controllers/keywords_controller.js
+++ b/app/javascript/controllers/keywords_controller.js
@@ -23,10 +23,16 @@ export default class extends Controller {
     this.containerTarget.classList.remove('is-invalid')
   }
 
-  checkForEnter(event) {
-    if (event.key === 'Enter') {
-      event.preventDefault() // prevent form submission
-      this.add(event);
+  checkForDuplicates(event) {
+    const input = event.target.closest('input[type="text"]')
+    const keywords = Array.from(document.querySelectorAll('.keyword-row:not([style*="display: none"]) input[type="text"]'), input => input.value)
+    const hasDuplicates = (new Set(keywords)).size !== keywords.length // a set cannot have duplicates, so this checks for dupes
+    if (hasDuplicates) {
+      input.classList.add('is-invalid')
+    }
+    else
+    {
+      input.classList.remove('is-invalid')
     }
   }
 
@@ -34,5 +40,6 @@ export default class extends Controller {
     const item = event.target.closest(".selection-choice")
     item.querySelector("input[name*='_destroy']").value = 1
     item.style.display = 'none'
+    this.checkForDuplicates() // clear out the invalid selection class if there are no duplicates anymore
   }
 }


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1502 - adds client side duplicate keyword validation

Notes:
- for simplicity of implementation, I reused the existing "invalid selection" that typically shows for blank keywords and expanded the error message from "Keyword must be filled in" to "Keyword must be filled in and be unique" so there is a single client side error message that will show in either case
- again for simplicity, the error shows next to the last text box that lost focus when a duplicate was detected, so it may be possible to get into some situations where the error shows on the wrong text box, though i think this simple method should work fine in most cases

Example:

![H2-keywords](https://user-images.githubusercontent.com/47137/185510313-c723121f-cc50-49bb-81fd-6c4a7b377a26.gif)

## How was this change tested? 🤨

Localhost

