### PR TITLE
remove attached files when globus option is selected

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -157,6 +157,8 @@ class WorksController < ObjectsController
   def after_save(form:, event_context:)
     work_version = form.model[:work_version]
     work = form.model[:work]
+    # if the user selects globus uploads, we cannot have any attached files
+    work_version.attached_files.destroy_all if work_version.globus
     work.event_context = event_context
     work_version.update_metadata!
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -157,8 +157,6 @@ class WorksController < ObjectsController
   def after_save(form:, event_context:)
     work_version = form.model[:work_version]
     work = form.model[:work]
-    # if the user selects globus uploads, we cannot have any attached files
-    work_version.attached_files.destroy_all if work_version.globus
     work.event_context = event_context
     work_version.update_metadata!
 

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -140,8 +140,12 @@ class DraftWorkForm < Reform::Form
     model[:work]
   end
 
+  def work_version
+    model[:work_version]
+  end
+
   def version_description
-    return if model.fetch(:work_version).deposited?
+    return if work_version.deposited?
 
     super
   end
@@ -157,7 +161,9 @@ class DraftWorkForm < Reform::Form
   # Ensure that this work version is now the head of the work versions for this work
   def save_model
     super
-    work.update(head: model.fetch(:work_version))
+    # if the user selects globus uploads, we cannot have any attached files
+    work_version.attached_files.destroy_all if work_version.globus
+    work.update(head: work_version)
   end
 
   # Override reform so that this looks just like a Work

--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -11,10 +11,6 @@ class WorkForm < DraftWorkForm
                              unless: lambda {
                                        ::ActiveRecord::Type::Boolean.new.cast(globus)
                                      }
-  validates :attached_files, length: { maximum: 0, message: 'Please remove all files.' },
-                             if: lambda {
-                                   ::ActiveRecord::Type::Boolean.new.cast(globus)
-                                 }
   validates :contact_emails, length: { minimum: 1, message: 'Please add at least contact email.' }
   validates :license, presence: true, inclusion: { in: License.license_list }
   validates :authors, length: { minimum: 1, message: 'Please add at least one author.' }

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -344,10 +344,9 @@ RSpec.describe WorkForm do
       expect(messages).to eq ['Please add at least one file.']
     end
 
-    it 'does not validate when has files and globus is true' do
+    it 'validates when has files and globus is true' do
       form.validate(attached_files: [{ 'label' => 'hello', 'hide' => true, 'file' => blob.signed_id }], globus: true)
-      expect(form).not_to be_valid
-      expect(messages).to eq ['Please remove all files.']
+      expect(messages).to be_empty
     end
 
     it 'validates when no files and globus is true' do

--- a/spec/requests/edit_work_spec.rb
+++ b/spec/requests/edit_work_spec.rb
@@ -138,6 +138,32 @@ RSpec.describe 'Updating an existing work' do
             expect(response).to redirect_to(next_step_work_path(work))
           end
         end
+
+        context 'with globus upload selected' do
+          before { work_params[:globus] = true }
+
+          context 'when deposited' do
+            it 'removes any attached files' do
+              expect(work.head.attached_files.count).to eq 1
+              patch "/works/#{work.id}", params: { work: work_params, commit: 'Deposit' }
+              expect(WorkVersion.where(work: work).count).to eq 2
+              work.reload
+              expect(work.head.state).to eq 'depositing'
+              expect(work.head.attached_files.count).to eq 0
+            end
+          end
+
+          context 'when saved as draft' do
+            it 'removes any attached files' do
+              expect(work.head.attached_files.count).to eq 1
+              patch "/works/#{work.id}", params: { work: work_params, commit: 'Save as draft' }
+              expect(WorkVersion.where(work: work).count).to eq 2
+              work.reload
+              expect(work.head.state).to eq 'version_draft'
+              expect(work.head.attached_files.count).to eq 0
+            end
+          end
+        end
       end
 
       context 'with a validation problem' do


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2662 (see comments for discussion on the ticket that led to this outcome): if the user selects the "globus" option and saves the form  (draft or deposit), remove any attached files instead of throwing a validation error.

## How was this change tested? 🤨

Localhost and added new requests specs