### PR TITLE
Make duplicate file prevent saving or depositing

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -6,7 +6,7 @@
                               bs_toggle: 'modal',
                               bs_target: '#contactUsModal' }) %>
   </p>
-  <div class="dropzone dropzone-default<%= ' is-invalid' if error? %>" data-dropzone-target="container">
+  <div class="dropzone dropzone-default" data-dropzone-target="container">
     <%= form.file_field :files, multiple: true, direct_upload: true,
                         data: { dropzone_target: 'input' } %>
     <div class="dz-message needsclick text-secondary">

--- a/app/components/works/file_row_component.html.erb
+++ b/app/components/works/file_row_component.html.erb
@@ -43,7 +43,7 @@
 
   <div class="col-md-1">
     <%= button_tag type: 'button',
-                   class: "dz-remove pull-right btn",
+                   class: "dz-remove pull-right btn remove-file",
                    "aria-label": "Remove file",
                    data: { action: "click->dropzone#removeAssociation" } do %>
       <span class="far fa-trash-alt"></span>

--- a/app/javascript/controllers/dropzone_controller.js
+++ b/app/javascript/controllers/dropzone_controller.js
@@ -115,8 +115,8 @@ export default class extends Controller {
       file.previewElement.querySelector('.dz-upload').classList.add('dz-upload-error')
       file.previewElement.querySelector('.dz-error-mark').style.display = 'block'
       file.previewElement.querySelector('.dz-success-mark').style.display = 'none'
-
-      this.containerTarget.classList.add("is-invalid")
+      // is-invalid needs to be on the hidden-file input for validation
+      file.previewElement.querySelector('.hidden-file').classList.add('is-invalid')
     })
 
     this.dropZone.on("complete", () => {

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -81,7 +81,11 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
           end
 
           expect(page).to have_content('Duplicate file')
-          click_button('Remove file', match: :first)
+          # remove the file which has the 'duplicate' error
+          within('div.dz-error', visible: true) do
+            find('.remove-file').click
+          end
+          expect(page).not_to have_content('Duplicate file')
           # End of client-side validation testing
 
           fill_in 'Title of deposit', with: 'My Title'
@@ -286,7 +290,14 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
             click_button('Choose files')
           end
 
+          click_button 'Deposit'
+          # should not deposit but continue to show duplicate file error
           expect(page).to have_content('Duplicate file')
+          # remove the file which has the 'duplicate' error
+          within('div.dz-error', visible: true) do
+            find('.remove-file').click
+          end
+          expect(page).not_to have_content('Duplicate file')
           # End of client-side validation testing
 
           fill_in 'Title of deposit', with: 'My Title'


### PR DESCRIPTION
## Why was this change made? 🤔
Fixes #2336. If a file marked as a duplicate exists, the work cannot be saved or deposited.

## How was this change tested? 🤨
Unit and Amy reviewed on stage.

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


