### PR TITLE
Simplify breadcrumb link rendering

### DIFF
--- a/app/views/works/edit.html.erb
+++ b/app/views/works/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :breadcrumbs do %>
   <%= render BreadcrumbNavComponent.new(
     breadcrumbs: [ { title: @form.collection.head.name, link: collection_path(@form.collection) },
-                   { title: @form.title, link: work_path(@form.model) },
+                   { title: @form.title, link: work_path(@form) },
                    { title: 'Edit', omit_title: true } ])
   %>
 <% end %>


### PR DESCRIPTION


## Why was this change made? 🤔

Previously it was rendering unnecessary attributes for the link, (e.g. /works/18056\?work\=18056\&work_version\=1821)

## How was this change tested? 🤨
Tested locally.