### PR TITLE
[HOLD] remove date last deposited filter in admin work report

### DIFF
--- a/app/controllers/admin/work_reports_controller.rb
+++ b/app/controllers/admin/work_reports_controller.rb
@@ -39,7 +39,6 @@ module Admin
     def report_params
       params.require(:work_report).permit(:date_created_start, :date_created_end,
                                           :date_modified_start, :date_modified_end,
-                                          :date_deposited_start, :date_deposited_end,
                                           :collection_id, state: [])
     end
   end

--- a/app/models/work_report.rb
+++ b/app/models/work_report.rb
@@ -11,6 +11,4 @@ class WorkReport
   attribute :date_created_end, :date
   attribute :date_modified_start, :date
   attribute :date_modified_end, :date
-  attribute :date_deposited_start, :date
-  attribute :date_deposited_end, :date
 end

--- a/app/services/admin/work_report_query.rb
+++ b/app/services/admin/work_report_query.rb
@@ -21,8 +21,6 @@ module Admin
       add_date_created_end_filter
       add_date_modified_start_filter
       add_date_modified_end_filter
-      add_date_deposited_start_filter
-      add_date_deposited_end_filter
       query.order('users.email ASC')
     end
 
@@ -71,20 +69,6 @@ module Admin
 
       self.query = query.where('work_versions.updated_at <= ?',
                                report.date_modified_end)
-    end
-
-    def add_date_deposited_start_filter
-      return unless report.date_deposited_start
-
-      self.query = query.where('work_versions.published_at >= ?',
-                               report.date_deposited_start)
-    end
-
-    def add_date_deposited_end_filter
-      return unless report.date_deposited_end
-
-      self.query = query.where('work_versions.published_at <= ?',
-                               report.date_deposited_end)
     end
   end
 end

--- a/app/views/admin/work_reports/new.html.erb
+++ b/app/views/admin/work_reports/new.html.erb
@@ -39,20 +39,6 @@
               <%= form.date_field :date_modified_end, class: 'form-control', max: Date.today, data: {'admin-date-range-target': "end", action: "admin-date-range#change"} %>
             </div>
           </div>
-
-          <div class="row g-3 mb-3" data-controller="admin-date-range">
-          <div class="col-sm-2">
-            <%= form.label :date_deposited_start, "Date last deposited range", class: 'col-form-label' %>
-          </div>
-          <div class="col-sm-3">
-            <%= form.date_field :date_deposited_start, class: 'form-control', max: Date.today, data: {'admin-date-range-target': "start", action: "admin-date-range#change"} %>
-          </div>
-          <div class="col-sm-1 text-center">
-            <%= form.label :date_deposited_end, "to", class: 'col-form-label' %>
-          </div>
-          <div class="col-sm-3">
-            <%= form.date_field :date_deposited_end, class: 'form-control', max: Date.today, data: {'admin-date-range-target': "end", action: "admin-date-range#change"} %>
-          </div>
         </div>
 
         <div class="mb-3">
@@ -74,10 +60,10 @@
           <%= form.collection_check_boxes(:state, states_in_order.map { |state| [state.to_s, I18n.t(state, scope: 'work.state')] }, :first, :last) do |b| %>
             <div class="form-check">
               <%= b.check_box class: 'form-check-input' %>
-              <%= b.label class: 'form-check-label' %> 
+              <%= b.label class: 'form-check-label' %>
             </div>
-          <% end %>  
-        </div>  
+          <% end %>
+        </div>
         <%= form.submit "Submit", class: 'btn btn-primary my-3' %>
       <% end %>
 
@@ -89,8 +75,6 @@
           <%= form.hidden_field :date_created_end %>
           <%= form.hidden_field :date_modified_start %>
           <%= form.hidden_field :date_modified_end %>
-          <%= form.hidden_field :date_deposited_start %>
-          <%= form.hidden_field :date_deposited_end %>
           <% @report.state.each do |state|%>
             <%= form.hidden_field :state, multiple: true, value: state %>
           <% end %>


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2661 - remove last deposited range filters for admin work reports (field still present in downloaded report when available).

## How was this change tested? 🤨

Localhost and CI