### PR TITLE
Add version description to event history tables

### DIFF
--- a/app/components/collections/history_component.html.erb
+++ b/app/components/collections/history_component.html.erb
@@ -3,8 +3,8 @@
     <tr>
       <th scope="col" class="table-title col-3">History</th>
       <th scope="col">Modified by</th>
-      <th scope="col">Date</th>
-      <th scope="col"></th>
+      <th scope="col">Last modified</th>
+      <th scope="col">Description of changes</th>
     </tr>
   </thead>
   <tbody>

--- a/app/jobs/deposit_status_job.rb
+++ b/app/jobs/deposit_status_job.rb
@@ -29,7 +29,9 @@ class DepositStatusJob
       end
 
       Honeybadger.context(object: object.to_global_id.to_s)
-      parent(object).event_context = { user: sdr_user }
+
+      what_changed = object.head.version_description.presence || 'not specified'
+      parent(object).event_context = { user: sdr_user, description: "What changed: #{what_changed}" }
 
       object.head.deposit_complete!
     end

--- a/lib/tasks/deposit.rake
+++ b/lib/tasks/deposit.rake
@@ -1,20 +1,28 @@
 # frozen_string_literal: true
 
+# NOTE: This task is largely copypasta from the DepositStatusJob, with the logic
+#       divorced from any messaging or background job frameworks. We could
+#       consider extracting the common bits to a service?
 desc 'Complete deposit of works and collections (only for development)'
 task complete_deposits: :environment do
   abort 'ERROR: This task only runs in the development environment!' unless Rails.env.development?
 
-  objects_awaiting_deposit.each do |object|
+  objects_awaiting_deposit.each do |object_version|
     druid = random_druid
-    parent = case object
+    parent = case object_version
              when CollectionVersion
-               object.collection
+               object_version.collection
              when WorkVersion
-               object.work
+               object_version.work
              end
     parent.update(druid: druid)
-    object.deposit_complete!
-    puts "Marked #{object.class} id=#{object.id} as deposited with #{druid}"
+
+    what_changed = object_version.version_description.presence || 'not specified'
+    # NOTE: This user is created when seeding the database, a common practice running in dev.
+    parent.event_context = { user: User.find_by(name: 'SDR'), description: "What changed: #{what_changed}" }
+
+    object_version.deposit_complete!
+    puts "Marked #{object_version.class} id=#{object_version.id} as deposited with #{druid}"
   end
 end
 

--- a/spec/components/collections/history_component_spec.rb
+++ b/spec/components/collections/history_component_spec.rb
@@ -7,9 +7,13 @@ RSpec.describe Collections::HistoryComponent, type: :component do
 
   context 'when viewing a collection' do
     let(:collection) { build_stubbed(:collection) }
+    let(:table) { rendered.css('table').to_html }
 
-    it 'renders the history component' do
-      expect(rendered.css('table').to_html).to include('History')
+    it 'renders the history component w/ expected event table header labels' do
+      expect(table).to include('History')
+      expect(table).to include('Modified by')
+      expect(table).to include('Last modified')
+      expect(table).to include('Description of changes')
     end
   end
 end

--- a/spec/jobs/deposit_status_job_spec.rb
+++ b/spec/jobs/deposit_status_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DepositStatusJob do
 
   context 'with a work that is depositing' do
     let(:work_version) do
-      build(:work_version, :depositing, work: work)
+      build(:work_version, :depositing, work: work, version_description: 'A new version description')
     end
     let(:work) { create(:work, :with_druid, collection: collection, depositor: collection.managed_by.first) }
     let(:collection) { build(:collection, :with_managers) }
@@ -34,6 +34,7 @@ RSpec.describe DepositStatusJob do
       expect(work_version.reload).to be_deposited
       # Event is recorded for SDR, not work creator.
       expect(work_version.work.events.first.user.name).to eq('SDR')
+      expect(work_version.work.events.first.description).to eq('What changed: A new version description')
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2346
Fixes #2347

This commit injects the version description into the event context for both works and collections, so that the user-provided description is surfaced in work and collection event history.

Thanks for working on this and using the more idiomatic approach, @lwrubel!

Also includes:
* Align collection event history component with work event history component

### Before

![Screenshot from 2022-09-01 15-53-21](https://user-images.githubusercontent.com/131982/188027222-5ae109cb-9333-481b-8488-c46e8e466323.png)

### After

![Screenshot from 2022-09-01 15-48-25](https://user-images.githubusercontent.com/131982/188027229-82e6ebd5-cb46-4d2e-aa8e-e35178500226.png)

## How was this change tested? 🤨

CI, local dev, QA
