### PR TITLE
Display error messages for dates.

### DIFF
--- a/app/components/works/dates_component.html.erb
+++ b/app/components/works/dates_component.html.erb
@@ -22,7 +22,9 @@
         <%= form.radio_button :created_type, 'single', class: 'form-check-input', data: { action: 'complex-radio#disableUnselectedInputs' } %>
         <%= form.label :created_type_single, 'Single date' %>
       </div>
-      <div data-controller="date-validation date-approximate" data-date-approximate-enabled-value="<%= form.object.created_type == 'single' %>" class="col-sm-10">
+      <div data-controller="date-validation date-approximate" 
+        data-date-approximate-enabled-value="<%= form.object.created_type == 'single' %>" 
+        class="col-sm-10 date">
         <div class="year">
           <label for="<%= prefix %>_created_year" class="visually-hidden">Created year</label>
           <%= number_field_tag "#{prefix}[created(1i)]", created_year,

--- a/app/components/works/publication_date_component.html.erb
+++ b/app/components/works/publication_date_component.html.erb
@@ -3,7 +3,7 @@
     Publication date
     <%= render PopoverComponent.new key: 'work.publication_date' %>
   </div>
-  <div data-controller="date-validation" class="col-sm-10<%= ' is-invalid' if error? %>">
+  <div data-controller="date-validation" class="col-sm-10 date <%= ' is-invalid' if error? %>">
     <div class="year">
       <label for="work_published_year" class="visually-hidden">Publication year</label>
       <%= year_field %>

