### PR TITLE
Send admins email when globus deposited.

### DIFF
--- a/app/mailers/first_draft_collections_mailer.rb
+++ b/app/mailers/first_draft_collections_mailer.rb
@@ -2,13 +2,12 @@
 
 # Sends email notifications about first_draft_collections
 class FirstDraftCollectionsMailer < ApplicationMailer
-  ADMIN_LIST = 'h2-administrators@lists.stanford.edu'
   NEW_COLLECTION_SUBJECT = 'A new collection has been created'
 
   def first_draft_created
     @collection_version = params[:collection_version]
     @creator = @collection_version.collection.creator
 
-    mail(to: ADMIN_LIST, subject: NEW_COLLECTION_SUBJECT)
+    mail(to: Settings.notifications.admin_email, subject: NEW_COLLECTION_SUBJECT)
   end
 end

--- a/app/mailers/works_mailer.rb
+++ b/app/mailers/works_mailer.rb
@@ -65,4 +65,11 @@ class WorksMailer < ApplicationMailer
     @user = UserPresenter.new(user: params[:user])
     mail(to: @user.email, subject: 'The ownership of an item in your collection has changed')
   end
+
+  def globus_deposited_email
+    @work_version = params[:work_version]
+    @work = @work_version.work
+    @user = UserPresenter.new(user: @work.depositor)
+    mail(to: Settings.notifications.admin_email, subject: 'User has deposited an item with files on Globus')
+  end
 end

--- a/app/services/work_observer.rb
+++ b/app/services/work_observer.rb
@@ -40,6 +40,7 @@ class WorkObserver
             mailer.deposited_email
           end
     job.deliver_later
+    mailer.globus_deposited_email.deliver_later if work_version.globus && Settings.notify_admin_list
   end
 
   def self.after_rejected(work_version, _transition)

--- a/app/views/works_mailer/globus_deposited_email.html.erb
+++ b/app/views/works_mailer/globus_deposited_email.html.erb
@@ -1,0 +1,11 @@
+Dear Administrator,
+
+<p>The following item has been deposited with the "Files have been uploaded to Globus" option checked.</p>
+
+<p>
+  Item: <%= link_to @work_version.title, work_url(@work) %>
+  Collection: <%= link_to @work.collection.head.name, collection_url(@work.collection) %>
+  Deposited by: <%= @user.name %>
+</p>
+
+<p>The Stanford Digital Repository Team</p>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -68,6 +68,7 @@ notifications:
   first_draft_reminder:
     first_interval: 14 # delay before initial first draft reminder, in days
     subsequent_interval: 28 # delay between reminders after the initial, also in days
+  admin_email: h2-administrators@lists.stanford.edu
 
 access:
   use_and_reproduction_statement: User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.

--- a/spec/mailers/first_draft_collections_mailer_spec.rb
+++ b/spec/mailers/first_draft_collections_mailer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe FirstDraftCollectionsMailer, type: :mailer do
 
     it 'renders the headers' do
       expect(mail.subject).to eq 'A new collection has been created'
-      expect(mail.to).to eq [described_class::ADMIN_LIST]
+      expect(mail.to).to eq ['h2-administrators@lists.stanford.edu']
       expect(mail.from).to eq ['no-reply@sdr.stanford.edu']
     end
 

--- a/spec/mailers/works_mailer_spec.rb
+++ b/spec/mailers/works_mailer_spec.rb
@@ -235,4 +235,25 @@ RSpec.describe WorksMailer, type: :mailer do
       expect(mail.body).to match("http://#{Socket.gethostname}/works/#{work.id}/edit")
     end
   end
+
+  describe 'globus_deposited_email' do
+    let(:work) { build_stubbed(:work, collection: collection, depositor: a_user) }
+    let(:work_version) { build_stubbed(:work_version, work: work) }
+    let(:mail) { described_class.with(work_version: work_version).globus_deposited_email }
+    let(:collection) { build_stubbed(:collection, head: collection_version) }
+    let(:collection_version) { build_stubbed(:collection_version) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq 'User has deposited an item with files on Globus'
+      expect(mail.to).to eq ['h2-administrators@lists.stanford.edu']
+      expect(mail.from).to eq ['no-reply@sdr.stanford.edu']
+    end
+
+    it 'renders body' do
+      expect(mail.body).to include 'The following item has been deposited'
+      expect(mail.body).to match("http://#{Socket.gethostname}/works/#{work.id}")
+      expect(mail.body).to match("http://#{Socket.gethostname}/collections/#{collection.id}")
+      expect(mail.body).to include a_user.name
+    end
+  end
 end


### PR DESCRIPTION
closes #2351

## Why was this change made? 🤔
So that admins know when to handle globus deposits.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit, Amy
