### PR TITLE
simplify recent activity on admin page

### DIFF
--- a/app/components/admin/collection_activity_row_component.html.erb
+++ b/app/components/admin/collection_activity_row_component.html.erb
@@ -1,5 +1,3 @@
 <tr>
   <td><%= link_to collection_title, collection, target: '_top' %></td>
-  <td><%= action %></td>
-  <td><%= render LocalTimeComponent.new(datetime: event_date) %></td>
 </tr>

--- a/app/components/admin/collection_activity_row_component.rb
+++ b/app/components/admin/collection_activity_row_component.rb
@@ -3,28 +3,16 @@
 module Admin
   # Renders a list of all collection events
   class CollectionActivityRowComponent < ApplicationComponent
-    with_collection_parameter :event
+    with_collection_parameter :collection
 
-    def initialize(event:)
-      @event = event
+    def initialize(collection:)
+      @collection = collection
     end
 
-    attr_reader :event
-
-    def collection
-      event.eventable
-    end
+    attr_reader :collection
 
     def collection_title
-      collection.head.name
-    end
-
-    def action
-      I18n.t(event.event_type, scope: 'event.type')
-    end
-
-    def event_date
-      event.created_at
+      CollectionTitlePresenter.show(collection.head)
     end
   end
 end

--- a/app/components/admin/collections_activity_table_component.html.erb
+++ b/app/components/admin/collections_activity_table_component.html.erb
@@ -2,11 +2,9 @@
   <thead class="table-light">
     <tr>
       <th>Collection Title</th>
-      <th>Activity</th>
-      <th>Date</th>
     </tr>
   </thead>
   <tbody>
-    <%= render(Admin::CollectionActivityRowComponent.with_collection(@events)) %>
+    <%= render(Admin::CollectionActivityRowComponent.with_collection(@collections)) %>
   </tbody>
 </table>

--- a/app/components/admin/collections_activity_table_component.rb
+++ b/app/components/admin/collections_activity_table_component.rb
@@ -3,8 +3,8 @@
 module Admin
   # Renders a table for collection activity
   class CollectionsActivityTableComponent < ApplicationComponent
-    def initialize(events:)
-      @events = events
+    def initialize(collections:)
+      @collections = collections
     end
   end
 end

--- a/app/components/admin/item_activity_row_component.html.erb
+++ b/app/components/admin/item_activity_row_component.html.erb
@@ -1,6 +1,4 @@
 <tr>
   <td><%= link_to item_title, item, target: '_top' %></td>
   <td><%= link_to collection_title, collection, target: '_top' %></td>
-  <td><%= action %></td>
-  <td><%= render LocalTimeComponent.new(datetime: event_date) %></td>
 </tr>

--- a/app/components/admin/item_activity_row_component.rb
+++ b/app/components/admin/item_activity_row_component.rb
@@ -3,34 +3,22 @@
 module Admin
   # Renders a list of all item events
   class ItemActivityRowComponent < ApplicationComponent
-    with_collection_parameter :event
+    with_collection_parameter :item
 
-    def initialize(event:)
-      @event = event
+    def initialize(item:)
+      @item = item
     end
 
-    attr_reader :event
-
-    def item
-      event.eventable
-    end
+    attr_reader :item
 
     def item_title
-      item.head.title
+      WorkTitlePresenter.show(item.head)
     end
 
     delegate :collection, to: :item
 
     def collection_title
-      collection.head.name
-    end
-
-    def action
-      I18n.t(event.event_type, scope: 'event.type')
-    end
-
-    def event_date
-      event.created_at
+      CollectionTitlePresenter.show(collection.head)
     end
   end
 end

--- a/app/components/admin/items_activity_table_component.html.erb
+++ b/app/components/admin/items_activity_table_component.html.erb
@@ -3,11 +3,9 @@
     <tr>
       <th>Item Title</th>
       <th>Collection Title</th>
-      <th>Activity</th>
-      <th>Date</th>
     </tr>
   </thead>
   <tbody>
-    <%= render(Admin::ItemActivityRowComponent.with_collection(@events)) %>
+    <%= render(Admin::ItemActivityRowComponent.with_collection(@items)) %>
   </tbody>
 </table>

--- a/app/components/admin/items_activity_table_component.rb
+++ b/app/components/admin/items_activity_table_component.rb
@@ -3,8 +3,8 @@
 module Admin
   # Renders a table for item activity
   class ItemsActivityTableComponent < ApplicationComponent
-    def initialize(events:)
-      @events = events
+    def initialize(items:)
+      @items = items
     end
   end
 end

