### PR TITLE
Remove impossible test.

### DIFF
--- a/spec/jobs/deposit_job_spec.rb
+++ b/spec/jobs/deposit_job_spec.rb
@@ -149,27 +149,6 @@ RSpec.describe DepositJob do
       end
     end
 
-    context 'when files have not changed and druid is nil' do
-      # The attached files for this version are the same as the previous version.
-      let(:second_work_version_metadata_only) do
-        build(:work_version, work: work, attached_files: [attached_file], version: 1,
-                             version_description: 'Updated metadata')
-      end
-      let(:work) { build(:work, collection: collection, assign_doi: false) } # NOTE: no druid provided
-
-      before do
-        allow(SdrClient::Find).to receive(:run).and_raise(SdrClient::Find::Failed, 'druid not found!')
-        allow(SdrClient::Deposit::CreateResource).to receive(:run)
-        work.work_versions = [first_work_version, second_work_version_metadata_only]
-      end
-
-      it 'does not run an SDR find operation' do
-        described_class.perform_now(second_work_version_metadata_only)
-
-        expect(SdrClient::Find).not_to have_received(:run)
-      end
-    end
-
     context 'when files have changed' do
       before do
         allow(SdrClient::Deposit::UploadFiles).to receive(:upload)


### PR DESCRIPTION
## Why was this change made? 🤔
This test is impossible: it cannot be the case that an update is being performed on a work without a druid. The druid is what determines if a create or an update.

This test was attempting to test the handling of a situation that only occurred because there was a different bug in the code (related to find previous versions). Once that was fixed, this test became impossible.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


