### PR TITLE
author should be first in the list

### DIFF
--- a/app/models/abstract_contributor.rb
+++ b/app/models/abstract_contributor.rb
@@ -6,9 +6,10 @@
 class AbstractContributor < ApplicationRecord
   SEPARATOR = '|'
 
+  # NOTE: "Author" is deliberately set to first (out of alpha order), as it should be the default
   PERSON_ROLES = [
-    'Advisor',
     'Author',
+    'Advisor',
     'Composer',
     'Contributing author',
     'Copyright holder',

--- a/spec/components/works/contributor_role_component_spec.rb
+++ b/spec/components/works/contributor_role_component_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Works::ContributorRoleComponent do
   it 'makes groups with headings including Department' do
     expected = <<~HTML
       <select class="form-select" data-contributors-target="role" name="role_term" id="role_term"><optgroup label="Individual">
-      <option value="person|Advisor">Advisor</option>
       <option value="person|Author">Author</option>
+      <option value="person|Advisor">Advisor</option>
       <option value="person|Composer">Composer</option>
       <option value="person|Contributing author">Contributing author</option>
       <option value="person|Copyright holder">Copyright holder</option>


### PR DESCRIPTION
## Why was this change made? 🤔

The author should be the default in the contributor role drop-down select list and this is the easy way, by just making it first in the list, even though it is slightly out of alphabetical order.

Verified as ok with PO
![Screen Shot 2022-09-01 at 9 36 03 AM](https://user-images.githubusercontent.com/47137/187966800-320266da-6330-4eec-a1a6-469a0725d16e.png)


## How was this change tested? 🤨

Localhost and CI 