### PR TITLE
moreTypes no longer includes exact matches to work type ('Data', 'Image', 'Text')

### DIFF
--- a/app/components/works/subtypes_component.rb
+++ b/app/components/works/subtypes_component.rb
@@ -34,7 +34,7 @@ module Works
     end
 
     def more_types
-      WorkType.more_types - subtypes
+      WorkType.more_types - subtypes - [work_type.titlecase]
     end
 
     def tooltip

--- a/app/javascript/controllers/work_type_controller.js
+++ b/app/javascript/controllers/work_type_controller.js
@@ -97,14 +97,14 @@ export default class extends Controller {
   moreTypesFor(type) {
     // Work types have a small number of primary subtypes and they share a large
     // number of general subtypes, which we refer to as "more types." Some work types
-    // have primary subtypes that also appear in the list of "more types" and we
-    // don't want users to be able to see and select multiple types of the same value,
-    // so we only return the "more types" for a given type that do not match any of
-    // the type's primary subtypes, hence the filtering in this function.
-
+    // appear in the list of "more types" and also have primary subtypes that can appear
+    // in the list of "more types" and we don't want users to be able to see and select
+    // multiple types of the exact same value, so we only return the "more types" that
+    // do not match the type or any of the type's primary subtypes, hence the filtering
+    // in this function.
     return document
       .moreTypes
-      .filter(moreType => !document.subtypes[type].includes(moreType))
+      .filter(moreType => (!document.subtypes[type].includes(moreType) && type !== moreType.toLowerCase()))
       .map((moreType) => {
         const id = moreType.replace(/\s/g, '_')
         return this.templateTarget.innerHTML.replace(/SUBTYPE_LABEL/g, moreType).replace(/SUBTYPE_ID/g, id)

--- a/spec/components/works/subtypes_component_spec.rb
+++ b/spec/components/works/subtypes_component_spec.rb
@@ -46,6 +46,48 @@ RSpec.describe Works::SubtypesComponent do
     end
   end
 
+  context 'when work type is "data"' do
+    # Text, Data, and Image are present in Work::MORE_TYPES, but Data should be filtered out
+    let(:work_version) { build_stubbed(:work_version, work_type: 'data') }
+
+    it 'does not include "Data" in more_types' do
+      expect(rendered.css('#work_subtype_data')).not_to be_present
+    end
+
+    it 'includes "Text" and "Image" in more_types' do
+      expect(rendered.css('#work_subtype_text')).to be_present
+      expect(rendered.css('#work_subtype_image')).to be_present
+    end
+  end
+
+  context 'when work type is "text"' do
+    # Text, Data, and Image are present in Work::MORE_TYPES but Text should be filtered out
+    let(:work_version) { build_stubbed(:work_version, work_type: 'text') }
+
+    it 'does not include "Text" in more_types' do
+      expect(rendered.css('#work_subtype_text')).not_to be_present
+    end
+
+    it 'includes "Data" and "Image" in more_types' do
+      expect(rendered.css('#work_subtype_data')).to be_present
+      expect(rendered.css('#work_subtype_image')).to be_present
+    end
+  end
+
+  context 'when work type is "image"' do
+    # Text, Data, and Image are present in Work::MORE_TYPES but Image should be filtered out
+    let(:work_version) { build_stubbed(:work_version, work_type: 'image') }
+
+    it 'does not include "Text" in more_types' do
+      expect(rendered.css('#work_subtype_image')).not_to be_present
+    end
+
+    it 'includes "Data" and "Text" in more_types' do
+      expect(rendered.css('#work_subtype_data')).to be_present
+      expect(rendered.css('#work_subtype_text')).to be_present
+    end
+  end
+
   context 'when work type is anything else' do
     it 'does not label subtypes as required' do
       expect(rendered.to_html).to include('Work subtypes')

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -176,7 +176,10 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
 
           expect(page).to have_content 'What type of content will you deposit?'
 
-          find('label', text: 'Sound').click
+          find('label', text: 'Data').click
+          # check that modal doesn't display subtype that exactly matches the type
+          click_link 'See more options'
+          expect(page).not_to have_css('#subtype_Data')
 
           click_button 'Continue'
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2281

### AFTER

![image](https://user-images.githubusercontent.com/96775/187516336-a4c8b64a-93e6-4ec9-a3db-40a2f6ebb122.png)

![image](https://user-images.githubusercontent.com/96775/187535930-dda59b7c-af71-48d2-9bc9-6dee0b00cac3.png)

### BEFORE


![Screen Shot 2022-06-08 at 2 19 42 PM](https://user-images.githubusercontent.com/5558511/172689168-a06a0651-126f-405f-b306-de05b690bb84.png)

![Screen Shot 2022-06-08 at 2 20 07 PM](https://user-images.githubusercontent.com/5558511/172689187-b6d7472e-da12-457e-82dd-2e1b10d7e4db.png)



## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


