### PR TITLE
New works and collections should say "Created" in the description of changes

### DIFF
--- a/app/controllers/first_draft_collections_controller.rb
+++ b/app/controllers/first_draft_collections_controller.rb
@@ -25,9 +25,12 @@ class FirstDraftCollectionsController < ObjectsController
     @form = collection_form(collection_version)
 
     if @form.validate(create_params) && @form.save
-      collection_version.collection.event_context = { user: current_user }
+      collection_version.collection.event_context = { user: current_user, description: 'Created' }
       collection_version.update_metadata!
-      collection_version.begin_deposit! if deposit_button_pushed?
+      if deposit_button_pushed?
+        collection_version.collection.event_context = { user: current_user }
+        collection_version.begin_deposit!
+      end
       redirect_to collection_path(collection)
     else
       render :new, status: :unprocessable_entity

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -26,9 +26,7 @@ class WorksController < ObjectsController
 
     @form = work_form(work_version)
     if @form.validate(work_params) && @form.save
-      # `changed?(field)` on a reform form object needs to be asked after persistence on new records
-      event_context = build_event_context(@form)
-      after_save(form: @form, event_context: event_context)
+      after_save(form: @form, event_context: { user: current_user, description: 'Created' })
     else
       @form.prepopulate!
       render :new, status: :unprocessable_entity

--- a/spec/features/create_new_collection_spec.rb
+++ b/spec/features/create_new_collection_spec.rb
@@ -42,6 +42,13 @@ RSpec.describe 'Create a new collection', js: true do
       expect(page).to have_content name
       expect(page).to have_content('Depositing')
 
+      within '#events' do
+        # New collection gets an updated event with a description of "Created" and then a deposited event
+        expect(page).to have_content 'Updated', count: 1
+        expect(page).to have_content 'Created', count: 1 # description of the updated event
+        expect(page).to have_content 'Submitted for deposit', count: 1
+      end
+
       # Simulate the deposit process
       CollectionVersion.last.tap do |version|
         version.collection.update!(druid: 'druid:dc224fz4940')

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -162,8 +162,8 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
           expect(page).to have_content 'CC0-1.0'
 
           within '#events' do
-            # The things that have been updated should only be logged in one event
-            expect(page).to have_content 'title of deposit modified', count: 1
+            # New work gets a description of "Created"
+            expect(page).to have_content 'Created', count: 1
           end
         end
       end
@@ -381,8 +381,8 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
           expect(page).to have_content 'CC0-1.0'
 
           within '#events' do
-            # The things that have been updated should only be logged in one event
-            expect(page).to have_content 'title of deposit modified', count: 1
+            # New work gets a description of "Created"
+            expect(page).to have_content 'Created', count: 1
           end
         end
       end


### PR DESCRIPTION
## Why was this change made? 🤔

Currently when you create a new work, the description of changes in the "Updated by user" history event lists a bunch of fields.  When you create a new collection, the description of changes in the "Updated by user" history event is blank.

This makes both say "Created", which seems to make more sense for a brand new work or collection.

Note: a new version of an existing work will continue to list fields that were changed, as will a new version of an existing collection.  This change only applies to new works and collections.

~~Verify this change with PO.~~ Verified

## How was this change tested? 🤨

Localhost and updated tests.