### PR TITLE
Add file size and date uploaded to upload file display

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -3,7 +3,7 @@
 
   <div class="form-check" data-complex-radio-target="selection">
     <%= form.radio_button :globus, false, class: 'form-check-input',
-      data: { action: 'complex-radio#disableUnselectedInputs' }    
+      data: { action: 'complex-radio#disableUnselectedInputs' }
     %>
     <%= form.label :globus, 'Upload files', class: 'form-check-label' %>
     <p>All file types are accepted. If you have a deposit that is over 10GB, or
@@ -37,7 +37,7 @@
       </template>
     </div>
   </div>
-  <div class="form-check" data-complex-radio-target="selection">
+  <div class="form-check pt-3" data-complex-radio-target="selection">
     <%= form.radio_button :globus, true, class: 'form-check-input',
       data: { action: 'complex-radio#disableUnselectedInputs' }
     %>

--- a/app/components/works/file_row_component.html.erb
+++ b/app/components/works/file_row_component.html.erb
@@ -1,12 +1,12 @@
-<div class="dz-preview dz-file-preview row pb-2 <%= 'dz-complete' if uploaded? %>" data-dropzone-target="preview">
-  <div class="thumb" class="col-md-1">
+<div class="dz-preview dz-file-preview row pb-3 pt-3 <%= 'dz-complete' if uploaded? %>" data-dropzone-target="preview">
+  <div class="thumb col-1">
     <img data-dz-thumbnail />
   </div>
-  <div class="col-4">
+  <div class="col-5 pt-2">
     <% if uploaded? %>
       <div data-dropzone-target="fileName">
         <span class="fa-regular fa-file" aria-hidden="true"></span>
-        <span><%= filename %>: <%= number_to_human_size(filesize) %>, <%= render LocalTimeComponent.new(datetime: date_uploaded, show_time: false) %></span>
+        <span><%= filename %>: <wbr><%= number_to_human_size(filesize) %>, <wbr><%= render LocalTimeComponent.new(datetime: date_uploaded, show_time: false) %></span>
       </div>
     <% else %>
       <div class="dz-filename" data-dropzone-target="fileName"><span data-dz-name></span></div>
@@ -19,29 +19,28 @@
         <div class="dz-error-message"><span data-dz-errormessage=""></span></div>
       </div>
     <% end %>
+    <div class="invalid-feedback">We were unable to upload your file due to size or other issues. Delete this file and try again.</div>
   </div>
 
-  <div class="upload-description col-5 row">
-    <div class="col-md-3">
-      <%= form.label :label, 'Description (optional)', class: 'col-form-label' %>
-      <%= render PopoverComponent.new key: 'work.description' %>
-    </div>
-    <div class="col-md-9">
-    <%= form.text_field :label, class: 'form-control' %>
-    </div>
+  <div class="upload-description col-4">
+      <div>
+        <%= form.label :label, 'Description (optional)' %>
+        <%= render PopoverComponent.new key: 'work.description' %>
+      </div>
+      <%= form.text_field :label, class: 'form-control' %>
   </div>
 
-  <div class="dz-details col-2">
+  <div class="dz-details col-1 d-flex align-items-center">
+    <div class="form-check">
     <%= form.hidden_field :_destroy %>
     <%= form.hidden_field :file %>
     <%= form.check_box :hide, class: 'form-check-input' %>
     <%= form.label :hide, 'Hide file', class: 'form-check-label col-form-label ' %>
     <%= render PopoverComponent.new key: 'work.hide_file' %>
+    </div>
   </div>
 
-  <div class="invalid-feedback col">We were unable to upload your file due to size or other issues. Delete this file and try again.</div>
-
-  <div class="col-1">
+  <div class="col-1 d-flex align-items-center">
     <%= button_tag type: 'button',
                    class: "dz-remove pull-right btn remove-file",
                    "aria-label": "Remove file",

