### PR TITLE
add advisor role to person list

### DIFF
--- a/app/models/abstract_contributor.rb
+++ b/app/models/abstract_contributor.rb
@@ -7,6 +7,7 @@ class AbstractContributor < ApplicationRecord
   SEPARATOR = '|'
 
   PERSON_ROLES = [
+    'Advisor',
     'Author',
     'Composer',
     'Contributing author',

--- a/spec/components/works/contributor_role_component_spec.rb
+++ b/spec/components/works/contributor_role_component_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Works::ContributorRoleComponent do
   it 'makes groups with headings including Department' do
     expected = <<~HTML
       <select class="form-select" data-contributors-target="role" name="role_term" id="role_term"><optgroup label="Individual">
+      <option value="person|Advisor">Advisor</option>
       <option value="person|Author">Author</option>
       <option value="person|Composer">Composer</option>
       <option value="person|Contributing author">Contributing author</option>


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2292 - add new "Advisor" role to drop-down menu for contributors

Despite this coming first in the list now, "Author" is still the default value.

## How was this change tested? 🤨

Localhost

