### PR TITLE
do not say a file description changed if it is blank

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -25,8 +25,9 @@ class WorksController < ObjectsController
     authorize! work_version
 
     @form = work_form(work_version)
-    event_context = build_event_context(@form)
     if @form.validate(work_params) && @form.save
+      # `changed?(field)` on a reform form object needs to be asked after persistence on new records
+      event_context = build_event_context(@form)
       after_save(form: @form, event_context: event_context)
     else
       @form.prepopulate!
@@ -59,6 +60,7 @@ class WorksController < ObjectsController
     authorize! work_version
 
     @form = work_form(work_version)
+    # `changed?(field)` on a reform form object needs to be asked before persistence on existing records
     event_context = build_event_context(context_form(orig_work_version, orig_clean_params))
     if @form.validate(clean_params) && @form.save
       after_save(form: @form, event_context: event_context)

--- a/app/services/work_version_event_description_builder.rb
+++ b/app/services/work_version_event_description_builder.rb
@@ -22,7 +22,7 @@ class WorkVersionEventDescriptionBuilder
   end
 
   def title
-    'title of deposit modified' if form.changed?(:title)
+    'title of deposit modified' if form.changed?('title')
   end
 
   def abstract
@@ -109,6 +109,6 @@ class WorkVersionEventDescriptionBuilder
   end
 
   def assign_doi
-    'assign DOI modified' if form.changed?(:assign_doi)
+    'assign DOI modified' if form.changed?('assign_doi')
   end
 end

--- a/app/services/work_version_event_description_builder.rb
+++ b/app/services/work_version_event_description_builder.rb
@@ -80,6 +80,8 @@ class WorkVersionEventDescriptionBuilder
   end
 
   def files
+    return unless form.input_params
+
     attributes = form.input_params[:attached_files_attributes]
     return unless attributes
 
@@ -99,7 +101,7 @@ class WorkVersionEventDescriptionBuilder
   end
 
   def file_description
-    'file description changed' if form.attached_files.any? { |af| af.changed?('label') }
+    'file description changed' if form.attached_files.any? { |af| af.changed?('label') && af.label.present? }
   end
 
   def related_works

--- a/spec/features/update_existing_work_spec.rb
+++ b/spec/features/update_existing_work_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Update an existing work in a deposited collection', js: true do
+  let(:user) { create(:user) }
+  let(:collection_version) { create(:collection_version, :deposited, collection: collection) }
+  let(:collection) { create(:collection, :depositor_selects_access, creator: user, depositors: [user]) }
+  let(:work_version) { create(:work_version_with_work, collection: collection, owner: user, title: original_title) }
+  let(:original_title) { 'Not an interesting title' }
+  let(:new_title) { 'A much better title' }
+
+  before do
+    collection.update(head: collection_version)
+    sign_in user, groups: ['dlss:hydrus-app-collection-creators']
+    allow(Settings).to receive(:allow_sdr_content_changes).and_return(true)
+  end
+
+  it 'updates the work and adds to the event description history' do
+    visit work_path(work_version.work)
+
+    within '#events' do
+      # nothing in the history of events yet
+      expect(page).not_to have_content 'title of deposit modified, abstract modified'
+    end
+
+    click_link "Edit #{original_title}"
+
+    # breadcrumbs showing
+    find('#breadcrumbs') do |nav|
+      expect(nav).to have_content('Dashboard')
+      expect(nav).to have_content(collection_version.name)
+      expect(nav).to have_content(original_title)
+    end
+
+    # update the title and abstract
+    fill_in 'Title of deposit', with: new_title
+    fill_in 'Abstract', with: 'I did really cool stuff'
+
+    click_button 'Save as draft'
+
+    # work detail page has new title
+    expect(page).to have_content(new_title)
+    expect(page).not_to have_content(original_title)
+    expect(page).to have_link(collection_version.name)
+
+    within '#events' do
+      # The things that have been updated should only be logged in one event
+      expect(page).to have_content 'title of deposit modified, abstract modified', count: 1
+    end
+  end
+end

--- a/spec/services/work_version_event_description_builder_spec.rb
+++ b/spec/services/work_version_event_description_builder_spec.rb
@@ -128,6 +128,34 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
     it { is_expected.to include 'file visibility changed' }
   end
 
+  context 'when file label has changed' do
+    before do
+      allow(AttachedFile).to receive(:new).and_return(AttachedFile.new)
+
+      form.validate(
+        attached_files: [
+          { 'label' => 'a new label!', 'hide' => false, 'file' => '123782312abcdef' }
+        ]
+      )
+    end
+
+    it { is_expected.to include 'file description changed' }
+  end
+
+  context 'when file label has not changed' do
+    before do
+      allow(AttachedFile).to receive(:new).and_return(AttachedFile.new)
+
+      form.validate(
+        attached_files: [
+          { 'label' => '', 'hide' => false, 'file' => '123782312abcdef' }
+        ]
+      )
+    end
+
+    it { is_expected.not_to include 'file description changed' }
+  end
+
   context 'when title has changed' do
     before do
       form.validate(title: 'new title')
@@ -157,7 +185,7 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
         subtype: %w[foo bar],
         assign_doi: 'false',
         attached_files_attributes: { '0' =>
-                      { 'label' => '', '_destroy' => 'false', 'hide' => '0',
+                      { 'label' => 'a label', '_destroy' => 'false', 'hide' => '0',
                         'file' => 'eyJfcmFpbHMiOnsibWVzc2FnZS...' } }
       )
     end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2633 - if a user uploads a file, but adds no description, we do not want to record the file description as changed (it currently says it's change even though it is blank, even though it technically "changed", so we just ignore if blank)

More importantly, I also noticed the the reform `changed?` method we use in `WorkVersionEventDescriptionBuilder` seems to indicate some attributes aren't changed, when they actually have.  I was having trouble getting this to work until I did some debugging and saw this.   I suspect that's because we are passing the form to this builder *after* we have persisted to the database, and perhaps this is altering the logic (update: but only for the update action for existing objects)

Event description updates for existing objects has been broken until now, and there didn't appear to be any tests to catch it.

This PR addresses this by building the context before the model is persisted and then passing it along to the method that needs it (for updates).

## How was this change tested? 🤨

Localhost, a new spec to verify that event descriptions are recorded for updating existing works; existing CI