--- a/app/components/works/file_row_component.html.erb
+++ b/app/components/works/file_row_component.html.erb
@@ -1,12 +1,12 @@
-<div class="dz-preview dz-file-preview row <%= 'dz-complete' if uploaded? %>" data-dropzone-target="preview">
+<div class="dz-preview dz-file-preview row pb-2 <%= 'dz-complete' if uploaded? %>" data-dropzone-target="preview">
   <div class="thumb" class="col-md-1">
     <img data-dz-thumbnail />
   </div>
-  <div class="col-md-2">
-    <% if filename %>
-      <div class="dz-filename" data-dropzone-target="fileName">
-        <span class="fa-solid fa-check file-uploaded" aria-hidden="true"></span>
-        <span><%= filename %></span>
+  <div class="col-4">
+    <% if uploaded? %>
+      <div data-dropzone-target="fileName">
+        <span class="fa-regular fa-file" aria-hidden="true"></span>
+        <span><%= filename %>: <%= number_to_human_size(filesize) %>, <%= render LocalTimeComponent.new(datetime: date_uploaded, show_time: false) %></span>
       </div>
     <% else %>
       <div class="dz-filename" data-dropzone-target="fileName"><span data-dz-name></span></div>
@@ -21,9 +21,9 @@
     <% end %>
   </div>
 
-  <div class="upload-description col row">
+  <div class="upload-description col-5 row">
     <div class="col-md-3">
-      <%= form.label :label, 'Description', class: 'col-form-label' %>
+      <%= form.label :label, 'Description (optional)', class: 'col-form-label' %>
       <%= render PopoverComponent.new key: 'work.description' %>
     </div>
     <div class="col-md-9">
@@ -31,7 +31,7 @@
     </div>
   </div>
 
-  <div class="dz-details col-md-2">
+  <div class="dz-details col-2">
     <%= form.hidden_field :_destroy %>
     <%= form.hidden_field :file %>
     <%= form.check_box :hide, class: 'form-check-input' %>
@@ -41,7 +41,7 @@
 
   <div class="invalid-feedback col">We were unable to upload your file due to size or other issues. Delete this file and try again.</div>
 
-  <div class="col-md-1">
+  <div class="col-1">
     <%= button_tag type: 'button',
                    class: "dz-remove pull-right btn remove-file",
                    "aria-label": "Remove file",

--- a/app/components/works/file_row_component.html.erb
+++ b/app/components/works/file_row_component.html.erb
@@ -1,8 +1,8 @@
-<div class="dz-preview dz-file-preview row pb-3 pt-3 <%= 'dz-complete' if uploaded? %>" data-dropzone-target="preview">
+<div class="dz-preview dz-file-preview row py-3 <%= 'dz-complete' if uploaded? %>" data-dropzone-target="preview">
   <div class="thumb col-1">
     <img data-dz-thumbnail />
   </div>
-  <div class="col-5 pt-2">
+  <div class="col-5">
     <% if uploaded? %>
       <div data-dropzone-target="fileName">
         <span class="fa-regular fa-file" aria-hidden="true"></span>

--- a/app/components/works/file_row_component.rb
+++ b/app/components/works/file_row_component.rb
@@ -15,6 +15,18 @@ module Works
       form.object.model.filename
     end
 
+    def filesize
+      return unless uploaded?
+
+      form.object.model.byte_size
+    end
+
+    def date_uploaded
+      return unless uploaded?
+
+      form.object.model.created_at
+    end
+
     def uploaded?
       form.object.persisted?
     end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1359 - add file size and date uploaded to the work edit page for previously uploaded files.

NOTE: See comment trail for updated screenshots

What I have now: 

![Screen Shot 2022-09-02 at 12 40 24 PM](https://user-images.githubusercontent.com/47137/188225588-7fc35100-8103-4948-a8ad-bc2f6ce5bd4f.png)

What is should look like: https://github.com/sul-dlss/happy-heron/issues/1359#issuecomment-900828723

![](https://user-images.githubusercontent.com/42216982/129844010-774b6770-aaee-4025-8c3c-bca94522f3fe.png)

## How was this change tested? 🤨

Localhost browser


