### PR TITLE
Display a lock instead of a pencil when a work is locked

### DIFF
--- a/app/components/popover_component.html.erb
+++ b/app/components/popover_component.html.erb
@@ -1,3 +1,3 @@
 <a tabindex="0" data-controller="popover" data-bs-placement="top" data-bs-content="<%= text %>" data-bs-html="true" class="info-icon">
-  <span class="fas fa-info-circle" aria-hidden="true"></span><span class="visually-hidden">more information</span>
+  <span class="<%= icon %>" aria-hidden="true"></span><span class="visually-hidden">more information</span>
 </a>

--- a/app/components/popover_component.rb
+++ b/app/components/popover_component.rb
@@ -2,9 +2,12 @@
 
 # Draws a bootstrap popover icon.
 class PopoverComponent < ApplicationComponent
-  def initialize(key:)
+  def initialize(key:, icon: 'fas fa-info-circle')
     @key = key
+    @icon = icon
   end
+
+  attr_reader :icon
 
   def text
     t(@key, scope: :tooltip)

--- a/app/views/works/_edit_button.html.erb
+++ b/app/views/works/_edit_button.html.erb
@@ -17,5 +17,7 @@
         <span class="fas fa-pencil-alt" aria-hidden="true"></span>
       <% end %>
     <% end %>
+  <% elsif work.locked? %>
+    <%= render PopoverComponent.new key: 'work.locked', icon: 'fas fa-lock' %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,7 @@ en:
       related_work: Enter the citation for another publication, such as a journal article, that cites or is directly related to this deposit. Please include the related work's unique identifier, such as a Digital Object Identifier (DOI) or ISBN, if it has one. Enter one work per box. Use the "Add another related work" button below to include additional works. These related works will display on the persistent URL (PURL) page for your deposit and on the Stanford Libraries' catalog record.
       related_link: This section allows you to provide links to other web pages that are related to your deposit. These links will display on the persistent URL (PURL) page for your deposit and on the Stanford Libraries' catalog record. Enter the text to be displayed on the page in the "Link text" box. This entire text will be hyperlinked to the URL you enter in the "URL" box. Examples of content you might consider linking to are lab, institute, or project pages; GitHub repositories for the current version of software code; or funder websites.
       license: A license helps others who access your content to understand what you are allowing them to do with your work and under what conditions.  Click on "Get help selecting a license" for assistance with the license options presented here.
+      locked: This deposit can no longer be edited in this application. If you need to make changes to this deposit, please use the Help link at the top of this page to contact us.
   hints:
     collection:
       review_enabled: >

--- a/spec/requests/work_edit_button_spec.rb
+++ b/spec/requests/work_edit_button_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Link to edit a work' do
+  before do
+    sign_in user
+  end
+
+  let(:collection) { create(:collection) }
+  let(:rendered) do
+    Capybara::Node::Simple.new(response.body)
+  end
+  let(:user) { create(:user) }
+
+  context 'with a user who may edit the object' do
+    let(:work) { create(:work_version_with_work, :version_draft, collection: collection, owner: user).work }
+
+    it 'draws a link' do
+      get "/works/#{work.id}/edit_button"
+      expect(response).to have_http_status(:ok)
+      expect(rendered).to have_selector('turbo-frame a span.fa-pencil-alt')
+    end
+
+    context 'when the work is locked' do
+      before do
+        work.update(locked: true)
+      end
+
+      it 'draws a lock' do
+        get "/works/#{work.id}/edit_button"
+        expect(response).to have_http_status(:ok)
+        expect(rendered).to have_selector('turbo-frame a span.fa-lock')
+      end
+    end
+  end
+
+  context 'with a user who may not edit the object' do
+    let(:work) { create(:work_version_with_work, :version_draft, collection: collection).work }
+
+    it 'only draws the turbo-frame' do
+      get "/works/#{work.id}/edit_button"
+      expect(response).to have_http_status(:ok)
+      expect(rendered).to have_selector('turbo-frame')
+      expect(rendered).not_to have_link
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔
Fixes #2319
Fixes #2321

## How was this change tested? 🤨
ci & locally
<img width="688" alt="Screen Shot 2022-08-26 at 10 06 02 AM" src="https://user-images.githubusercontent.com/92044/186938402-dad304a9-a1db-49d0-b02d-1e59c39342f1.png">

