### PR TITLE
split authors/contributors into two tables on details page

### DIFF
--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -108,26 +108,8 @@
     </tbody>
   </table>
 
-  <table id="contributors" class="table table-sm caption-header">
-    <caption>Authors and contributors
-      <%= helpers.turbo_frame_tag dom_id(work, 'edit_author'), src: edit_button_work_path(work, tag: 'author'), target: '_top' %>
-    </caption>
-    <tbody>
-    <% contributors.each do |contributor| %>
-      <tr>
-        <% if contributor.person? %>
-          <td>
-            <%= contributor.first_name %> <%= contributor.last_name %>
-          </td>
-        <% else %>
-          <td><%= contributor.full_name %></td>
-        <% end %>
-        <td><%= render Works::Show::OrcidComponent.new(orcid: contributor.orcid) %></td>
-        <td><%= contributor.role %></td>
-      </tr>
-    <% end %>
-    </tbody>
-  </table>
+<%= render Works::Show::AuthorsContributorsComponent.new(work: work, participants: authors, participant_type: 'author') %>
+<%= render Works::Show::AuthorsContributorsComponent.new(work: work, participants: contributors, participant_type: 'contributor') %>
 
   <table class="table table-sm mb-5 caption-header">
     <caption>Dates

--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -14,12 +14,8 @@ module Works
     delegate :doi_option, to: :collection, prefix: true
 
     delegate :work_type, :contact_emails, :abstract, :citation, :first_draft?,
-             :attached_files, :related_works, :related_links,
+             :attached_files, :related_works, :related_links, :contributors, :authors,
              :created_edtf, :published_edtf, :rejected?, :work, :description, to: :work_version
-
-    def contributors
-      work_version.authors + work_version.contributors
-    end
 
     def version
       return '1 - initial version' if first_draft?

--- a/app/components/works/show/authors_contributors_component.html.erb
+++ b/app/components/works/show/authors_contributors_component.html.erb
@@ -1,0 +1,20 @@
+  <table id="<%= participant_type %>s" class="table table-sm caption-header">
+    <caption><%= participant_type.titlecase %>
+      <%= helpers.turbo_frame_tag dom_id(work, 'edit_author'), src: edit_button_work_path(work, tag: 'author'), target: '_top' %>
+    </caption>
+    <tbody>
+    <% participants.each do |participant| %>
+      <tr>
+        <% if participant.person? %>
+          <td style="width: 50%">
+            <%= participant.first_name %> <%= participant.last_name %>
+          </td>
+        <% else %>
+          <td style="width: 50%"><%= participant.full_name %></td>
+        <% end %>
+        <td style="width: 25%"><%= render Works::Show::OrcidComponent.new(orcid: participant.orcid) %></td>
+        <td style="width: 25%"><%= participant.role %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>

--- a/app/components/works/show/authors_contributors_component.rb
+++ b/app/components/works/show/authors_contributors_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Works
+  module Show
+    # Displays the author or contributor table on the show page
+    class AuthorsContributorsComponent < ApplicationComponent
+      attr_reader :work, :participants, :participant_type
+
+      def initialize(work:, participants:, participant_type:)
+        @work = work
+        @participants = participants
+        @participant_type = participant_type
+      end
+    end
+  end
+end

--- a/spec/components/works/detail_component_spec.rb
+++ b/spec/components/works/detail_component_spec.rb
@@ -78,17 +78,18 @@ RSpec.describe Works::DetailComponent, type: :component do
     end
   end
 
-  describe 'contributors' do
+  describe 'authors and contributors' do
     let(:work_version) { build_stubbed(:work_version, authors: [author1, author2], contributors: [contributor]) }
     let(:author1) { build_stubbed(:person_author, orcid: 'https://orcid.org/0000-0002-1825-0097') }
     let(:author2) { build_stubbed(:person_author) }
     let(:contributor) { build_stubbed(:person_contributor, orcid: 'https://orcid.org/0000-0002-1825-0098') }
 
-    it 'renders the contributor' do
-      expect(rendered.css('#contributors a').to_html).to include('https://orcid.org/0000-0002-1825-0097')
+    it 'renders the authors and contributors table' do
+      expect(rendered.css('#authors a').to_html).to include('https://orcid.org/0000-0002-1825-0097')
       expect(rendered.css('#contributors a').to_html).to include('https://orcid.org/0000-0002-1825-0098')
       # No link for author without ORCID.
-      expect(rendered.css('#contributors').search('a').size).to eq 2
+      expect(rendered.css('#authors').search('a').size).to eq 1
+      expect(rendered.css('#contributors').search('a').size).to eq 1
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2283 - split authors and contributors into two tables on detail page

Opted to create a new component since each table is basically the same.

## How was this change tested? 🤨

Localhost and CI


