### PR TITLE
Extract deposit completer class from task and job

### DIFF
--- a/app/jobs/deposit_status_job.rb
+++ b/app/jobs/deposit_status_job.rb
@@ -13,7 +13,6 @@ class DepositStatusJob
   # these messages in addition to those that result from depositing in h2.
   from_queue 'h2.deposit_complete', env: nil
 
-  # rubocop:disable Metrics/AbcSize
   def work(msg)
     druid = parse_message(msg)
     Honeybadger.context(druid: druid)
@@ -22,22 +21,13 @@ class DepositStatusJob
     ActiveRecord::Base.connection_pool.with_connection do
       object = Work.find_by(druid: druid) || Collection.find_by(druid: druid)
 
-      unless object && object.head.depositing? # rubocop:disable Style/SafeNavigation
-        # This guards against objects from a different project and prevents
-        # invalid transitions where the workflow was kicked off outside of h2.
-        return ack!
-      end
-
       Honeybadger.context(object: object.to_global_id.to_s)
 
-      what_changed = object.head.version_description.presence || 'not specified'
-      parent(object).event_context = { user: sdr_user, description: "What changed: #{what_changed}" }
-
-      object.head.deposit_complete!
+      DepositCompleter.complete(object_version: object.head)
     end
+
     ack!
   end
-  # rubocop:enable Metrics/AbcSize
 
   def parse_message(msg)
     json = JSON.parse(msg)
@@ -45,15 +35,5 @@ class DepositStatusJob
     return druid if druid.present?
 
     raise "Unable to find required field 'druid' in payload:\n\t#{json}"
-  end
-
-  def parent(object)
-    # Though object and object.head.collection/object.head.work are the same in DB, they are not the same in memory.
-    # Thus, need to set event_context on the traversed parent object.
-    object.head.try(:collection) || object.head.work
-  end
-
-  def sdr_user
-    User.find_by!(name: 'SDR')
   end
 end

--- a/app/services/deposit_completer.rb
+++ b/app/services/deposit_completer.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Completes the deposit of an object
+class DepositCompleter
+  def self.complete(object_version:)
+    new(object_version: object_version).complete
+  end
+
+  attr_reader :object_version
+
+  def initialize(object_version:)
+    @object_version = object_version
+  end
+
+  def complete
+    # No-op unless object version is in a state that can transition to `deposit_complete`
+    return unless object_version&.can_deposit_complete?
+
+    parent.event_context = {
+      user: sdr_user,
+      description: "What changed: #{what_changed}"
+    }
+
+    object_version.deposit_complete!
+  end
+
+  def parent
+    # Though object and object.head.collection/object.head.work are the same in DB, they are not the same in memory.
+    # Thus, need to set event_context on the traversed parent object.
+    object_version.try(:collection) || object_version.work
+  end
+
+  private
+
+  def sdr_user
+    User.find_by!(name: 'SDR')
+  end
+
+  def what_changed
+    object_version.version_description.presence || 'not specified'
+  end
+end

--- a/lib/tasks/deposit.rake
+++ b/lib/tasks/deposit.rake
@@ -1,27 +1,14 @@
 # frozen_string_literal: true
 
-# NOTE: This task is largely copypasta from the DepositStatusJob, with the logic
-#       divorced from any messaging or background job frameworks. We could
-#       consider extracting the common bits to a service?
 desc 'Complete deposit of works and collections (only for development)'
 task complete_deposits: :environment do
   abort 'ERROR: This task only runs in the development environment!' unless Rails.env.development?
 
   objects_awaiting_deposit.each do |object_version|
-    druid = random_druid
-    parent = case object_version
-             when CollectionVersion
-               object_version.collection
-             when WorkVersion
-               object_version.work
-             end
-    parent.update(druid: druid)
-
-    what_changed = object_version.version_description.presence || 'not specified'
-    # NOTE: This user is created when seeding the database, a common practice running in dev.
-    parent.event_context = { user: User.find_by(name: 'SDR'), description: "What changed: #{what_changed}" }
-
-    object_version.deposit_complete!
+    deposit_completer = DepositCompleter.new(object_version: object_version)
+    druid = deposit_completer.parent.druid.presence || random_druid
+    deposit_completer.parent.update(druid: druid)
+    deposit_completer.complete
     puts "Marked #{object_version.class} id=#{object_version.id} as deposited with #{druid}"
   end
 end

--- a/spec/services/deposit_completer_spec.rb
+++ b/spec/services/deposit_completer_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DepositCompleter do
+  subject(:deposit_completer) { described_class.new(object_version: object_version) }
+
+  let(:work) { create(:work, :with_druid) }
+  let(:object_version) do
+    build(:work_version, state, work: work, version_description: version_description)
+  end
+  let(:state) { :depositing }
+  let(:version_description) { 'Fixing the title' }
+
+  describe '.complete' do
+    let(:instance) { described_class.new(object_version: object_version) }
+
+    before do
+      allow(described_class).to receive(:new).and_return(instance)
+      allow(instance).to receive(:complete)
+    end
+
+    it 'invokes #complete on a new instance' do
+      described_class.complete(object_version: object_version)
+      expect(instance).to have_received(:complete).once
+    end
+  end
+
+  describe '#object_version' do
+    it 'has an object version' do
+      expect(deposit_completer.object_version).to eq(object_version)
+    end
+  end
+
+  describe '#parent' do
+    context 'with a work version' do
+      it 'returns a work' do
+        expect(deposit_completer.parent).to be_a(Work)
+      end
+    end
+
+    context 'with a collection version' do
+      let(:object_version) do
+        build(:collection_version, state, version_description: version_description)
+      end
+
+      it 'returns a collection' do
+        expect(deposit_completer.parent).to be_a(Collection)
+      end
+    end
+  end
+
+  describe '#complete' do
+    context 'when object cannot transition to deposit_complete state' do
+      let(:state) { :first_draft }
+
+      it 'returns nil' do
+        expect(deposit_completer.complete).to be_nil
+      end
+    end
+
+    it 'transitions state to deposited' do
+      expect { deposit_completer.complete }.to change(object_version, :state).from('depositing').to('deposited')
+    end
+
+    it 'logs an event as expected' do
+      expect { deposit_completer.complete }.to change(Event, :count).by(1)
+      expect(Event.last.description).to eq("What changed: #{version_description}")
+      expect(Event.last.user.email).to eq('sdr@stanford.edu')
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

This commit better aligns how local dev handles completing deposits and how it is done in deployed environments. It reduces potential drift.


## How was this change tested? 🤨

CI, local, QA
