### PR TITLE
Replace bootstrap 4 class with bootstrap 5 class

### DIFF
--- a/app/components/works/keywords_row_component.html.erb
+++ b/app/components/works/keywords_row_component.html.erb
@@ -1,6 +1,6 @@
 <div class="mb-3 row plain-container g-0 keyword-row">
   <div class="col-sm-6">
-    <%= form.label :label, 'Keyword', class: 'col-form-label sr-only' %>
+    <%= form.label :label, 'Keyword', class: 'col-form-label visually-hidden' %>
     <div data-controller="keywords autocomplete autocomplete-edit" data-autocomplete-url-value="/autocomplete" data-autocomplete-min-length-value="3" class="dropdown">
       <%= form.text_field :label, { class: "form-control#{ 'is-invalid' if error?}", required: true, 'data-autocomplete-target': 'input', 'data-autocomplete-edit-target': 'input',
                 'data-keywords-target': 'input', 'data-action': 'blur->keywords#checkForDuplicates' } %>


### PR DESCRIPTION


## Why was this change made? 🤔
See https://getbootstrap.com/docs/5.0/migration/#helpers The only reason this happened to work is that fort-awesome also ships a .sr-only class


## How was this change tested? 🤨
locally