### PR TITLE
Update link to point at the right place

### DIFF
--- a/app/views/collections/_edit_link.html.erb
+++ b/app/views/collections/_edit_link.html.erb
@@ -1,7 +1,9 @@
 <%= turbo_frame_tag dom_id(collection, ['edit', anchor].compact.join('_')) do %>
   <% if allowed_to?(:update?, collection.head) %>
+    <% url = collection.head.first_draft? ?
+       edit_first_draft_collection_path(collection, anchor: anchor) :
+       edit_collection_path(collection, anchor: anchor) %>
     <%= link_to tag.span(class: 'fa-solid fa-pencil-alt edit'),
-                edit_collection_path(collection, anchor: anchor),
-                aria: { label: label } %>
+                url, aria: { label: label } %>
   <% end %>
 <% end %>


### PR DESCRIPTION


## Why was this change made? 🤔
Previously we were relying on a redirect to get to the correct path, however this looses the anchor, so we wouldn't end up at the right spot on the page.

Fixes #2289


## How was this change tested? 🤨
Tested locally.
