### PR TITLE
Add radio button labels to improve accessability of authors/contributors

### DIFF
--- a/app/assets/stylesheets/workEditor.scss
+++ b/app/assets/stylesheets/workEditor.scss
@@ -77,8 +77,9 @@
       font-size: 1rem;
     }
 
-    .person-name-row {
+    .person-identifier-row {
       padding-bottom: 1.5rem;
+      margin-left: 0.8rem;
     }
 
     .form-text {

--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -11,11 +11,11 @@
       <div class="col" data-contributors-target="person">
         <fieldset>
           <legend>Details</legend>
-          <div class="row person-name-row" data-contributors-target="personName">
-            <div class="col-md-1 form-check">
-              <%= form.radio_button :with_orcid, 'false', html_options_for_radio(true, !orcid?) %>
-            </div>
-
+          <div class="form-check">
+            <%= form.radio_button :with_orcid, 'false', html_options_for_radio(true, !orcid?) %>
+            <%= form.label :with_orcid, 'Enter author name', value: 'false', class: 'form-check-label' %>
+          </div>
+          <div class="row person-identifier-row" data-contributors-target="personName">
             <div class="col-md-5">
               <%= form.label :first_name, first_name_label, class: 'form-label' %>
               <%= render PopoverComponent.new key: 'work.first_name' %>
@@ -29,13 +29,16 @@
             </div>
             <%= form.hidden_field :orcid %>
           </div>
+
           <div class="row">
             <div class="col-md-1 pb-2"><strong>OR</strong></div>
           </div>
-          <div class="row" data-contributors-target="personOrcid">
-            <div class="col-md-1 form-check">
-              <%= form.radio_button :with_orcid, 'true', html_options_for_radio(false, orcid?) %>
-            </div>
+          
+          <div class="form-check">
+            <%= form.radio_button :with_orcid, 'true', html_options_for_radio(false, orcid?) %>
+            <%= form.label :with_orcid, 'Enter ORCID iD', value: 'true', class: 'form-check-label' %>
+          </div>
+          <div class="row person-identifier-row" data-contributors-target="personOrcid">
             <div class="col">
               <%= form.label :orcid, orcid_label, class: 'form-label' %>
               <%= render PopoverComponent.new key: 'work.orcid' %>


### PR DESCRIPTION


## Why was this change made? 🤔
Ref #2642


## How was this change tested? 🤨

Locally:
Before:
<img width="715" alt="Screen Shot 2022-09-14 at 12 12 08 PM" src="https://user-images.githubusercontent.com/92044/190219240-65d5bb0c-1a92-4dd6-8fc3-80200a70bfb3.png">


After:
<img width="717" alt="Screen Shot 2022-09-14 at 12 11 25 PM" src="https://user-images.githubusercontent.com/92044/190219108-024034f6-ec73-437a-864c-b5967248b461.png">