--- a/app/components/admin/locked_item_row_component.rb
+++ b/app/components/admin/locked_item_row_component.rb
@@ -12,15 +12,18 @@ module Admin
     attr_reader :work
 
     delegate :collection, :druid_without_namespace, :owner, to: :work
-    delegate :title, to: :work_version
     delegate :sunetid, to: :owner
 
     def work_version
       work.head
     end
 
+    def title
+      WorkTitlePresenter.show(work_version)
+    end
+
     def collection_title
-      collection.head.name
+      CollectionTitlePresenter.show(collection.head)
     end
   end
 end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -13,12 +13,13 @@ class AdminsController < ApplicationController
   def items_recent_activity
     authorize! :admin_dashboard
     @days_limit = params.fetch(:days, 7).to_i
-    @events = Event.work_events.includes(:eventable).where('created_at > ?', @days_limit.days.ago)
+    @items = Work.joins(:head).where('work_versions.updated_at > ?',
+                                     @days_limit.days.ago).order('work_versions.updated_at DESC')
   end
 
   def collections_recent_activity
     authorize! :admin_dashboard
     @days_limit = params.fetch(:days, 7).to_i
-    @events = Event.collection_events.includes(:eventable).where('created_at > ?', @days_limit.days.ago)
+    @collections = Collection.where('updated_at > ?', @days_limit.days.ago).order('updated_at DESC')
   end
 end

--- a/app/forms/collection_settings_form.rb
+++ b/app/forms/collection_settings_form.rb
@@ -62,6 +62,13 @@ class CollectionSettingsForm < Reform::Form
     Work.joins(:head).where(collection: @model).exists?(['work_versions.embargo_date > ?', Time.zone.now])
   end
 
+  # rubocop:disable Rails/SkipsModelValidations
+  def save(*)
+    model.touch # ensure we set the updated_at column for collection when any participants are changed (e.g. depositor)
+    super
+  end
+  # rubocop:enable Rails/SkipsModelValidations
+
   def deserialize!(params)
     case params['license_option']
     when 'required'

--- a/app/views/admins/collections_recent_activity.html.erb
+++ b/app/views/admins/collections_recent_activity.html.erb
@@ -1,4 +1,4 @@
 <turbo-frame id="collectionsActivityFrame">
   <%= render Admin::ActivityTimeSelectorComponent.new(path: collections_recent_activity_admin_path, frame_id: 'collectionsActivityFrame', default_days: @days_limit) %>
-  <%= render Admin::CollectionsActivityTableComponent.new(events: @events) %>
+  <%= render Admin::CollectionsActivityTableComponent.new(collections: @collections) %>
 </turbo-frame>

--- a/app/views/admins/items_recent_activity.html.erb
+++ b/app/views/admins/items_recent_activity.html.erb
@@ -1,4 +1,4 @@
 <turbo-frame id="itemsActivityFrame">
   <%= render Admin::ActivityTimeSelectorComponent.new(path: items_recent_activity_admin_path, frame_id: 'itemsActivityFrame', default_days: @days_limit) %>
-  <%= render Admin::ItemsActivityTableComponent.new(events: @events) %>
+  <%= render Admin::ItemsActivityTableComponent.new(items: @items) %>
 </turbo-frame>

--- a/spec/requests/admins_spec.rb
+++ b/spec/requests/admins_spec.rb
@@ -44,8 +44,6 @@ RSpec.describe 'Admin dashboard' do
         expect(response.body).to include 'itemsActivityFrame'
         expect(response.body).to include work_version2.title
         expect(response.body).to include 'MyString'
-        expect(response.body).to include 'Updated by user'
-        expect(response.body).not_to include 'Embargo lifted'
       end
     end
 
@@ -61,8 +59,6 @@ RSpec.describe 'Admin dashboard' do
         expect(response.body).to include 'collectionsActivityFrame'
         expect(response.body).to include collection_version.name
         expect(response.body).to include 'MyString'
-        expect(response.body).to include 'Updated by user'
-        expect(response.body).not_to include 'Embargo lifted'
       end
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2567 - simplify recent activity tables in admin interface

Note: we are also simplifying the query and ignoring events, and just using the "last_updated" column on the work/collection versions, which means we will consider even a change to a title as a recent activity.  This required adding some hooks to ensure the updated_at column is touched when any bits of metadata in associated tables are changed.

Also, use title presenters for works and collections so that those in draft states and/or without entered titles will display correctly in the tables (e.g. they will show a linked "No title" instead of a URL or blank row).

## How was this change tested? 🤨

Localhost

