### PR TITLE
Allow removing all work subtypes.

### DIFF
--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -47,6 +47,7 @@ class DraftWorkForm < Reform::Form
   def deserialize!(params)
     # Choose between using the user provided citation and the auto-generated citation
     params['citation'] = params.delete('citation_auto') if params['default_citation'] == 'true'
+    params['subtype'] = [] unless params['subtype']
     deserialize_embargo(params)
     access_from_collection(params)
     deserialize_license(params)

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -192,4 +192,8 @@ FactoryBot.define do
       work_version.work.update(head: work_version)
     end
   end
+
+  trait :with_no_subtype do
+    subtype { [] }
+  end
 end

--- a/spec/requests/edit_work_spec.rb
+++ b/spec/requests/edit_work_spec.rb
@@ -79,9 +79,11 @@ RSpec.describe 'Updating an existing work' do
             expect(CollectionObserver).to have_received(:version_draft_created)
             expect(WorkVersion.where(work: work).count).to eq 2
             expect(work.reload.head).to be_version_draft
+            expect(work.head.subtype).to eq []
             # Only changed fields are recorded in event.
             expect(work.events.first.description).to eq('title of deposit modified, contact email modified, ' \
-                                                        'authors modified, file description changed')
+                                                        'authors modified, work subtypes modified, ' \
+                                                        'file description changed')
             expect(response).to redirect_to(work)
           end
         end

--- a/spec/services/work_version_event_description_builder_spec.rb
+++ b/spec/services/work_version_event_description_builder_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
   subject(:result) { described_class.build(form) }
 
   let(:collection) { build(:collection, :depositor_selects_access, :depositor_selects_release_date) }
-  let(:work_version) { create(:work_version_with_work, collection: collection) }
+  let(:work_version) { create(:work_version_with_work, :with_no_subtype, collection: collection) }
   let(:work) { work_version.work }
   let(:form) { DraftWorkForm.new(work_version: work_version, work: work) }
 
@@ -17,7 +17,8 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
         work_type: work_version.work_type,
         title: work_version.title,
         abstract: work_version.abstract,
-        citation: work_version.citation
+        citation: work_version.citation,
+        subtype: work_version.subtype
       )
     end
 
@@ -30,7 +31,9 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
 
   context 'when embargoed, then edited with no changes to embargo' do
     let(:embargo_date) { 11.months.from_now }
-    let(:work_version) { create(:work_version_with_work, embargo_date: embargo_date, collection: collection) }
+    let(:work_version) do
+      create(:work_version_with_work, :with_no_subtype, embargo_date: embargo_date, collection: collection)
+    end
     let(:params) do
       ActionController::Parameters.new(
         title: 'new title',
@@ -53,7 +56,9 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
   context 'when embargoed, then changes to embargo date' do
     let(:embargo_date) { 10.months.from_now }
     let(:new_embargo_date) { 11.months.from_now }
-    let(:work_version) { create(:work_version_with_work, embargo_date: embargo_date, collection: collection) }
+    let(:work_version) do
+      create(:work_version_with_work, :with_no_subtype, embargo_date: embargo_date, collection: collection)
+    end
     let(:params) do
       ActionController::Parameters.new(
         title: 'new title',
@@ -75,7 +80,7 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
 
   context 'when not embargoed, then embargo set' do
     let(:new_embargo_date) { 11.months.from_now }
-    let(:work_version) { create(:work_version_with_work, collection: collection) }
+    let(:work_version) { create(:work_version_with_work, :with_no_subtype, collection: collection) }
     let(:params) do
       ActionController::Parameters.new(
         title: 'new title',
@@ -97,7 +102,9 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
 
   context 'when embargoed, then embargo removed' do
     let(:embargo_date) { 10.months.from_now }
-    let(:work_version) { create(:work_version_with_work, embargo_date: embargo_date, collection: collection) }
+    let(:work_version) do
+      create(:work_version_with_work, :with_no_subtype, embargo_date: embargo_date, collection: collection)
+    end
     let(:params) do
       ActionController::Parameters.new(
         title: 'new title',


### PR DESCRIPTION
closes #2683

## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit
