### PR TITLE
add paragraph breaks for collection descriptions and work abstracts

### DIFF
--- a/app/components/collections/detail_component.html.erb
+++ b/app/components/collections/detail_component.html.erb
@@ -12,7 +12,7 @@
     </tr>
     <tr>
       <th class="col-3">Description</th>
-      <td><%= description %></td>
+      <td><%= simple_format description, class: 'mb-3' %></td>
     </tr>
     <tr>
       <th class="col-3">Contact emails</th>

--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -152,7 +152,7 @@
     <tbody>
     <tr>
       <th class="col-3" scope="row">Abstract</th>
-      <td><%= simple_format abstract %></td>
+      <td><%= simple_format abstract, class: 'mb-3' %></td>
     </tr>
     <tr>
       <th class="col-3" scope="row">Keywords</th>


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2297 and Fixes #2298

Add paragraph breaks and padding between paragraphs for work abstracts and collection descriptions. 

Note that this easy implementation adds a bottom margin below each paragraph, which spaces multiple paragraphs nicely, but also adds a bit of padding below a single paragraph (see examples below).  Seems like a reasonable tradeoff.

**Work (multiple paragraphs)**

![Screen Shot 2022-08-30 at 4 01 04 PM](https://user-images.githubusercontent.com/47137/187558671-44a494bc-181a-4a4c-aea0-5bea612e4476.png)

**Work (single paragraph)**

![Screen Shot 2022-08-30 at 4 02 27 PM](https://user-images.githubusercontent.com/47137/187558679-867217ab-3df0-44ca-b7ac-ab7b7cd70b15.png)


**Collection (multiple paragraphs)**

![Screen Shot 2022-08-30 at 4 00 45 PM](https://user-images.githubusercontent.com/47137/187558588-fe5830aa-5a31-4435-9034-cd0f4762c36f.png)


## How was this change tested? 🤨

Localhost