### PR TITLE
Remove unnecessary env variables from example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ See https://github.com/sul-dlss/happy-heron/wiki/Complete-deposits-locally for s
 To enable interactive debugging, invoke `bin/dev` as follows:
 
 ```
-REMOTE_DEBUGGER=byebug REMOTE_USER=auser@stanford.edu ROLES=dlss:hydrus-app-administrators bin/dev
+REMOTE_DEBUGGER=byebug bin/dev
 ```
 
 And then start up the debugger in another window (only byebug is supported at this time):


### PR DESCRIPTION
## Why was this change made? 🤔
Clearer example.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


