### PR TITLE
add debounce to avoid too many sunet lookups

### DIFF
--- a/app/javascript/controllers/collection_participant_form_controller.js
+++ b/app/javascript/controllers/collection_participant_form_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "stimulus"
+import debounce from 'lodash.debounce'
 
 export default class extends Controller {
   static targets = ["addItem", "template", "control", "lookup",
@@ -8,6 +9,7 @@ export default class extends Controller {
   static values = { selector: String }
 
   connect() {
+    this.search = debounce(this.search, 700)
     this.controlTarget.hidden = true
     this.hideResult()
   }

--- a/app/javascript/controllers/sunet_input_controller.js
+++ b/app/javascript/controllers/sunet_input_controller.js
@@ -1,10 +1,12 @@
 import { Controller } from "stimulus"
+import debounce from 'lodash.debounce'
 
 export default class extends Controller {
-  static targets = ["result", "resultNone", "resultOne", "resultName", "resultDescription", "queryValue", 
+  static targets = ["result", "resultNone", "resultOne", "resultName", "resultDescription", "queryValue",
   "resultError", "errorValue", "submit"]
-  
+
   connect() {
+    this.search = debounce(this.search, 700)
     this.submitTarget.disabled = true
     this.hideResult()
   }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dropzone": "^5.7.2",
     "esbuild": "^0.13.6",
     "esbuild-plugin-stimulus": "^0.1.2",
+    "lodash.debounce": "^4.0.8",
     "sass": "^1.43.2",
     "simple-datatables": "^3.0.0",
     "stimulus": "2.0.0",


### PR DESCRIPTION
## Why was this change made? 🤔

Could help with #2524 - sunet lookup issues for collection partipants/owner changes.

I saw this issue too when running the integration tests, and one theory is that we are running too many queries too quickly against the sunet lookup API.  This adds a debounce, so that we won't execute more than one query every 700 milliseconds.  That seems like a reasonable delay that is not so long as to make you think something is not working, but long enough to keep it from firing with each keypress.

## How was this change tested? 🤨

Localhost browser


