### PR TITLE
use work owner instead of depositor in collection mailers

### DIFF
--- a/app/mailers/collections_mailer.rb
+++ b/app/mailers/collections_mailer.rb
@@ -50,7 +50,7 @@ class CollectionsMailer < ApplicationMailer
   def first_draft_created
     @user = UserPresenter.new(user: params[:user])
     @collection_version = params[:collection_version]
-    @depositor = params[:depositor]
+    @owner = params[:owner]
 
     mail(to: @user.email, subject: "Draft item created in the #{@collection_version.name} collection")
   end
@@ -76,7 +76,7 @@ class CollectionsMailer < ApplicationMailer
   def item_deposited
     @user = UserPresenter.new(user: params[:user])
     @collection_version = params[:collection_version]
-    @depositor = params[:depositor]
+    @owner = params[:owner]
 
     mail(to: @user.email, subject: "Item deposit completed in the #{@collection_version.name} collection")
   end
@@ -84,7 +84,7 @@ class CollectionsMailer < ApplicationMailer
   def version_draft_created
     @user = UserPresenter.new(user: params[:user])
     @collection_version = params[:collection_version]
-    @depositor = params[:depositor]
+    @owner = params[:owner]
 
     mail(to: @user.email, subject: "New version created in the #{@collection_version.name} collection")
   end

--- a/app/services/collection_observer.rb
+++ b/app/services/collection_observer.rb
@@ -3,20 +3,20 @@
 # Actions that happen when something happens to a collection
 class CollectionObserver
   def self.first_draft_created(work_version, _transition)
-    collection_managers_excluding_depositor(work_version).each do |user|
-      mailer_with_depositor(user: user, work_version: work_version).first_draft_created.deliver_later
+    collection_managers_excluding_owner(work_version).each do |user|
+      mailer_with_owner(user: user, work_version: work_version).first_draft_created.deliver_later
     end
   end
 
   def self.item_deposited(work_version, _transition)
-    collection_managers_excluding_depositor(work_version).each do |user|
-      mailer_with_depositor(user: user, work_version: work_version).item_deposited.deliver_later
+    collection_managers_excluding_owner(work_version).each do |user|
+      mailer_with_owner(user: user, work_version: work_version).item_deposited.deliver_later
     end
   end
 
   def self.version_draft_created(work_version, _transition)
-    collection_managers_excluding_depositor(work_version).each do |user|
-      mailer_with_depositor(user: user, work_version: work_version).version_draft_created.deliver_later
+    collection_managers_excluding_owner(work_version).each do |user|
+      mailer_with_owner(user: user, work_version: work_version).version_draft_created.deliver_later
     end
   end
 
@@ -44,19 +44,19 @@ class CollectionObserver
   end
   private_class_method :create_settings_updated_event
 
-  def self.collection_managers_excluding_depositor(work_version)
-    depositor = work_version.work.depositor
+  def self.collection_managers_excluding_owner(work_version)
+    owner = work_version.work.owner
     collection = work_version.work.collection
-    collection.managed_by.reject { |manager| manager == depositor }
+    collection.managed_by.reject { |manager| manager == owner }
   end
-  private_class_method :collection_managers_excluding_depositor
+  private_class_method :collection_managers_excluding_owner
 
-  def self.mailer_with_depositor(user:, work_version:)
-    depositor = work_version.work.depositor
+  def self.mailer_with_owner(user:, work_version:)
+    owner = work_version.work.owner
     collection = work_version.work.collection
-    CollectionsMailer.with(user: user, collection_version: collection.head, depositor: depositor)
+    CollectionsMailer.with(user: user, collection_version: collection.head, owner: owner)
   end
-  private_class_method :mailer_with_depositor
+  private_class_method :mailer_with_owner
 
   def self.depositors_added(collection_version, change_set)
     change_set.added_depositors.each do |depositor|

--- a/app/views/collections_mailer/first_draft_created.html.erb
+++ b/app/views/collections_mailer/first_draft_created.html.erb
@@ -1,6 +1,6 @@
 <p>Dear <%= @user.first_name %>,</p>
 
-<p>The Depositor <%= @depositor.name %> has created a draft in the <%= @collection_version.name %> collection.</p>
+<p>The Depositor <%= @owner.name %> has created a draft in the <%= @collection_version.name %> collection.</p>
 
 <p>If you have any questions, contact the SDR team at: <%= link_to contact_form_url, contact_form_url %></p>
 

--- a/app/views/collections_mailer/item_deposited.html.erb
+++ b/app/views/collections_mailer/item_deposited.html.erb
@@ -1,6 +1,6 @@
 <p>Dear <%= @user.first_name %>,</p>
 
-<p>The Depositor <%= @depositor.name %> has submitted a deposit in the <%= @collection_version.name %> collection.</p>
+<p>The Depositor <%= @owner.name %> has submitted a deposit in the <%= @collection_version.name %> collection.</p>
 
 <p>If you have any questions, contact the SDR team at: <%= link_to contact_form_url, contact_form_url %></p>
 

