### PR TITLE
Remove capistrano-rvm dependency

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -10,7 +10,6 @@ require 'capistrano/scm/git'
 install_plugin Capistrano::SCM::Git
 
 require 'capistrano/bundler'
-require 'capistrano/rvm'
 require 'capistrano/rails'
 require 'capistrano/honeybadger'
 require 'capistrano/passenger'

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ group :deployment do
   gem 'capistrano-maintenance', '~> 1.2', require: false
   gem 'capistrano-passenger', require: false
   gem 'capistrano-rails', require: false
-  gem 'capistrano-rvm', require: false
   gem 'dlss-capistrano', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,9 +107,6 @@ GEM
     capistrano-rails (1.6.2)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     capybara (3.37.1)
       addressable
@@ -542,7 +539,6 @@ DEPENDENCIES
   capistrano-maintenance (~> 1.2)
   capistrano-passenger
   capistrano-rails
-  capistrano-rvm
   capybara (~> 3.34)
   capybara-screenshot
   config (~> 2.2)


### PR DESCRIPTION
## Why was this change made? 🤔

This commit removes capistrano-rvm, a dependency we no longer need. Done because it is on the FR board.



## How was this change tested? 🤨

Deployed to stage
