### PR TITLE
Render work subtypes on edit form like the new form

### DIFF
--- a/app/components/works/subtypes_component.html.erb
+++ b/app/components/works/subtypes_component.html.erb
@@ -5,10 +5,10 @@
   </div>
 </div>
 
-<fieldset>
+<fieldset class="mb-4 work-types"  data-controller="more-types">
   <legend class="visually-hidden">Work subtypes</legend>
-  <div class="mb-5 row work-types" data-controller="more-types">
-    <% if other_type? %>
+  <% if other_type? %>
+    <div class="mb-4 subtype-container">
       <div class="col-sm-2">
         <div class="col-form-label">
           <%= form.label :subtype, 'Specify "Other" type' %> <%= render PopoverComponent.new key: 'work.subtypes.other' %>
@@ -19,36 +19,38 @@
         <%= form.text_field :subtype, class: 'form-control', required: true, multiple: true %>
         <div class="invalid-feedback">You must provide a subtype for works of type 'Other'</div>
       </div>
-    <% else %>
+    </div>
+  <% else %>
+    <div class="mb-4 subtype-container">
       <% if music_type? %>
-        <h6>Select at least one term below:</h6>
-      <% elsif mixed_material_type? %>
-        <h6>Select at least two terms below:</h6>
-      <% end %>
+      <h6>Select at least one term below:</h6>
+    <% elsif mixed_material_type? %>
+      <h6>Select at least two terms below:</h6>
+    <% end %>
 
-      <% subtypes.each do |subtype| %>
-        <div class="col-sm-4">
+    <% subtypes.each do |subtype| %>
+      <div class="subtype-item">
+        <div class="form-check">
+          <%= form.check_box :subtype, { multiple: true, class: 'form-check-input' }, subtype, nil %>
+          <%= form.label "subtype_#{sanitized_value(subtype)}", subtype, class: 'form-check-label' %>
+        </div>
+      </div>
+    <% end %>
+    </div>
+
+    <a href="#" class="more-options collapsed" data-action="more-types#toggleMoreTypes" data-more-types-target="moreTypesLink">
+      See more options
+    </a>
+
+    <div class="mb-4 subtype-container" data-more-types-target="moreTypes" hidden>
+      <% more_types.each do |more_type| %>
+        <div class="subtype-item">
           <div class="form-check">
-            <%= form.check_box :subtype, { multiple: true, class: 'form-check-input' }, subtype, nil %>
-            <%= form.label "subtype_#{sanitized_value(subtype)}", subtype, class: 'form-check-label' %>
+            <%= form.check_box :subtype, { multiple: true, class: 'form-check-input' }, more_type, nil %>
+            <%= form.label "subtype_#{sanitized_value(more_type)}", more_type, class: 'form-check-label' %>
           </div>
         </div>
       <% end %>
-
-      <a href="#" class="mt-4 more-options collapsed" data-action="more-types#toggleMoreTypes" data-more-types-target="moreTypesLink">
-        See more options
-      </a>
-
-      <div class="row" data-more-types-target="moreTypes" hidden>
-        <% more_types.each do |more_type| %>
-          <div class="col-sm-4">
-            <div class="form-check">
-              <%= form.check_box :subtype, { multiple: true, class: 'form-check-input' }, more_type, nil %>
-              <%= form.label "subtype_#{sanitized_value(more_type)}", more_type, class: 'form-check-label' %>
-            </div>
-          </div>
-        <% end %>
-      </div>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </fieldset>


### PR DESCRIPTION

## Why was this change made? 🤔

Fixes #2282

This commit tweaks CSS classes and HTML structure in the work subtypes component so that subtypes (and "more types") in the work edit form render as vertically oriented checkboxes as opposed to horizontally oriented checkboxes.

## How was this change tested? 🤨

CI, local testing, and tested successfully by PO in stage

No tests added since this affects only visual rendering of page.
