### PR TITLE
show/hide file uploads panel depending on globus radio selection

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -1,47 +1,49 @@
-<section data-controller="complex-radio" id="file">
+<section data-controller="complex-radio file-uploads" id="file">
   <header>Add your files *</header>
 
   <div class="form-check" data-complex-radio-target="selection">
     <%= form.radio_button :globus, false, class: 'form-check-input',
-      data: { action: 'complex-radio#disableUnselectedInputs' }
+      data: { action: 'complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility' }
     %>
-    <%= form.label :globus, 'Upload files', class: 'form-check-label' %>
-    <p>All file types are accepted. If you have a deposit that is over 10GB, or
-      have any trouble with adding your files,
-      <%= link_to('contact us.', '#contactUsModal', data: {
-                                bs_toggle: 'modal',
-                                bs_target: '#contactUsModal' }) %>
-    </p>
-      <div data-controller="dropzone" data-dropzone-max-file-size="10000" data-dropzone-max-files="1000">
-      <fieldset>
-        <div class="dropzone dropzone-default" data-dropzone-target="container">
-          <%= form.file_field :files, multiple: true, direct_upload: true,
-                              data: { dropzone_target: 'input' } %>
-          <div class="dz-message needsclick text-secondary">
-            <p>Drop files here</p>
+    <%= form.label :globus, 'Upload files', class: 'form-check-label', style: 'font-weight: bold' %>
+    <div id="uploaded-files-panel" data-file-uploads-target="fileUploads">
+      <p>All file types are accepted. If you have a deposit that is over 10GB, or
+        have any trouble with adding your files,
+        <%= link_to('contact us.', '#contactUsModal', data: {
+                                  bs_toggle: 'modal',
+                                  bs_target: '#contactUsModal' }) %>
+      </p>
+        <div data-controller="dropzone" data-dropzone-max-file-size="10000" data-dropzone-max-files="1000">
+        <fieldset>
+          <div class="dropzone dropzone-default" data-dropzone-target="container">
+            <%= form.file_field :files, multiple: true, direct_upload: true,
+                                data: { dropzone_target: 'input' } %>
+            <div class="dz-message needsclick text-secondary">
+              <p>Drop files here</p>
+            </div>
           </div>
-        </div>
-        <span style="margin: .7rem">or</span> <button type="button" class="dz-clickable btn btn-outline-primary">Choose files</button>
-        <div class="invalid-feedback" data-dropzone-target="feedback">You must attach a file<%= error_message %></div>
-        <div class="dropzone-previews" data-dropzone-target="previewsContainer">
-          <%= form.fields_for :attached_files do |file_form| %>
+          <span style="margin: .7rem">or</span> <button type="button" class="dz-clickable btn btn-outline-primary">Choose files</button>
+          <div class="invalid-feedback" data-dropzone-target="feedback">You must attach a file<%= error_message %></div>
+          <div class="dropzone-previews" data-dropzone-target="previewsContainer">
+            <%= form.fields_for :attached_files do |file_form| %>
+              <%= render Works::FileRowComponent.new(form: file_form) %>
+            <% end %>
+          </div>
+        </fieldset>
+
+        <template data-dropzone-target='template'>
+          <%= form.fields_for :attached_files, AttachedFile.new, child_index: 'TEMPLATE_RECORD' do |file_form| %>
             <%= render Works::FileRowComponent.new(form: file_form) %>
           <% end %>
-        </div>
-      </fieldset>
-
-      <template data-dropzone-target='template'>
-        <%= form.fields_for :attached_files, AttachedFile.new, child_index: 'TEMPLATE_RECORD' do |file_form| %>
-          <%= render Works::FileRowComponent.new(form: file_form) %>
-        <% end %>
-      </template>
+        </template>
+      </div>
     </div>
   </div>
   <div class="form-check pt-3" data-complex-radio-target="selection">
-    <%= form.radio_button :globus, true, class: 'form-check-input',
-      data: { action: 'complex-radio#disableUnselectedInputs' }
+    <%= form.radio_button :globus, true, class: 'form-check-input', 'data-file-uploads-target': 'globusRadioButton',
+      data: { action: 'complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility' }
     %>
-    <%= form.label :globus, 'I have uploaded my files to a Globus endpoint provided to me by SDR staff.', class: 'form-check-label' %>
-    <p>Do not check this box unless you have already discussed this with SDR staff.</p>
+    <%= form.label :globus, 'I have uploaded my files to a Globus endpoint provided to me by SDR staff.', class: 'form-check-label', style: 'font-weight: bold' %>
+    <p><em>Only select this option if you have already discussed Globus with SDR staff.</em></p>
   </div>
 </section>

--- a/app/javascript/controllers/file_uploads_controller.js
+++ b/app/javascript/controllers/file_uploads_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = ["fileUploads", "globusRadioButton"]
+
+  connect() {
+    this.updatePanelVisibility()
+  }
+
+  updatePanelVisibility(_event) {
+    this.fileUploadsTarget.hidden = this.globusRadioButtonTarget.checked
+  }
+}


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2627 - show or hide the uploaded file panel depending on which radio button (globus or uploads) the user has chosen.  It now matches the design shown in the ticket.

## How was this change tested? 🤨

Localhost