### PR TITLE
use work owner instead of depositor in work mailers

### DIFF
--- a/app/components/dashboard/approvals_component.html.erb
+++ b/app/components/dashboard/approvals_component.html.erb
@@ -5,7 +5,7 @@
     <thead class="table-light">
       <tr>
         <th>Deposit</th>
-        <th>Depositor</th>
+        <th>Owner</th>
         <th>Collection</th>
         <th>Deposit status</th>
         <th>Last modified</th>
@@ -15,7 +15,7 @@
     <% approvals.each do |submission| %>
       <tr>
         <%= render Works::LinkToShowComponent.new(work_version: submission) %>
-        <td><%= submission.work.depositor.sunetid %></td>
+        <td><%= submission.work.owner.sunetid %></td>
         <td><%= render Collections::LinkToShowComponent.new(collection_version: submission.work.collection.head) %></td>
         <td><%= render Works::StateDisplayComponent.new(work_version: submission) %></td>
         <td><%= render LocalTimeComponent.new(datetime: submission.updated_at, show_time: false) %></td>

--- a/app/mailers/works_mailer.rb
+++ b/app/mailers/works_mailer.rb
@@ -18,15 +18,14 @@ class WorksMailer < ApplicationMailer
 
   def first_draft_reminder_email
     @work = params[:work_version].work
-    @user = UserPresenter.new(user: @work.depositor)
+    @user = UserPresenter.new(user: @work.owner)
     subject = "Reminder: Deposit to the #{@work.collection_name} collection in the SDR is in progress"
-
     mail(to: @user.email, subject: subject)
   end
 
   def new_version_reminder_email
     @work = params[:work_version].work
-    @user = UserPresenter.new(user: @work.depositor)
+    @user = UserPresenter.new(user: @work.owner)
 
     subject = "Reminder: New version of a deposit to the #{@work.collection_name} collection in the SDR is in progress"
 
@@ -69,7 +68,7 @@ class WorksMailer < ApplicationMailer
   def globus_deposited_email
     @work_version = params[:work_version]
     @work = @work_version.work
-    @user = UserPresenter.new(user: @work.depositor)
+    @user = UserPresenter.new(user: @work.owner)
     mail(to: Settings.notifications.admin_email, subject: 'User has deposited an item with files on Globus')
   end
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -54,6 +54,7 @@ class Work < ApplicationRecord
   end
 
   delegate :name, to: :depositor, prefix: true
+  delegate :name, to: :owner, prefix: true
   delegate :purl_reservation?, to: :head
 
   private

--- a/app/services/work_observer.rb
+++ b/app/services/work_observer.rb
@@ -49,7 +49,7 @@ class WorkObserver
 
   def self.after_submit_for_review(work_version, _transition)
     collection = work_version.work.collection
-    (collection.reviewed_by + collection.managed_by - [work_version.work.depositor]).each do |recipient|
+    (collection.reviewed_by + collection.managed_by - [work_version.work.owner]).each do |recipient|
       ReviewersMailer.with(user: recipient, work_version: work_version).submitted_email.deliver_later
     end
     work_mailer(work_version).submitted_email.deliver_later
@@ -64,7 +64,7 @@ class WorkObserver
   end
 
   def self.work_mailer(work_version)
-    WorksMailer.with(user: work_version.work.depositor, work_version: work_version)
+    WorksMailer.with(user: work_version.work.owner, work_version: work_version)
   end
   private_class_method :work_mailer
 end

--- a/app/views/reviewers_mailer/submitted_email.html.erb
+++ b/app/views/reviewers_mailer/submitted_email.html.erb
@@ -1,6 +1,6 @@
 <p>Dear <%= @user.first_name %>,</p>
 
-<p>The Depositor <%= @work.depositor_name %> has submitted the deposit "<%= @work_version.title %>" for
+<p>The Depositor <%= @work.owner_name %> has submitted the deposit "<%= @work_version.title %>" for
   review in the <%= @work.collection_name %> collection. You can access this item directly at <%= link_to work_url(@work), work_url(@work) %></p>
 
 <p>Please see the list of pending approvals at the top of the dashboard page for this collection at <%= link_to dashboard_url, dashboard_url %>, where you will be able to select items to review and approve.</p>

--- a/spec/mailers/reviewers_mailer_spec.rb
+++ b/spec/mailers/reviewers_mailer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ReviewersMailer, type: :mailer do
   describe 'submitted_email' do
     let(:user) { build(:user, name: 'Al Dente', first_name: 'Fred') }
     let(:mail) { described_class.with(user: user, work_version: work_version).submitted_email }
