### PR TITLE
Add missing radio button bootstrap styles

### DIFF
--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -12,7 +12,7 @@
         <fieldset>
           <legend>Details</legend>
           <div class="row person-name-row" data-contributors-target="personName">
-            <div class="col-md-1">
+            <div class="col-md-1 form-check">
               <%= form.radio_button :with_orcid, 'false', html_options_for_radio(true, !orcid?) %>
             </div>
 
@@ -33,7 +33,7 @@
             <div class="col-md-1 pb-2"><strong>OR</strong></div>
           </div>
           <div class="row" data-contributors-target="personOrcid">
-            <div class="col-md-1">
+            <div class="col-md-1 form-check">
               <%= form.radio_button :with_orcid, 'true', html_options_for_radio(false, orcid?) %>
             </div>
             <div class="col">

--- a/app/components/works/contributor_row_component.rb
+++ b/app/components/works/contributor_row_component.rb
@@ -82,6 +82,7 @@ module Works
     def html_options_for_radio(is_name, checked)
       {
         checked: checked,
+        class: 'form-check-input',
         data: {}.tap do |data|
           actions = ['contributors#personChanged']
           actions << 'auto-citation#updateDisplay' if author?


### PR DESCRIPTION


## Why was this change made? 🤔
Consistency in the UI. This makes the radios the primary color. Now they match the look of the radios on the collection form.


## How was this change tested? 🤨
Old:
<img width="371" alt="Screen Shot 2022-09-13 at 10 26 44 AM" src="https://user-images.githubusercontent.com/92044/189942602-094524f4-0e71-4f54-b4bd-b8ddc49f8e69.png">


New:
<img width="386" alt="Screen Shot 2022-09-13 at 10 26 21 AM" src="https://user-images.githubusercontent.com/92044/189942502-b103d255-68a1-4a10-8dba-4324225d4caf.png">


