### PR TITLE
rename description column in works to version_description

### DIFF
--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -15,12 +15,12 @@ module Works
 
     delegate :work_type, :contact_emails, :abstract, :citation, :first_draft?,
              :attached_files, :related_works, :related_links, :contributors, :authors,
-             :created_edtf, :published_edtf, :rejected?, :work, :description, to: :work_version
+             :created_edtf, :published_edtf, :rejected?, :work, :version_description, to: :work_version
 
     def version
       return '1 - initial version' if first_draft?
 
-      "#{work_version.version} - #{description}"
+      "#{work_version.version} - #{version_description}"
     end
 
     def doi_setting

--- a/app/components/works/version_description_component.html.erb
+++ b/app/components/works/version_description_component.html.erb
@@ -1,9 +1,9 @@
 <section class="version">
    <header>Version your work *</header>
    <div class="mb-3 row">
-     <%= form.label :description, "What's changing?", class: 'col-sm-2 col-form-label' %>
+     <%= form.label :version_description, "What's changing?", class: 'col-sm-2 col-form-label' %>
      <div class="col-sm-10">
-       <%= form.text_field :description, class: "form-control", required: true %>
+       <%= form.text_field :version_description, class: "form-control", required: true %>
        <div class="invalid-feedback">You must describe your changes.</div>
      </div>
    </div>

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -11,7 +11,7 @@ class DraftWorkForm < Reform::Form
   feature Coercion # Casts properties to a specific type
 
   property :work_type, on: :work_version
-  property :description, on: :work_version
+  property :version_description, on: :work_version
   property :subtype, on: :work_version
   property :title, on: :work_version, type: Dry::Types['params.nil'] | Dry::Types['string']
   property :abstract, on: :work_version, type: Dry::Types['params.nil'] | Dry::Types['string']
@@ -140,7 +140,7 @@ class DraftWorkForm < Reform::Form
     model[:work]
   end
 
-  def description
+  def version_description
     return if model.fetch(:work_version).deposited?
 
     super

--- a/app/jobs/deposit_job.rb
+++ b/app/jobs/deposit_job.rb
@@ -51,7 +51,7 @@ class DepositJob < BaseDepositJob
     SdrClient::Deposit::UpdateResource.run(metadata: new_request_dro,
                                            logger: Rails.logger,
                                            connection: connection,
-                                           version_description: work_version.description.presence)
+                                           version_description: work_version.version_description.presence)
   end
 
   def upload_responses(blobs)

--- a/db/migrate/20220901184555_version_description.rb
+++ b/db/migrate/20220901184555_version_description.rb
@@ -1,0 +1,5 @@
+class VersionDescription < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :work_versions, :description, :version_description
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -551,7 +551,7 @@ CREATE TABLE public.work_versions (
     published_edtf character varying,
     subtype text[] DEFAULT '{}'::text[],
     work_id bigint NOT NULL,
-    description character varying,
+    version_description character varying,
     published_at timestamp(6) without time zone,
     globus boolean DEFAULT false NOT NULL
 );
@@ -1259,6 +1259,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220808222722'),
 ('20220812205204'),
 ('20220824225302'),
-('20220829114247');
+('20220829114247'),
+('20220901184555');
 
 

--- a/spec/components/works/detail_component_spec.rb
+++ b/spec/components/works/detail_component_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe Works::DetailComponent, type: :component do
   end
 
   context 'when deposited' do
-    let(:work_version) { build_stubbed(:work_version, :deposited, version: 2, description: 'changed the title') }
+    let(:work_version) do
+      build_stubbed(:work_version, :deposited, version: 2, version_description: 'changed the title')
+    end
 
     it 'renders the draft title' do
       expect(rendered.css('.state').to_html).not_to include('Not deposited')

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     license { 'CC0-1.0' }
     access { 'world' }
     state { 'first_draft' }
-    description { 'initial version' }
+    version_description { 'initial version' }
     published_at { Time.zone.parse('2019-01-01') }
     globus { false }
     work

--- a/spec/jobs/deposit_job_spec.rb
+++ b/spec/jobs/deposit_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe DepositJob do
   let(:attached_file) { build(:attached_file) }
   let(:work) { build(:work, collection: collection, assign_doi: false) }
   let(:work_version) do
-    build(:work_version, id: 8, work: work, attached_files: [attached_file], description: 'Updated metadata')
+    build(:work_version, id: 8, work: work, attached_files: [attached_file], version_description: 'Updated metadata')
   end
   let(:collection) { build(:collection, druid: 'druid:bc123df4567', doi_option: 'depositor-selects') }
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2575  -- i find the two different column names in work_version and collection_version that actually refer to the same sort of data to be confusing.  Also leads to some code complexity that is coming out of work in #2346 

## How was this change tested? 🤨

CI