### PR TITLE
Transition pending_approval and rejected works to version_draft when …

### DIFF
--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -101,6 +101,10 @@ class WorkVersion < ApplicationRecord
       transition %i[first_draft version_draft pending_approval rejected] => same
       transition purl_reserved: :first_draft
     end
+
+    event :no_review_workflow do
+      transition %i[pending_approval rejected] => :version_draft
+    end
   end
 
   # 6/3/2022 : Added to prevent https://app.honeybadger.io/projects/77112/faults/85827019

--- a/app/services/collection_observer.rb
+++ b/app/services/collection_observer.rb
@@ -33,6 +33,7 @@ class CollectionObserver
     reviewers_added(collection_version, change_set)
     reviewers_removed(collection_version, change_set)
     send_participant_change_emails(collection, change_set)
+    fix_state(collection) unless collection.review_enabled
   end
 
   def self.collection_managers_excluding_depositor(work_version)
@@ -109,4 +110,11 @@ class CollectionObserver
     end
   end
   private_class_method :send_participant_change_emails
+
+  def self.fix_state(collection)
+    collection.works.joins(:head).where("state in ('pending_approval', 'rejected')").each do |work|
+      work.head.no_review_workflow!
+    end
+  end
+  private_class_method :fix_state
 end

--- a/spec/services/collection_observer_spec.rb
+++ b/spec/services/collection_observer_spec.rb
@@ -155,5 +155,42 @@ RSpec.describe CollectionObserver do
         )
       end
     end
+
+    context 'when review not enabled' do
+      let(:collection) { create(:collection) }
+      let!(:work_version1) { create(:work_version_with_work, collection: collection, state: 'pending_approval') }
+      let!(:work_version2) { create(:work_version_with_work, collection: collection, state: 'rejected') }
+      let!(:work_version3) { create(:work_version_with_work, collection: collection, state: 'deposited') }
+      let(:collection_after) { collection }
+
+      before do
+        collection.reload
+      end
+
+      it 'updates states of works from pending_approval and rejected to version_draft' do
+        action
+        expect(work_version1.reload.state).to eq 'version_draft'
+        expect(work_version2.reload.state).to eq 'version_draft'
+        expect(work_version3.reload.state).to eq 'deposited'
+      end
+    end
+
+    context 'when review is enabled' do
+      let(:collection) { create(:collection) }
+      let!(:work_version1) { create(:work_version_with_work, collection: collection, state: 'pending_approval') }
+      let!(:work_version2) { create(:work_version_with_work, collection: collection, state: 'rejected') }
+      let(:collection_after) { collection }
+
+      before do
+        collection.update(review_enabled: true)
+        collection.reload
+      end
+
+      it 'does not update states of works from pending_approval and rejected to version_draft' do
+        action
+        expect(work_version1.reload.state).to eq 'pending_approval'
+        expect(work_version2.reload.state).to eq 'rejected'
+      end
+    end
   end
 end


### PR DESCRIPTION
…collection review disabled.

closes #2455

## Why was this change made? 🤔
Corner case.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit, local