-    let(:work) { build_stubbed(:work, collection: collection, depositor: user) }
+    let(:work) { build_stubbed(:work, collection: collection, depositor: user, owner: user) }
     let(:work_version) { build_stubbed(:work_version, :pending_approval, work: work, title: 'Test title') }
     let(:collection) { build(:collection, :with_reviewers, head: collection_version) }
     let(:collection_version) { build(:collection_version, name: 'small batch organic') }

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -393,7 +393,7 @@ RSpec.describe WorkVersion do
             .to('deposited')
             .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                    'WorksMailer', 'deposited_email', 'deliver_now',
-                   { params: { user: work.depositor, work_version: work_version }, args: [] }
+                   { params: { user: work.owner, work_version: work_version }, args: [] }
                  ))
             .and change(Event, :count).by(1)
         end
@@ -413,11 +413,11 @@ RSpec.describe WorkVersion do
             .to('deposited')
             .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                    'WorksMailer', 'deposited_email', 'deliver_now',
-                   { params: { user: work.depositor, work_version: work_version }, args: [] }
+                   { params: { user: work.owner, work_version: work_version }, args: [] }
                  ))
             .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                    'WorksMailer', 'globus_deposited_email', 'deliver_now',
-                   { params: { user: work.depositor, work_version: work_version }, args: [] }
+                   { params: { user: work.owner, work_version: work_version }, args: [] }
                  ))
             .and change(Event, :count).by(1)
         end
@@ -434,7 +434,7 @@ RSpec.describe WorkVersion do
             .to('deposited')
             .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                    'WorksMailer', 'new_version_deposited_email', 'deliver_now',
-                   { params: { user: work.depositor, work_version: work_version }, args: [] }
+                   { params: { user: work.owner, work_version: work_version }, args: [] }
                  ))
             .and change(Event, :count).by(1)
         end
@@ -449,7 +449,7 @@ RSpec.describe WorkVersion do
             .to('deposited')
             .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                    'WorksMailer', 'approved_email', 'deliver_now',
-                   { params: { user: work.depositor, work_version: work_version }, args: [] }
+                   { params: { user: work.owner, work_version: work_version }, args: [] }
                  ))
             .and change(Event, :count).by(1)
         end
@@ -459,11 +459,12 @@ RSpec.describe WorkVersion do
     describe 'a submit_for_review event' do
       let(:collection) { build(:collection, reviewed_by: [depositor, reviewer]) }
       let(:depositor) { build(:user) }
+      let(:owner) { build(:user) }
       let(:reviewer) { build(:user) }
 
       context 'when work is first_draft' do
         let(:work_version) { create(:work_version, :first_draft, work: work) }
-        let(:work) { create(:work, collection: collection, depositor: depositor) }
+        let(:work) { create(:work, collection: collection, depositor: depositor, owner: owner) }
 
         it 'transitions to pending_approval' do
           expect { work_version.submit_for_review! }
@@ -475,7 +476,7 @@ RSpec.describe WorkVersion do
                  ))
             .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                    'WorksMailer', 'submitted_email', 'deliver_now',
-                   { params: { user: depositor, work_version: work_version }, args: [] }
+                   { params: { user: owner, work_version: work_version }, args: [] }
                  ))
             .and change(Event, :count).by(1)
         end
@@ -483,7 +484,7 @@ RSpec.describe WorkVersion do
 
       context 'when work was rejected' do
         let(:work_version) { create(:work_version, :rejected, work: work) }
-        let(:work) { create(:work, collection: collection, depositor: depositor) }
+        let(:work) { create(:work, collection: collection, depositor: depositor, owner: owner) }
 
         it 'transitions to pending_approval' do
           expect { work_version.submit_for_review! }
@@ -495,7 +496,7 @@ RSpec.describe WorkVersion do
                  ))
             .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                    'WorksMailer', 'submitted_email', 'deliver_now',
-                   { params: { user: depositor, work_version: work_version }, args: [] }
+                   { params: { user: owner, work_version: work_version }, args: [] }
                  ))
             .and change(Event, :count).by(1)
         end
@@ -512,7 +513,7 @@ RSpec.describe WorkVersion do
           .to('rejected')
           .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                  'WorksMailer', 'reject_email', 'deliver_now',
-                 { params: { user: work.depositor, work_version: work_version }, args: [] }
+                 { params: { user: work.owner, work_version: work_version }, args: [] }
                ))
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2654 - when sending email notifications/reminders about work activity, we should send to the current **owner** not the **depositor**.  In many cases, these are the same person (and start out that way by default), but when an admin switches the work to a new owner, the new owner should be getting these notifications, not the original depositor.

## How was this change tested? 🤨

Updated CI