### PR TITLE
correctly render new collection page link

### DIFF
--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -45,7 +45,7 @@
       </tr>
       <tr>
         <th class="col-3" scope="row">Collection</th>
-        <td><%= link_to collection_name, collection %></td>
+        <td><%= link_to collection_name, collection, target: '_top' %></td>
       </tr>
       <tr>
         <th class="col-3" scope="row">Deposit type</th>


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2641 - looks like a turbo/stimlus  issue with the link back to collection page, tell it to re-render the whole page

## How was this change tested? 🤨

Localhost