--- a/app/javascript/controllers/date_range_controller.js
+++ b/app/javascript/controllers/date_range_controller.js
@@ -22,7 +22,9 @@ export default class extends Controller {
 
     clearValidationMessages() {
         this.startYearTarget.dispatchEvent(new Event('clear'))
+        this.startErrorTarget.textContent = ''
         this.endYearTarget.dispatchEvent(new Event('clear'))
+        this.endErrorTarget.textContent = ''
     }
 
     // If any of the years are filled in, then make both required.

--- a/app/javascript/controllers/date_validation_controller.js
+++ b/app/javascript/controllers/date_validation_controller.js
@@ -38,31 +38,69 @@ export default class extends Controller {
     const month = this.toInt(this.monthTarget)
     const year = this.toInt(this.yearTarget)
 
+    if (!this.validateYearMin(year)) return
+    if (!this.validateYearPast(year, currentYear, month, day)) return
+    if (!this.validateMonthPast(year, currentYear, month, currentMonth, day)) return
+    if (!this.validateDayPast(year, currentYear, month, currentMonth, day, currentDay)) return
+    this.validateDayExists(month, day)
+  }
+
+  validateYearMin(year) {
     if (year != 0 && year < this.yearTarget.min) {
-      this.yearTarget.classList.add('is-invalid')
-      this.yearTarget.setCustomValidity('invalid')
-      this.errorTarget.textContent = 'must be after ' + this.yearTarget.min
-    } else if (year > currentYear) {
-      this.yearTarget.classList.add('is-invalid')
-      this.yearTarget.setCustomValidity('invalid')
-      this.errorTarget.textContent = 'must be in the past'
-    } else if (year == currentYear) {
-      if (month > currentMonth) {
-        this.monthTarget.classList.add('is-invalid')
-        this.monthTarget.setCustomValidity('invalid')
-        this.yearTarget.classList.add('is-invalid')
-        this.yearTarget.setCustomValidity('invalid')
-        this.errorTarget.textContent = 'must be in the past'
-      } else if (month == currentMonth && day > currentDay) {
-        this.dayTarget.classList.add('is-invalid')
-        this.dayTarget.setCustomValidity('invalid')
-        this.monthTarget.classList.add('is-invalid')
-        this.monthTarget.setCustomValidity('invalid')
-        this.yearTarget.classList.add('is-invalid')
-        this.yearTarget.setCustomValidity('invalid')
-        this.errorTarget.textContent = 'must be in the past'
-      }
+      this.invalid('must be after ' + this.yearTarget.min, false, false)
+      return false
     }
+    return true
+  }
+
+  validateYearPast(year, currentYear, month, day) {
+    if (year > currentYear) {
+      this.invalid('must be in the past', !!month, !!day)
+      return false
+    }
+    return true
+  }
+
+  validateMonthPast(year, currentYear, month, currentMonth, day) {
+    if (year == currentYear && month > currentMonth) {
+      this.invalid('must be in the past', true, !!day)
+      return false
+    }
+    return true
+  }
+
+  validateDayPast(year, currentYear, month, currentMonth, day, currentDay) {
+    if (year == currentYear && month == currentMonth && day > currentDay) {
+      this.invalid('must be in the past', true, true)
+      return false
+    }
+    return true
+  }
+
+  validateDayExists(month, day) {
+    if(!month || !day) return true
+
+    const lastDays = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+    if (lastDays[month - 1] < day) {
+      this.invalid('must be a valid day', true, true)
+      return false
+    }
+    return true
+  }
+
+  invalid(msg, invalid_month, invalid_day) {
+    this.yearTarget.classList.add('is-invalid')
+    this.yearTarget.setCustomValidity('invalid')  
+    if(invalid_month) {
+      this.monthTarget.classList.add('is-invalid')
+      this.monthTarget.setCustomValidity('invalid')
+    }
+    if(invalid_day) {
+      this.dayTarget.classList.add('is-invalid')
+      this.dayTarget.setCustomValidity('invalid')
+    }
+    this.errorTarget.textContent = msg
   }
 
   // Validate that the most signifcant parts are provided when a less significant part is provided.

--- a/app/javascript/controllers/date_validation_controller.js
+++ b/app/javascript/controllers/date_validation_controller.js
@@ -50,10 +50,16 @@ export default class extends Controller {
       if (month > currentMonth) {
         this.monthTarget.classList.add('is-invalid')
         this.monthTarget.setCustomValidity('invalid')
+        this.yearTarget.classList.add('is-invalid')
+        this.yearTarget.setCustomValidity('invalid')
         this.errorTarget.textContent = 'must be in the past'
       } else if (month == currentMonth && day > currentDay) {
         this.dayTarget.classList.add('is-invalid')
         this.dayTarget.setCustomValidity('invalid')
+        this.monthTarget.classList.add('is-invalid')
+        this.monthTarget.setCustomValidity('invalid')
+        this.yearTarget.classList.add('is-invalid')
+        this.yearTarget.setCustomValidity('invalid')
         this.errorTarget.textContent = 'must be in the past'
       }
     }

--- a/app/javascript/modules/validate-forms.js
+++ b/app/javascript/modules/validate-forms.js
@@ -10,11 +10,12 @@
     Array.prototype.slice.call(forms)
       .forEach(function (form) {
         form.addEventListener('submit', function (event) {
+          console.log('submit')
           // Note that checkValidity and :invalid do not work in hidden inputs such as dropzone files.
           const invalidFileElem = form.querySelector('.hidden-file.is-invalid')
-          if (event.submitter.id === 'save-draft-button') {
+          if (event.submitter.id === 'save-draft-button') {            
             // limited client side validation for saving drafts
-            const elem = invalidFileElem || form.querySelector('.date-range *:invalid')
+            const elem = invalidFileElem || form.querySelector('.date *:invalid') || form.querySelector('.date-range *:invalid')
             if(!elem) return
             event.preventDefault()
             event.stopPropagation()

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -69,8 +69,17 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
           )
           expect(page).to have_content('You must provide an abstract')
 
+          fill_in 'Created year', with: '2000'
+          select 'February', from: 'Created month'
+          select '31', from: 'Created day'
+          expect(page).to have_content(
+            'must be a valid day'
+          )
+
           fill_in 'Created year', with: ''
           fill_in 'Publication year', with: ''
+          select 'month', from: 'Created month'
+          select 'day', from: 'Created day'
 
           page.attach_file(Rails.root.join('spec/fixtures/files/sul.svg')) do
             click_button('Choose files')


### PR DESCRIPTION
closes #2293, #2294

## Why was this change made? 🤔
Validation error was detected, but not correctly displayed to user.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Local, Amy.

I did not write a error message in the past because it would have been problematic either in December (when months wrap) or the last day of the month (when days wrap).