--- a/app/views/collections_mailer/version_draft_created.html.erb
+++ b/app/views/collections_mailer/version_draft_created.html.erb
@@ -1,6 +1,6 @@
 <p>Dear <%= @user.first_name %>,</p>
 
-<p>The Depositor <%= @depositor.name %> has started a new version in the <%= @collection_version.name %> collection.</p>
+<p>The Depositor <%= @owner.name %> has started a new version in the <%= @collection_version.name %> collection.</p>
 
 <p>If you have any questions, contact the SDR team at: <%= link_to contact_form_url, contact_form_url %></p>
 

--- a/spec/jobs/deposit_status_job_spec.rb
+++ b/spec/jobs/deposit_status_job_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe DepositStatusJob do
         'CollectionsMailer', 'item_deposited', 'deliver_now',
         { params: {
           user: collection.managed_by.last,
-          depositor: work.depositor,
+          owner: work.owner,
           collection_version: collection_version
         }, args: [] }
       )

--- a/spec/mailers/collections_mailer_spec.rb
+++ b/spec/mailers/collections_mailer_spec.rb
@@ -157,11 +157,11 @@ RSpec.describe CollectionsMailer, type: :mailer do
 
   describe '#first_draft_created' do
     let(:user) { a_user }
-    let(:depositor) { build(:user, name: 'Audre Lorde', first_name: 'Queueueue') }
+    let(:owner) { build(:user, name: 'Audre Lorde', first_name: 'Queueueue') }
 
     let(:mail) do
       described_class.with(user: user, collection_version: collection_version,
-                           depositor: depositor).first_draft_created
+                           owner: owner).first_draft_created
     end
     let(:collection) { build(:collection) }
 
@@ -172,7 +172,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
     end
 
     it 'renders the body' do
-      expect(mail.body.encoded).to match "The Depositor #{depositor.name} has created a draft"
+      expect(mail.body.encoded).to match "The Depositor #{owner.name} has created a draft"
       expect(mail.body.encoded).to match "in the #{collection_name} collection"
     end
 
@@ -218,10 +218,10 @@ RSpec.describe CollectionsMailer, type: :mailer do
 
   describe '#item_deposited' do
     let(:user) { a_user }
-    let(:depositor) { build(:user, name: 'Audre Lorde', first_name: 'Queueueue') }
+    let(:owner) { build(:user, name: 'Audre Lorde', first_name: 'Queueueue') }
 
     let(:mail) do
-      described_class.with(user: user, collection_version: collection_version, depositor: depositor).item_deposited
+      described_class.with(user: user, collection_version: collection_version, owner: owner).item_deposited
     end
     let(:collection) { build(:collection) }
 
@@ -232,7 +232,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
     end
 
     it 'renders the body' do
-      expect(mail.body.encoded).to match "The Depositor #{depositor.name} has submitted a deposit"
+      expect(mail.body.encoded).to match "The Depositor #{owner.name} has submitted a deposit"
       expect(mail.body.encoded).to match "in the #{collection_name} collection"
     end
 
@@ -244,11 +244,11 @@ RSpec.describe CollectionsMailer, type: :mailer do
 
   describe '#version_draft_created' do
     let(:user) { a_user }
-    let(:depositor) { build(:user, name: 'Audre Lorde') }
+    let(:owner) { build(:user, name: 'Audre Lorde') }
 
     let(:mail) do
       described_class.with(user: user, collection_version: collection_version,
-                           depositor: depositor).version_draft_created
+                           owner: owner).version_draft_created
     end
     let(:collection) { build(:collection) }
 
@@ -259,7 +259,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
     end
 
     it 'renders the body' do
-      expect(mail.body.encoded).to match "The Depositor #{depositor.name} has started a new version"
+      expect(mail.body.encoded).to match "The Depositor #{owner.name} has started a new version"
       expect(mail.body.encoded).to match "in the #{collection_name} collection"
     end
 

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -363,7 +363,7 @@ RSpec.describe WorkVersion do
                                              'CollectionsMailer', 'first_draft_created', 'deliver_now',
                                              { params: {
                                                user: collection.managed_by.last,
-                                               depositor: work.depositor,
+                                               owner: work.owner,
                                                collection_version: collection_version
                                              }, args: [] }
                                            ))


### PR DESCRIPTION
## Why was this change made? 🤔

Similar to #2663, the work owner is used instead of the depositor when sending email notifications (in this case, for the collection emails, in the case of #2663, for the work related emails).

Note that the text of a couple of the emails looks like this:

"The Depositor XXXX has started a new version"

Not sure if we want to change the text in the email to say "The Owner XXX...", to me that seems a bit awkward and oddly worded for an end user, even if technically correct.

## How was this change tested? 🤨

Updated tests


