### PR TITLE
do not grey out unselected radio options

### DIFF
--- a/app/assets/stylesheets/workEditor.scss
+++ b/app/assets/stylesheets/workEditor.scss
@@ -13,9 +13,6 @@
     @include embargo;
     align-items: center;
 
-    input[type="radio"]:not(:checked) + label {
-      color: $btn-link-disabled-color;
-    }
     input[type="radio"]:checked + label {
       font-weight: bold;
     }


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2605 - do not grey out unselected labels next to radio buttons

Date drop downs are still made inactive if you select "immediately" since they are not applicable

This PR changes it to look like this:



![Screen Shot 2022-09-08 at 11 19 22 AM](https://user-images.githubusercontent.com/47137/189196897-e0d7e6b2-8077-494b-b935-800d2f3ddd34.png)

![Screen Shot 2022-09-08 at 11 19 26 AM](https://user-images.githubusercontent.com/47137/189196917-5bb3b193-b28e-40d6-a6e4-0924a9b3ad34.png)


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


