### PR TITLE
Update the rubocop spec to use ruby 3.1 language syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,9 @@ orbs:
   cypress: cypress-io/cypress@2.2.0
 jobs:
   cypress:
-    executor: ruby-rails/ruby-postgres
+    executor:
+      name: ruby-rails/ruby-postgres
+      ruby-tag: '3.1.2'
     steps:
       - checkout
       - ruby/install-deps

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ inherit_from: .rubocop_todo.yml
 #### Local Settings
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   Exclude:
     - db/**/*
     - node_modules/**/*

--- a/app/components/collections/link_to_show_component.rb
+++ b/app/components/collections/link_to_show_component.rb
@@ -8,11 +8,11 @@ module Collections
     end
 
     def link
-      link_to name, collection, name: name
+      link_to name, collection, name:
     end
 
     def name
-      @name ||= Collections::DetailComponent.new(collection_version: collection_version).name
+      @name ||= Collections::DetailComponent.new(collection_version:).name
     end
 
     attr_reader :collection_version

--- a/app/components/collections/works_component.rb
+++ b/app/components/collections/works_component.rb
@@ -23,11 +23,11 @@ module Collections
     private
 
     def policy
-      WorkVersionPolicy.new(user: current_user, user_with_groups: user_with_groups)
+      WorkVersionPolicy.new(user: current_user, user_with_groups:)
     end
 
     def collection_policy
-      CollectionPolicy.new(collection, user: current_user, user_with_groups: user_with_groups)
+      CollectionPolicy.new(collection, user: current_user, user_with_groups:)
     end
   end
 end

--- a/app/components/dashboard/collection_component.rb
+++ b/app/components/dashboard/collection_component.rb
@@ -31,11 +31,11 @@ module Dashboard
     private
 
     def work_policy
-      WorkPolicy.new(user: current_user, user_with_groups: user_with_groups)
+      WorkPolicy.new(user: current_user, user_with_groups:)
     end
 
     def policy
-      CollectionPolicy.new(collection, user: current_user, user_with_groups: user_with_groups)
+      CollectionPolicy.new(collection, user: current_user, user_with_groups:)
     end
   end
 end

--- a/app/components/dashboard/in_progress_collection_row_component.rb
+++ b/app/components/dashboard/in_progress_collection_row_component.rb
@@ -14,7 +14,7 @@ module Dashboard
     delegate :collection, to: :collection_version
 
     def collection_name
-      Dashboard::CollectionHeaderComponent.new(collection_version: collection_version).name
+      Dashboard::CollectionHeaderComponent.new(collection_version:).name
     end
 
     def show_collection_link

--- a/app/components/dashboard/in_progress_row_component.rb
+++ b/app/components/dashboard/in_progress_row_component.rb
@@ -22,7 +22,7 @@ module Dashboard
     end
 
     def work_link
-      link_to truncate(title, length: 100, separator: ' '), work_path(work), title: title
+      link_to truncate(title, length: 100, separator: ' '), work_path(work), title:
     end
 
     def show_collection_link

--- a/app/components/help_collection_component.rb
+++ b/app/components/help_collection_component.rb
@@ -10,7 +10,7 @@ class HelpCollectionComponent < ApplicationComponent
   end
 
   def label
-    I18n.t("#{key}.label", scope: scope)
+    I18n.t("#{key}.label", scope:)
   end
 
   def description_key

--- a/app/components/popover_component.rb
+++ b/app/components/popover_component.rb
@@ -11,7 +11,7 @@ class PopoverComponent < ApplicationComponent
   attr_reader :icon, :scope
 
   def text
-    t(@key, scope: scope)
+    t(@key, scope:)
   end
 
   def render?

--- a/app/components/related_link_component.rb
+++ b/app/components/related_link_component.rb
@@ -10,6 +10,6 @@ class RelatedLinkComponent < ApplicationComponent
   attr_reader :form, :key
 
   def tooltip
-    render PopoverComponent.new key: key
+    render PopoverComponent.new key:
   end
 end

--- a/app/components/works/contact_email_component.rb
+++ b/app/components/works/contact_email_component.rb
@@ -11,7 +11,7 @@ module Works
     attr_reader :form, :key
 
     def row(email_form)
-      render Works::ContactEmailRowComponent.new(form: email_form, key: key)
+      render Works::ContactEmailRowComponent.new(form: email_form, key:)
     end
   end
 end

--- a/app/components/works/contact_email_row_component.rb
+++ b/app/components/works/contact_email_row_component.rb
@@ -11,7 +11,7 @@ module Works
     attr_reader :form, :key
 
     def tooltip
-      render PopoverComponent.new key: key
+      render PopoverComponent.new key:
     end
 
     def bootstrap_classes

--- a/app/components/works/contributor_role_component.rb
+++ b/app/components/works/contributor_role_component.rb
@@ -31,8 +31,8 @@ module Works
       end
 
       def roles
-        AbstractContributor.grouped_roles(citable: citable)
-                           .fetch(key).map { |label| Role.new(contributor_type: key, label: label) }
+        AbstractContributor.grouped_roles(citable:)
+                           .fetch(key).map { |label| Role.new(contributor_type: key, label:) }
       end
     end
 
@@ -54,7 +54,7 @@ module Works
 
     def grouped_options
       %w[person organization].map do |key|
-        ContributorType.new(key: key, citable: false)
+        ContributorType.new(key:, citable: false)
       end
     end
   end

--- a/app/components/works/contributor_row_component.rb
+++ b/app/components/works/contributor_row_component.rb
@@ -19,14 +19,14 @@ module Works
     end
 
     def select_role
-      render ContributorRoleComponent.new(form: form, data_options: data_options_for_select)
+      render ContributorRoleComponent.new(form:, data_options: data_options_for_select)
     end
 
     def html_options(auto_citation_target, contributors_target: nil, disabled: false)
       {
         class: 'form-control',
         data: {
-          contributors_target: contributors_target
+          contributors_target:
         }.tap do |data|
           if author?
             data[:action] = 'change->auto-citation#updateDisplay'
@@ -34,7 +34,7 @@ module Works
           end
         end.compact,
         required: author?,
-        disabled: disabled
+        disabled:
       }
     end
 
@@ -81,7 +81,7 @@ module Works
 
     def html_options_for_radio(is_name, checked)
       {
-        checked: checked,
+        checked:,
         class: 'form-check-input',
         data: {}.tap do |data|
           actions = ['contributors#personChanged']

--- a/app/components/works/link_to_show_component.rb
+++ b/app/components/works/link_to_show_component.rb
@@ -8,7 +8,7 @@ module Works
     end
 
     def link
-      link_to truncate(title, length: 150, separator: ' '), work, title: title
+      link_to truncate(title, length: 150, separator: ' '), work, title:
     end
 
     def title

--- a/app/components/works/publication_date_component.rb
+++ b/app/components/works/publication_date_component.rb
@@ -69,7 +69,7 @@ module Works
 
     def month_field
       select_month published_month,
-                   { prefix: prefix, field_name: 'published(2i)', prompt: 'month' },
+                   { prefix:, field_name: 'published(2i)', prompt: 'month' },
                    data: {
                      date_validation_target: 'month',
                      date_clear_target: 'month',
@@ -81,7 +81,7 @@ module Works
 
     def day_field
       select_day published_day,
-                 { prefix: prefix, field_name: 'published(3i)', prompt: 'day' },
+                 { prefix:, field_name: 'published(3i)', prompt: 'day' },
                  data: {
                    date_validation_target: 'day',
                    date_clear_target: 'day',

--- a/app/components/works/subtypes_component.rb
+++ b/app/components/works/subtypes_component.rb
@@ -49,7 +49,7 @@ module Works
              else
                'default'
              end
-      render PopoverComponent.new key: key
+      render PopoverComponent.new key:
     end
 
     def sanitized_value(value)

--- a/app/controllers/admin/druid_searches_controller.rb
+++ b/app/controllers/admin/druid_searches_controller.rb
@@ -23,7 +23,7 @@ module Admin
 
     def lookup_druid(druid)
       druid = "druid:#{druid}" unless druid.start_with?('druid:')
-      item = Collection.find_by(druid: druid) || Work.find_by(druid: druid)
+      item = Collection.find_by(druid:) || Work.find_by(druid:)
       return Failure(:not_found) unless item
 
       Success(item)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -18,7 +18,7 @@ module Admin
     def build_presenter(user)
       return Failure(:not_found) unless user
 
-      presenter = Admin::UserPresenter.new(user: user,
+      presenter = Admin::UserPresenter.new(user:,
                                            collections_created_by_user: user.created_collections,
                                            collections: user.collections_with_access,
                                            works: user.works_created_or_owned)

--- a/app/controllers/collection_versions_controller.rb
+++ b/app/controllers/collection_versions_controller.rb
@@ -55,7 +55,7 @@ class CollectionVersionsController < ObjectsController
     # `changed?(field)` on a reform form object needs to be asked before persistence on existing records
     event_context = build_event_context(context_form(orig_collection_version, orig_clean_params))
     if @form.validate(clean_params) && @form.save
-      after_save(form: @form, event_context: event_context)
+      after_save(form: @form, event_context:)
     else
       @form.prepopulate!
       render :edit, status: :unprocessable_entity
@@ -69,7 +69,7 @@ class CollectionVersionsController < ObjectsController
   def edit_link
     collection_version = CollectionVersion.find(params[:id])
     render partial: 'edit_link', locals: {
-      collection_version: collection_version,
+      collection_version:,
       name: collection_version.name
     }
   end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -54,21 +54,21 @@ class CollectionsController < ObjectsController
   # The access can vary depending on the user and the state of the collection.
   def dashboard
     collection = Collection.find(params[:id])
-    render partial: 'collections/dashboard', locals: { collection: collection }
+    render partial: 'collections/dashboard', locals: { collection: }
   end
 
   # We render this button lazily because it requires doing a query to see if the user has access.
   # The access can vary depending on the user and the state of the collection.
   def deposit_button
     collection = Collection.find(params[:id])
-    render partial: 'collections/deposit_button', locals: { collection: collection }
+    render partial: 'collections/deposit_button', locals: { collection: }
   end
 
   # We render this button lazily because it requires doing a query to see if the user has access.
   # The access can vary depending on the user and the state of the collection.
   def delete_button
     collection = Collection.find(params[:id])
-    render partial: 'collections/delete_button', locals: { collection: collection }
+    render partial: 'collections/delete_button', locals: { collection: }
   end
 
   # We render this link lazily because it requires doing a query to see if the user has access.
@@ -79,8 +79,8 @@ class CollectionsController < ObjectsController
     collection = Collection.find(params[:id])
     label = params.fetch(:label) { "Edit #{collection.head.name}" }
     render partial: 'edit_link', locals: {
-      collection: collection,
-      label: label,
+      collection:,
+      label:,
       anchor: params[:ref]
     }
   end

--- a/app/controllers/first_draft_collections_controller.rb
+++ b/app/controllers/first_draft_collections_controller.rb
@@ -11,8 +11,8 @@ class FirstDraftCollectionsController < ObjectsController
     collection = Collection.new(creator: current_user)
     authorize! collection
 
-    collection_version = CollectionVersion.new(collection: collection)
-    @form = CreateCollectionForm.new(collection_version: collection_version, collection: collection)
+    collection_version = CollectionVersion.new(collection:)
+    @form = CreateCollectionForm.new(collection_version:, collection:)
     @form.prepopulate!
   end
 
@@ -21,7 +21,7 @@ class FirstDraftCollectionsController < ObjectsController
     collection = Collection.new(creator: current_user)
     authorize! collection
 
-    collection_version = CollectionVersion.new(collection: collection)
+    collection_version = CollectionVersion.new(collection:)
     @form = collection_form(collection_version)
 
     if @form.validate(create_params) && @form.save
@@ -46,7 +46,7 @@ class FirstDraftCollectionsController < ObjectsController
     redirect_to edit_collection_path(collection) unless collection.head.first_draft?
 
     collection_version = collection.collection_versions.first # this is a first draft and should only have one version
-    @form = CreateCollectionForm.new(collection_version: collection_version, collection: collection)
+    @form = CreateCollectionForm.new(collection_version:, collection:)
     # @form = CollectionSettingsForm.new(collection)
     @form.prepopulate!
   end
@@ -76,11 +76,11 @@ class FirstDraftCollectionsController < ObjectsController
 
   def collection_form(collection_version)
     if deposit_button_pushed?
-      return CreateCollectionForm.new(collection_version: collection_version,
+      return CreateCollectionForm.new(collection_version:,
                                       collection: collection_version.collection)
     end
 
-    DraftCollectionForm.new(collection_version: collection_version, collection: collection_version.collection)
+    DraftCollectionForm.new(collection_version:, collection: collection_version.collection)
   end
 
   def create_params

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -8,11 +8,11 @@ class ReservationsController < ObjectsController
 
   def create
     work = Work.new(collection_id: params[:collection_id], depositor: current_user, owner: current_user)
-    work_version = WorkVersion.new(work: work)
+    work_version = WorkVersion.new(work:)
 
     authorize! work_version
 
-    @form = ReservationForm.new(work_version: work_version, work: work)
+    @form = ReservationForm.new(work_version:, work:)
     if @form.validate(work_params) && @form.save
       work_version.reserve_purl!
       redirect_to dashboard_path

--- a/app/controllers/work_locks_controller.rb
+++ b/app/controllers/work_locks_controller.rb
@@ -31,7 +31,7 @@ class WorkLocksController < ApplicationController
 
   def create_event(work, lock_state)
     event_type = lock_state ? 'lock_work' : 'unlock_work'
-    work.events.create(work.event_context.merge(event_type: event_type))
+    work.events.create(work.event_context.merge(event_type:))
   end
 
   def update_lock_params

--- a/app/controllers/work_owners_controller.rb
+++ b/app/controllers/work_owners_controller.rb
@@ -39,18 +39,18 @@ class WorkOwnersController < ApplicationController
 
   def send_participant_change_emails(collection)
     (collection.managed_by + collection.reviewed_by).uniq.each do |user|
-      CollectionsMailer.with(collection_version: collection.head, user: user)
+      CollectionsMailer.with(collection_version: collection.head, user:)
                        .participants_changed_email.deliver_later
     end
   end
 
   def send_changed_owner_email(work)
-    WorksMailer.with(work: work).changed_owner_email.deliver_later
+    WorksMailer.with(work:).changed_owner_email.deliver_later
   end
 
   def send_collection_managers_email(work)
     work.collection.managed_by.each do |user|
-      WorksMailer.with(work: work, user: user).changed_owner_collection_manager_email.deliver_later
+      WorksMailer.with(work:, user:).changed_owner_collection_manager_email.deliver_later
     end
   end
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -10,17 +10,17 @@ class WorksController < ObjectsController
   def new
     validate_work_types!
     collection = Collection.find(params[:collection_id])
-    work = Work.new(collection: collection, owner: current_user)
-    work_version = WorkVersion.new(work_type: params[:work_type], subtype: params[:subtype], work: work)
+    work = Work.new(collection:, owner: current_user)
+    work_version = WorkVersion.new(work_type: params[:work_type], subtype: params[:subtype], work:)
     authorize! work_version
 
-    @form = WorkForm.new(work_version: work_version, work: work)
+    @form = WorkForm.new(work_version:, work:)
     @form.prepopulate!
   end
 
   def create
     work = Work.new(collection_id: params[:collection_id], depositor: current_user, owner: current_user)
-    work_version = WorkVersion.new(work: work)
+    work_version = WorkVersion.new(work:)
 
     authorize! work_version
 
@@ -38,7 +38,7 @@ class WorksController < ObjectsController
     work_version = work.head
     authorize! work_version
 
-    @form = WorkForm.new(work_version: work_version, work: work_version.work)
+    @form = WorkForm.new(work_version:, work: work_version.work)
     @form.prepopulate!
   end
 
@@ -61,7 +61,7 @@ class WorksController < ObjectsController
     # `changed?(field)` on a reform form object needs to be asked before persistence on existing records
     event_context = build_event_context(context_form(orig_work_version, orig_clean_params))
     if @form.validate(clean_params) && @form.save
-      after_save(form: @form, event_context: event_context)
+      after_save(form: @form, event_context:)
     else
       @form.prepopulate!
       render :edit, status: :unprocessable_entity
@@ -114,7 +114,7 @@ class WorksController < ObjectsController
   # The access can vary depending on the user and the state of the work.
   def delete_button
     work = Work.find(params[:id])
-    render partial: 'works/delete_button', locals: { work: work }
+    render partial: 'works/delete_button', locals: { work: }
   end
 
   # We render this button lazily because it requires doing a query to see if the user has access.
@@ -130,7 +130,7 @@ class WorksController < ObjectsController
                     end
     edit_label = I18n.t params[:tag], scope: %i[work edit_links], default: default_label
 
-    render partial: 'works/edit_button', locals: { work: work, anchor: params[:tag], edit_label: edit_label }
+    render partial: 'works/edit_button', locals: { work:, anchor: params[:tag], edit_label: }
   end
 
   private
@@ -146,9 +146,9 @@ class WorksController < ObjectsController
 
   def work_form(work_version)
     if deposit_button_pushed?
-      WorkForm.new(work_version: work_version, work: work_version.work)
+      WorkForm.new(work_version:, work: work_version.work)
     else
-      DraftWorkForm.new(work_version: work_version, work: work_version.work)
+      DraftWorkForm.new(work_version:, work: work_version.work)
     end
   end
 

--- a/app/forms/application_populator.rb
+++ b/app/forms/application_populator.rb
@@ -11,7 +11,7 @@ class ApplicationPopulator
   attr_reader :klass
 
   def existing_record(form:, id:)
-    value(form).find_by(id: id) if id.present?
+    value(form).find_by(id:) if id.present?
   end
 
   def value(form)

--- a/app/forms/attached_files_populator.rb
+++ b/app/forms/attached_files_populator.rb
@@ -6,7 +6,7 @@ class AttachedFilesPopulator < ApplicationPopulator
   # find out if incoming file is already added.
   def call(form, args)
     fragment = args.fetch(:fragment)
-    item = existing_record(form: form, id: fragment['id'])
+    item = existing_record(form:, id: fragment['id'])
 
     if fragment['_destroy'] == '1'
       # Remove AttachedFile and associated ActiveStorage objects

--- a/app/forms/collection_contributor_populator.rb
+++ b/app/forms/collection_contributor_populator.rb
@@ -8,7 +8,7 @@ class CollectionContributorPopulator < ApplicationPopulator
     fragment = args.fetch(:fragment)
     as = args.fetch(:as)
 
-    item = existing_record(form: form, id: fragment['id'])
+    item = existing_record(form:, id: fragment['id'])
     if fragment['_destroy'] == '1'
       # Remove contributor
       form.public_send(as).delete(item) if item

--- a/app/forms/contact_emails_populator.rb
+++ b/app/forms/contact_emails_populator.rb
@@ -5,7 +5,7 @@ class ContactEmailsPopulator < ApplicationPopulator
   # The fragment represents one row of the attached file data from the HTML form
   def call(form, args)
     fragment = args.fetch(:fragment)
-    item = existing_record(form: form, id: fragment['id'])
+    item = existing_record(form:, id: fragment['id'])
 
     if fragment['_destroy'] == '1'
       form.contact_emails.delete(item)

--- a/app/forms/contributor_form.rb
+++ b/app/forms/contributor_form.rb
@@ -6,8 +6,8 @@ module ContributorForm
 
   class_methods do
     def has_contributors(validate:)
-      has_generic_contributors(validate: validate)
-      has_authors(validate: validate)
+      has_generic_contributors(validate:)
+      has_authors(validate:)
     end
 
     def has_generic_contributors(validate:)
@@ -15,7 +15,7 @@ module ContributorForm
                  populator: ContributorPopulator.new(:contributors, Contributor),
                  prepopulator: ->(*) { contributors << Contributor.new if contributors.blank? },
                  on: :work_version,
-                 &form_properties(validate: validate)
+                 &form_properties(validate:)
     end
 
     def has_authors(validate:)
@@ -23,7 +23,7 @@ module ContributorForm
                  populator: ContributorPopulator.new(:authors, Author),
                  prepopulator: ->(*) { authors << Author.new if authors.blank? },
                  on: :work_version,
-                 &form_properties(validate: validate)
+                 &form_properties(validate:)
     end
 
     # rubocop:disable Metrics/AbcSize

--- a/app/forms/contributor_populator.rb
+++ b/app/forms/contributor_populator.rb
@@ -8,7 +8,7 @@ class ContributorPopulator < ApplicationPopulator
   # rubocop:disable Metrics/MethodLength
   def call(form, args)
     fragment = args.fetch(:fragment)
-    item = existing_record(form: form, id: fragment['id'])
+    item = existing_record(form:, id: fragment['id'])
 
     if fragment['_destroy'] == '1'
       value(form).delete(item)

--- a/app/forms/edtf.rb
+++ b/app/forms/edtf.rb
@@ -4,7 +4,7 @@
 module Edtf
   # Adds a property method that can handle the :edtf and :range options
   module ClassMethods
-    def property(name, options = {}, &block)
+    def property(name, options = {}, &)
       if options[:edtf]
         prop_name = name.to_s.delete_suffix('_edtf')
         property "#{prop_name}(1i)", virtual: true
@@ -14,7 +14,7 @@ module Edtf
 
         create_range(prop_name) if options[:range]
       end
-      super(name, options, &block)
+      super(name, options, &)
     end
 
     def create_range(prop_name)

--- a/app/forms/edtf_params_filter.rb
+++ b/app/forms/edtf_params_filter.rb
@@ -42,8 +42,8 @@ class EdtfParamsFilter
 
     date = year.dup
     if month.present?
-      date += "-#{format('%<month>02d', month: month)}"
-      date += "-#{format('%<day>02d', day: day)}" if day.present?
+      date += "-#{format('%<month>02d', month:)}"
+      date += "-#{format('%<day>02d', day:)}" if day.present?
     end
     date += '?' if uncertain
     date

--- a/app/forms/embargo_date.rb
+++ b/app/forms/embargo_date.rb
@@ -4,13 +4,13 @@
 module EmbargoDate
   # Adds a property method that can handle the :embargo_date
   module ClassMethods
-    def property(prop_name, options = {}, &block)
+    def property(prop_name, options = {}, &)
       if options[:embargo_date]
         property "#{prop_name}(1i)", virtual: true, default: Time.zone.today.year
         property "#{prop_name}(2i)", virtual: true
         property "#{prop_name}(3i)", virtual: true
       end
-      super(prop_name, options, &block)
+      super(prop_name, options, &)
     end
   end
 

--- a/app/forms/keywords_populator.rb
+++ b/app/forms/keywords_populator.rb
@@ -6,7 +6,7 @@ class KeywordsPopulator < ApplicationPopulator
     # The fragment represents one row of the attached file data from the HTML form
     # find out if incoming file is already added.
     fragment = args.fetch(:fragment)
-    item = existing_record(form: form, id: fragment['id'])
+    item = existing_record(form:, id: fragment['id'])
 
     if fragment['_destroy'] == '1'
       form.keywords.delete(item)

--- a/app/forms/related_links_populator.rb
+++ b/app/forms/related_links_populator.rb
@@ -6,7 +6,7 @@ class RelatedLinksPopulator < ApplicationPopulator
   # find out if incoming file is already added.
   def call(form, args)
     fragment = args.fetch(:fragment)
-    item = existing_record(form: form, id: fragment['id'])
+    item = existing_record(form:, id: fragment['id'])
 
     if fragment['_destroy'] == '1'
       form.related_links.delete(item)

--- a/app/forms/related_works_populator.rb
+++ b/app/forms/related_works_populator.rb
@@ -6,7 +6,7 @@ class RelatedWorksPopulator < ApplicationPopulator
   # find out if incoming file is already added.
   def call(form, args)
     fragment = args.fetch(:fragment)
-    item = existing_record(form: form, id: fragment['id'])
+    item = existing_record(form:, id: fragment['id'])
 
     if fragment['_destroy'] == '1'
       form.related_works.delete(item)

--- a/app/forms/reviewers_populator.rb
+++ b/app/forms/reviewers_populator.rb
@@ -8,7 +8,7 @@ class ReviewersPopulator < CollectionContributorPopulator
     return super if doc['review_enabled'] != 'false'
 
     fragment = args.fetch(:fragment)
-    item = existing_record(form: form, id: fragment['id'])
+    item = existing_record(form:, id: fragment['id'])
     # Remove reviewer
     as = args.fetch(:as)
     form.public_send(as).delete(item) if item

--- a/app/jobs/deposit_collection_job.rb
+++ b/app/jobs/deposit_collection_job.rb
@@ -5,7 +5,7 @@ class DepositCollectionJob < BaseDepositJob
   queue_as :default
 
   def perform(collection_version)
-    deposit(request_dro: CocinaGenerator::CollectionGenerator.generate_model(collection_version: collection_version),
+    deposit(request_dro: CocinaGenerator::CollectionGenerator.generate_model(collection_version:),
             version_description: collection_version.version_description.presence)
   rescue StandardError => e
     Honeybadger.notify(e)
@@ -27,12 +27,12 @@ class DepositCollectionJob < BaseDepositJob
       SdrClient::Deposit::CreateResource.run(accession: true,
                                              metadata: request_dro,
                                              logger: Rails.logger,
-                                             connection: connection)
+                                             connection:)
     when Cocina::Models::Collection
       SdrClient::Deposit::UpdateResource.run(metadata: request_dro,
                                              logger: Rails.logger,
-                                             connection: connection,
-                                             version_description: version_description)
+                                             connection:,
+                                             version_description:)
     end
   end
 

--- a/app/jobs/deposit_job.rb
+++ b/app/jobs/deposit_job.rb
@@ -9,7 +9,7 @@ class DepositJob < BaseDepositJob
     Honeybadger.context({ work_version_id: work_version.id, druid: work_version.work.druid,
                           work_id: work_version.work.id, depositor_sunet: work_version.work.depositor.sunetid })
 
-    request_dro = CocinaGenerator::DROGenerator.generate_model(work_version: work_version)
+    request_dro = CocinaGenerator::DROGenerator.generate_model(work_version:)
 
     perform_login
 
@@ -39,7 +39,7 @@ class DepositJob < BaseDepositJob
     new_request_dro = update_dro_with_existing_file_identifiers(request_dro, work_version.work.druid)
     # Update with any new externalIdentifiers assigned by SDR API during upload.
     SdrClient::Deposit::UpdateDroWithFileIdentifiers.update(request_dro: new_request_dro,
-                                                            upload_responses: upload_responses)
+                                                            upload_responses:)
   end
 
   def update_dro_with_existing_file_identifiers(request_dro, druid)
@@ -62,20 +62,20 @@ class DepositJob < BaseDepositJob
                                            assign_doi: work_version.work.assign_doi?,
                                            metadata: new_request_dro,
                                            logger: Rails.logger,
-                                           connection: connection)
+                                           connection:)
   end
 
   def update(new_request_dro, work_version)
     SdrClient::Deposit::UpdateResource.run(metadata: new_request_dro,
                                            logger: Rails.logger,
-                                           connection: connection,
+                                           connection:,
                                            version_description: work_version.version_description.presence)
   end
 
   def perform_upload(blobs)
     SdrClient::Deposit::UploadFiles.upload(file_metadata: build_file_metadata(blobs),
                                            logger: Rails.logger,
-                                           connection: connection)
+                                           connection:)
   end
 
   def connection

--- a/app/jobs/deposit_status_job.rb
+++ b/app/jobs/deposit_status_job.rb
@@ -15,11 +15,11 @@ class DepositStatusJob
 
   def work(msg)
     druid = parse_message(msg)
-    Honeybadger.context(druid: druid)
+    Honeybadger.context(druid:)
 
     # Without this, the database connection pool gets exhausted
     ActiveRecord::Base.connection_pool.with_connection do
-      object = Work.find_by(druid: druid) || Collection.find_by(druid: druid)
+      object = Work.find_by(druid:) || Collection.find_by(druid:)
 
       return ack! unless object
 

--- a/app/jobs/reserve_job.rb
+++ b/app/jobs/reserve_job.rb
@@ -8,11 +8,11 @@ class ReserveJob < BaseDepositJob
     login_result = login
     raise login_result.failure unless login_result.success?
 
-    request_dro = CocinaGenerator::DROGenerator.generate_model(work_version: work_version)
+    request_dro = CocinaGenerator::DROGenerator.generate_model(work_version:)
     SdrClient::Deposit::CreateResource.run(accession: false,
                                            metadata: request_dro,
                                            logger: Rails.logger,
-                                           connection: connection)
+                                           connection:)
   end
 
   def connection

--- a/app/mailers/collections_mailer.rb
+++ b/app/mailers/collections_mailer.rb
@@ -61,7 +61,7 @@ class CollectionsMailer < ApplicationMailer
 
     subject = "Reminder: Your #{@collection_version.name} collection in the SDR is still in progress"
 
-    mail(to: @user.email, subject: subject)
+    mail(to: @user.email, subject:)
   end
 
   def new_version_reminder_email
@@ -70,7 +70,7 @@ class CollectionsMailer < ApplicationMailer
 
     subject = "Reminder: New version of your #{@collection_version.name} collection in the SDR is still in progress"
 
-    mail(to: @user.email, subject: subject)
+    mail(to: @user.email, subject:)
   end
 
   def item_deposited

--- a/app/mailers/helps_mailer.rb
+++ b/app/mailers/helps_mailer.rb
@@ -13,6 +13,6 @@ class HelpsMailer < ApplicationMailer
 
     mail(to: 'sdr-support@jirasul.stanford.edu',
          from: email,
-         subject: subject)
+         subject:)
   end
 end

--- a/app/mailers/works_mailer.rb
+++ b/app/mailers/works_mailer.rb
@@ -20,7 +20,7 @@ class WorksMailer < ApplicationMailer
     @work = params[:work_version].work
     @user = UserPresenter.new(user: @work.owner)
     subject = "Reminder: Deposit to the #{@work.collection_name} collection in the SDR is in progress"
-    mail(to: @user.email, subject: subject)
+    mail(to: @user.email, subject:)
   end
 
   def new_version_reminder_email
@@ -29,7 +29,7 @@ class WorksMailer < ApplicationMailer
 
     subject = "Reminder: New version of a deposit to the #{@work.collection_name} collection in the SDR is in progress"
 
-    mail(to: @user.email, subject: subject)
+    mail(to: @user.email, subject:)
   end
 
   def new_version_deposited_email

--- a/app/models/abstract_contributor.rb
+++ b/app/models/abstract_contributor.rb
@@ -86,6 +86,6 @@ class AbstractContributor < ApplicationRecord
 
   def role_term=(val)
     contributor_type, role = val.split(SEPARATOR)
-    self.attributes = { contributor_type: contributor_type, role: role }
+    self.attributes = { contributor_type:, role: }
   end
 end

--- a/app/models/collection_version.rb
+++ b/app/models/collection_version.rb
@@ -29,17 +29,17 @@ class CollectionVersion < ApplicationRecord
     after_transition on: :begin_deposit do |collection_version, transition|
       if transition.from == 'first_draft'
         collection_version.collection.depositors.each do |depositor|
-          CollectionsMailer.with(collection_version: collection_version, user: depositor)
+          CollectionsMailer.with(collection_version:, user: depositor)
                            .invitation_to_deposit_email.deliver_later
         end
 
         collection_version.collection.reviewed_by.each do |reviewer|
-          CollectionsMailer.with(collection_version: collection_version, user: reviewer)
+          CollectionsMailer.with(collection_version:, user: reviewer)
                            .review_access_granted_email.deliver_later
         end
 
         collection_version.collection.managed_by.each do |manager|
-          CollectionsMailer.with(collection_version: collection_version, user: manager)
+          CollectionsMailer.with(collection_version:, user: manager)
                            .manage_access_granted_email.deliver_later
         end
       end
@@ -48,7 +48,7 @@ class CollectionVersion < ApplicationRecord
 
     after_transition new: :first_draft do |collection_version|
       if Settings.notify_admin_list
-        FirstDraftCollectionsMailer.with(collection_version: collection_version)
+        FirstDraftCollectionsMailer.with(collection_version:)
                                    .first_draft_created.deliver_later
       end
     end

--- a/app/services/account_service.rb
+++ b/app/services/account_service.rb
@@ -10,7 +10,7 @@ class AccountService
 
   def fetch(sunetid)
     Rails.cache.fetch(sunetid, namespace: 'account', expires_in: 1.month) do
-      url = template.partial_expand(sunetid: sunetid).pattern
+      url = template.partial_expand(sunetid:).pattern
       response = connection.get(url)
       doc = response.body
       doc.slice('name', 'description')

--- a/app/services/admin/work_report_query.rb
+++ b/app/services/admin/work_report_query.rb
@@ -36,7 +36,7 @@ module Admin
       state = report.state.compact_blank
       return if state.empty?
 
-      self.query = query.where(head: { state: state })
+      self.query = query.where(head: { state: })
     end
 
     def add_collection_filter

--- a/app/services/cocina_generator/access_generator.rb
+++ b/app/services/cocina_generator/access_generator.rb
@@ -4,7 +4,7 @@ module CocinaGenerator
   # This generates a the Access cocina model for a work
   class AccessGenerator
     def self.generate(work_version:)
-      new(work_version: work_version).generate
+      new(work_version:).generate
     end
 
     def initialize(work_version:)

--- a/app/services/cocina_generator/collection_generator.rb
+++ b/app/services/cocina_generator/collection_generator.rb
@@ -4,7 +4,7 @@ module CocinaGenerator
   # This generates a RequestCollection or Collection for a Collection
   class CollectionGenerator
     def self.generate_model(collection_version:)
-      new(collection_version: collection_version).generate_model
+      new(collection_version:).generate_model
     end
 
     def initialize(collection_version:)
@@ -26,7 +26,7 @@ module CocinaGenerator
 
     def model_attributes # rubocop:disable Metrics/AbcSize
       {
-        access: access,
+        access:,
         administrative: {
           hasAdminPolicy: Settings.h2.hydrus_apo
         },
@@ -35,7 +35,7 @@ module CocinaGenerator
         },
         label: collection_version.name,
         type: Cocina::Models::ObjectType.collection,
-        description: Description::CollectionDescriptionGenerator.generate(collection_version: collection_version).to_h,
+        description: Description::CollectionDescriptionGenerator.generate(collection_version:).to_h,
         version: collection_version.version
       }.tap do |h|
         h[:administrative][:partOfProject] = Settings.h2.project_tag unless collection_version.collection.druid

--- a/app/services/cocina_generator/description/collection_description_generator.rb
+++ b/app/services/cocina_generator/description/collection_description_generator.rb
@@ -5,7 +5,7 @@ module CocinaGenerator
     # This generates a Collection Description
     class CollectionDescriptionGenerator
       def self.generate(collection_version:)
-        new(collection_version: collection_version).generate
+        new(collection_version:).generate
       end
 
       def initialize(collection_version:)
@@ -14,10 +14,10 @@ module CocinaGenerator
 
       def generate
         description_class.new({
-          title: title,
+          title:,
           note: [abstract],
           relatedResource: related_resources.presence,
-          access: access,
+          access:,
           purl: collection_version.collection.purl
         }.compact)
       end

--- a/app/services/cocina_generator/description/contributors_generator.rb
+++ b/app/services/cocina_generator/description/contributors_generator.rb
@@ -7,11 +7,11 @@ module CocinaGenerator
     # rubocop:disable Metrics/ClassLength
     class ContributorsGenerator
       def self.generate(work_version:)
-        new(work_version: work_version).generate
+        new(work_version:).generate
       end
 
       def self.events_from_publisher_contributors(work_version:, pub_date: nil)
-        new(work_version: work_version).publication_event_values(pub_date)
+        new(work_version:).publication_event_values(pub_date)
       end
 
       def initialize(work_version:)
@@ -194,7 +194,7 @@ module CocinaGenerator
         source, value = Orcid.split(contributor.orcid)
 
         [
-          Cocina::Models::DescriptiveValue.new(type: 'ORCID', value: value, source: { uri: source })
+          Cocina::Models::DescriptiveValue.new(type: 'ORCID', value:, source: { uri: source })
         ]
       end
       # rubocop:enable Metrics/ClassLength

--- a/app/services/cocina_generator/description/date_generator.rb
+++ b/app/services/cocina_generator/description/date_generator.rb
@@ -9,7 +9,7 @@ module CocinaGenerator
       # @param [boolean] primary - whether status is primary
       # @return [Hash] the props for the date
       def self.generate(date:, type: nil, primary: false)
-        new(date: date, type: type, primary: primary).generate
+        new(date:, type:, primary:).generate
       end
 
       def initialize(date:, type:, primary:)
@@ -21,7 +21,7 @@ module CocinaGenerator
       def generate
         {
           encoding: { code: 'edtf' },
-          type: type,
+          type:,
           status: primary ? 'primary' : nil
         }.compact.merge(date_props)
       end
@@ -63,7 +63,7 @@ module CocinaGenerator
         {
           qualifier: edtf_date.uncertain? ? 'approximate' : nil,
           value: edtf_date.edtf.chomp('?'),
-          type: type
+          type:
         }.compact
       end
 

--- a/app/services/cocina_generator/description/events_generator.rb
+++ b/app/services/cocina_generator/description/events_generator.rb
@@ -5,7 +5,7 @@ module CocinaGenerator
     # This generates Events for a work
     class EventsGenerator
       def self.generate(work_version:)
-        new(work_version: work_version).generate
+        new(work_version:).generate
       end
 
       def initialize(work_version:)
@@ -23,7 +23,7 @@ module CocinaGenerator
       attr_reader :work_version
 
       def publisher_events
-        @publisher_events ||= ContributorsGenerator.events_from_publisher_contributors(work_version: work_version,
+        @publisher_events ||= ContributorsGenerator.events_from_publisher_contributors(work_version:,
                                                                                        pub_date: published_date_event)
       end
 
@@ -73,13 +73,13 @@ module CocinaGenerator
 
         Cocina::Models::Event.new({
                                     type: event_type,
-                                    date: [DateGenerator.generate(date: date, type: date_type, primary: primary)]
+                                    date: [DateGenerator.generate(date:, type: date_type, primary:)]
                                   })
       end
 
       def event_for_work_version(work_version:, event_type:, date_type:)
         date = work_version.published_at || work_version.updated_at
-        event_for_date(date: date, event_type: event_type, date_type: date_type)
+        event_for_date(date:, event_type:, date_type:)
       end
     end
   end

--- a/app/services/cocina_generator/description/generator.rb
+++ b/app/services/cocina_generator/description/generator.rb
@@ -5,7 +5,7 @@ module CocinaGenerator
     # This generates a RequestDRO Description for a work
     class Generator
       def self.generate(work_version:)
-        new(work_version: work_version).generate
+        new(work_version:).generate
       end
 
       def initialize(work_version:)
@@ -15,14 +15,14 @@ module CocinaGenerator
       # rubocop:disable Metrics/AbcSize
       def generate
         description_class.new({
-          title: title,
-          contributor: ContributorsGenerator.generate(work_version: work_version).presence,
+          title:,
+          contributor: ContributorsGenerator.generate(work_version:).presence,
           subject: keywords.presence,
           note: [abstract, citation].compact.presence,
-          event: EventsGenerator.generate(work_version: work_version).presence,
+          event: EventsGenerator.generate(work_version:).presence,
           relatedResource: related_resources.presence,
-          form: TypesGenerator.generate(work_version: work_version).presence,
-          access: access,
+          form: TypesGenerator.generate(work_version:).presence,
+          access:,
           purl: work_version.work.purl,
           adminMetadata: admin_metadata
         }.compact)

--- a/app/services/cocina_generator/description/related_links_generator.rb
+++ b/app/services/cocina_generator/description/related_links_generator.rb
@@ -5,7 +5,7 @@ module CocinaGenerator
     # This generates a description from RelatedLinks
     class RelatedLinksGenerator
       def self.generate(object:)
-        new(object: object).generate
+        new(object:).generate
       end
 
       def initialize(object:)

--- a/app/services/cocina_generator/description/types_generator.rb
+++ b/app/services/cocina_generator/description/types_generator.rb
@@ -8,7 +8,7 @@ module CocinaGenerator
       DATACITE_SOURCE_LABEL = 'DataCite resource types'
 
       def self.generate(work_version:)
-        new(work_version: work_version).generate
+        new(work_version:).generate
       end
 
       def initialize(work_version:)
@@ -51,7 +51,7 @@ module CocinaGenerator
 
         [
           Cocina::Models::DescriptiveValue.new(
-            value: value,
+            value:,
             source: { value: DATACITE_SOURCE_LABEL },
             type: 'resource type'
           )

--- a/app/services/cocina_generator/dro_generator.rb
+++ b/app/services/cocina_generator/dro_generator.rb
@@ -4,7 +4,7 @@ module CocinaGenerator
   # This generates a RequestDRO for a work
   class DROGenerator
     def self.generate_model(work_version:)
-      new(work_version: work_version).generate_model
+      new(work_version:).generate_model
     end
 
     def initialize(work_version:)
@@ -28,15 +28,15 @@ module CocinaGenerator
 
     def model_attributes # rubocop:disable Metrics/AbcSize
       {
-        access: AccessGenerator.generate(work_version: work_version),
+        access: AccessGenerator.generate(work_version:),
         administrative: {
           hasAdminPolicy: Settings.h2.hydrus_apo
         },
-        identification: identification,
-        structural: structural,
+        identification:,
+        structural:,
         label: work_version.title,
         type: cocina_type,
-        description: Description::Generator.generate(work_version: work_version).to_h,
+        description: Description::Generator.generate(work_version:).to_h,
         version: work_version.version
       }.tap do |h|
         h[:administrative][:partOfProject] = Settings.h2.project_tag unless druid
@@ -46,7 +46,7 @@ module CocinaGenerator
     def identification
       {
         sourceId: "hydrus:object-#{work.id}",
-        doi: doi
+        doi:
       }.compact
     end
 
@@ -57,7 +57,7 @@ module CocinaGenerator
     end
 
     def structural
-      Structural::Generator.generate(work_version: work_version)
+      Structural::Generator.generate(work_version:)
     end
   end
 end

--- a/app/services/cocina_generator/structural/file_generator.rb
+++ b/app/services/cocina_generator/structural/file_generator.rb
@@ -5,7 +5,7 @@ module CocinaGenerator
     # This generates a File for a work
     class FileGenerator
       def self.generate(work_version:, attached_file:)
-        new(work_version: work_version, attached_file: attached_file).generate
+        new(work_version:, attached_file:).generate
       end
 
       def initialize(work_version:, attached_file:)
@@ -30,9 +30,9 @@ module CocinaGenerator
           type: Cocina::Models::ObjectType.file,
           version: work_version.version,
           label: attached_file.label,
-          filename: filename,
-          access: access,
-          administrative: administrative,
+          filename:,
+          access:,
+          administrative:,
           hasMimeType: blob.content_type,
           hasMessageDigests: message_digests,
           size: blob.byte_size

--- a/app/services/cocina_generator/structural/generator.rb
+++ b/app/services/cocina_generator/structural/generator.rb
@@ -5,7 +5,7 @@ module CocinaGenerator
     # This generates a DROStructural for a work
     class Generator
       def self.generate(work_version:)
-        new(work_version: work_version).generate
+        new(work_version:).generate
       end
 
       def initialize(work_version:)
@@ -32,7 +32,7 @@ module CocinaGenerator
           version: work_version.version,
           label: attached_file.label,
           structural: {
-            contains: [FileGenerator.generate(work_version: work_version, attached_file: attached_file)]
+            contains: [FileGenerator.generate(work_version:, attached_file:)]
           }
         }.tap do |fileset|
           if work_version.work.druid

--- a/app/services/collection_event_description_builder.rb
+++ b/app/services/collection_event_description_builder.rb
@@ -3,7 +3,7 @@
 # This creates an appropriate description for an update event on a Collection
 class CollectionEventDescriptionBuilder
   def self.build(form:, change_set:)
-    new(form: form, change_set: change_set).build
+    new(form:, change_set:).build
   end
 
   def initialize(form:, change_set:)

--- a/app/services/collection_observer.rb
+++ b/app/services/collection_observer.rb
@@ -4,25 +4,25 @@
 class CollectionObserver
   def self.first_draft_created(work_version, _transition)
     collection_managers_excluding_owner(work_version).each do |user|
-      mailer_with_owner(user: user, work_version: work_version).first_draft_created.deliver_later
+      mailer_with_owner(user:, work_version:).first_draft_created.deliver_later
     end
   end
 
   def self.item_deposited(work_version, _transition)
     collection_managers_excluding_owner(work_version).each do |user|
-      mailer_with_owner(user: user, work_version: work_version).item_deposited.deliver_later
+      mailer_with_owner(user:, work_version:).item_deposited.deliver_later
     end
   end
 
   def self.version_draft_created(work_version, _transition)
     collection_managers_excluding_owner(work_version).each do |user|
-      mailer_with_owner(user: user, work_version: work_version).version_draft_created.deliver_later
+      mailer_with_owner(user:, work_version:).version_draft_created.deliver_later
     end
   end
 
   # When an already published collection is updated
   def self.settings_updated(collection, change_set:, user:, form:)
-    create_settings_updated_event(collection: collection, change_set: change_set, form: form, user: user)
+    create_settings_updated_event(collection:, change_set:, form:, user:)
 
     collection_version = collection.head
     managers_added(collection_version, change_set)
@@ -36,8 +36,8 @@ class CollectionObserver
   end
 
   def self.create_settings_updated_event(collection:, change_set:, form:, user:)
-    event_params = { user: user, event_type: 'settings_updated' }.tap do |params|
-      description = CollectionEventDescriptionBuilder.build(change_set: change_set, form: form)
+    event_params = { user:, event_type: 'settings_updated' }.tap do |params|
+      description = CollectionEventDescriptionBuilder.build(change_set:, form:)
       params[:description] = description if description.present?
     end
     collection.events.create(event_params)
@@ -54,13 +54,13 @@ class CollectionObserver
   def self.mailer_with_owner(user:, work_version:)
     owner = work_version.work.owner
     collection = work_version.work.collection
-    CollectionsMailer.with(user: user, collection_version: collection.head, owner: owner)
+    CollectionsMailer.with(user:, collection_version: collection.head, owner:)
   end
   private_class_method :mailer_with_owner
 
   def self.depositors_added(collection_version, change_set)
     change_set.added_depositors.each do |depositor|
-      CollectionsMailer.with(collection_version: collection_version, user: depositor)
+      CollectionsMailer.with(collection_version:, user: depositor)
                        .invitation_to_deposit_email.deliver_later
     end
   end
@@ -68,7 +68,7 @@ class CollectionObserver
 
   def self.managers_added(collection_version, change_set)
     change_set.added_managers.each do |manager|
-      CollectionsMailer.with(collection_version: collection_version, user: manager)
+      CollectionsMailer.with(collection_version:, user: manager)
                        .manage_access_granted_email.deliver_later
     end
   end
@@ -76,7 +76,7 @@ class CollectionObserver
 
   def self.managers_removed(collection_version, change_set)
     change_set.removed_managers.each do |manager|
-      CollectionsMailer.with(collection_version: collection_version, user: manager)
+      CollectionsMailer.with(collection_version:, user: manager)
                        .manage_access_removed_email.deliver_later
     end
   end
@@ -84,7 +84,7 @@ class CollectionObserver
 
   def self.depositors_removed(collection_version, change_set)
     change_set.removed_depositors.each do |depositor|
-      CollectionsMailer.with(collection_version: collection_version, user: depositor)
+      CollectionsMailer.with(collection_version:, user: depositor)
                        .deposit_access_removed_email.deliver_later
     end
   end
@@ -92,7 +92,7 @@ class CollectionObserver
 
   def self.reviewers_added(collection_version, change_set)
     change_set.added_reviewers.each do |reviewer|
-      CollectionsMailer.with(collection_version: collection_version, user: reviewer)
+      CollectionsMailer.with(collection_version:, user: reviewer)
                        .review_access_granted_email.deliver_later
     end
   end
@@ -100,7 +100,7 @@ class CollectionObserver
 
   def self.reviewers_removed(collection_version, change_set)
     change_set.removed_reviewers.each do |reviewer|
-      CollectionsMailer.with(collection_version: collection_version, user: reviewer)
+      CollectionsMailer.with(collection_version:, user: reviewer)
                        .review_access_removed_email.deliver_later
     end
   end
@@ -112,7 +112,7 @@ class CollectionObserver
     (collection.managed_by + collection.reviewed_by).uniq.each do |user|
       # Don't send if the user is the only changed participant.
       unless change_set.changed_participants == [user]
-        CollectionsMailer.with(collection_version: collection.head, user: user)
+        CollectionsMailer.with(collection_version: collection.head, user:)
                          .participants_changed_email.deliver_later
       end
     end

--- a/app/services/collection_reminder_generator.rb
+++ b/app/services/collection_reminder_generator.rb
@@ -18,7 +18,7 @@ class CollectionReminderGenerator
     eligible_collections(first_interval, subsequent_interval).each do |state, scope|
       scope.find_each do |collection_version|
         collection_version.collection.managed_by.each do |user|
-          mailer = CollectionsMailer.with(collection_version: collection_version, user: user)
+          mailer = CollectionsMailer.with(collection_version:, user:)
           case state
           when :first_draft
             mailer.first_draft_reminder_email.deliver_later
@@ -35,7 +35,7 @@ class CollectionReminderGenerator
     query = '(((CURRENT_DATE - CAST(created_at AS DATE)) - :first_interval) % :subsequent_interval) = 0'
     %i[first_draft version_draft].index_with do |state|
       CollectionVersion.with_state(state)
-                       .where(query, first_interval: first_interval, subsequent_interval: subsequent_interval)
+                       .where(query, first_interval:, subsequent_interval:)
     end
   end
 end

--- a/app/services/deposit_completer.rb
+++ b/app/services/deposit_completer.rb
@@ -3,7 +3,7 @@
 # Completes the deposit of an object
 class DepositCompleter
   def self.complete(object_version:)
-    new(object_version: object_version).complete
+    new(object_version:).complete
   end
 
   attr_reader :object_version

--- a/app/services/orcid_service.rb
+++ b/app/services/orcid_service.rb
@@ -3,7 +3,7 @@
 # This looks up a name from ORCID.org
 class OrcidService
   def self.lookup(orcid:)
-    new(orcid: orcid).lookup
+    new(orcid:).lookup
   end
 
   def initialize(orcid:)

--- a/app/services/work_observer.rb
+++ b/app/services/work_observer.rb
@@ -50,21 +50,21 @@ class WorkObserver
   def self.after_submit_for_review(work_version, _transition)
     collection = work_version.work.collection
     (collection.reviewed_by + collection.managed_by - [work_version.work.owner]).each do |recipient|
-      ReviewersMailer.with(user: recipient, work_version: work_version).submitted_email.deliver_later
+      ReviewersMailer.with(user: recipient, work_version:).submitted_email.deliver_later
     end
     work_mailer(work_version).submitted_email.deliver_later
   end
 
   def self.after_decommission(work_version, _transition)
-    WorksMailer.with(work_version: work_version).decommission_owner_email.deliver_later
+    WorksMailer.with(work_version:).decommission_owner_email.deliver_later
     collection = work_version.work.collection
     collection.managed_by.each do |recipient|
-      WorksMailer.with(user: recipient, work_version: work_version).decommission_manager_email.deliver_later
+      WorksMailer.with(user: recipient, work_version:).decommission_manager_email.deliver_later
     end
   end
 
   def self.work_mailer(work_version)
-    WorksMailer.with(user: work_version.work.owner, work_version: work_version)
+    WorksMailer.with(user: work_version.work.owner, work_version:)
   end
   private_class_method :work_mailer
 end

--- a/app/services/work_reminder_generator.rb
+++ b/app/services/work_reminder_generator.rb
@@ -16,7 +16,7 @@ class WorkReminderGenerator
 
     eligible_works(first_interval, subsequent_interval).each do |state, scope|
       scope.find_each do |work_version|
-        mailer = WorksMailer.with(work_version: work_version)
+        mailer = WorksMailer.with(work_version:)
         case state
         when :first_draft
           mailer.first_draft_reminder_email.deliver_later
@@ -31,7 +31,7 @@ class WorkReminderGenerator
     %i[first_draft version_draft].index_with do |state|
       WorkVersion.with_state(state)
                  .where('(((CURRENT_DATE - CAST(created_at AS DATE)) - :first_interval) % :subsequent_interval) = 0',
-                        first_interval: first_interval, subsequent_interval: subsequent_interval)
+                        first_interval:, subsequent_interval:)
     end
   end
 end

--- a/cypress/cypress_helper.rb
+++ b/cypress/cypress_helper.rb
@@ -32,7 +32,7 @@ factory = FactoryGirl if defined?(FactoryGirl)
 
 CypressOnRails::SmartFactoryWrapper.configure(
   always_reload: false,
-  factory: factory,
+  factory:,
   files: [
     Rails.root.join('spec/factories.rb'),
     Rails.root.join('spec/factories/**/*.rb')

--- a/lib/tasks/deposit.rake
+++ b/lib/tasks/deposit.rake
@@ -5,9 +5,9 @@ task complete_deposits: :environment do
   abort 'ERROR: This task only runs in the development environment!' unless Rails.env.development?
 
   objects_awaiting_deposit.each do |object_version|
-    deposit_completer = DepositCompleter.new(object_version: object_version)
+    deposit_completer = DepositCompleter.new(object_version:)
     druid = deposit_completer.parent.druid.presence || random_druid
-    deposit_completer.parent.update(druid: druid)
+    deposit_completer.parent.update(druid:)
     deposit_completer.complete
     puts "Marked #{object_version.class} id=#{object_version.id} as deposited with #{druid}"
   end
@@ -19,7 +19,7 @@ task assign_pids: :environment do
 
   WorkVersion.with_state('reserving_purl').each do |object|
     druid = random_druid
-    object.work.update(druid: druid)
+    object.work.update(druid:)
     object.pid_assigned!
     puts "Assigned #{druid} to #{object.title} (id=#{object.id})"
   end

--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ApplicationCable::Connection do
   let(:env) { { 'warden' => warden } }
   let(:mount_path) { Rails.application.config.action_cable.mount_path }
-  let(:warden) { instance_double(Warden::Proxy, user: user) }
+  let(:warden) { instance_double(Warden::Proxy, user:) }
 
   before do
     allow_any_instance_of(described_class).to receive(:env).and_return(env)

--- a/spec/components/admin/all_collections_row_component_spec.rb
+++ b/spec/components/admin/all_collections_row_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Admin::AllCollectionsRowComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(collection: collection, counts: counts)) }
+  let(:rendered) { render_inline(described_class.new(collection:, counts:)) }
   let(:collection) { build_stubbed(:collection, head: collection_version) }
   let(:collection_version) { build_stubbed(:collection_version) }
   let(:counts) { {} }

--- a/spec/components/breadcrumb_nav_component_spec.rb
+++ b/spec/components/breadcrumb_nav_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe BreadcrumbNavComponent, type: :component do
-  let(:nav) { described_class.new(breadcrumbs: breadcrumbs) }
+  let(:nav) { described_class.new(breadcrumbs:) }
   let(:rendered) { render_inline(nav) }
 
   context 'when no breadcrumbs' do

--- a/spec/components/citation_component_spec.rb
+++ b/spec/components/citation_component_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe CitationComponent, type: :component do
   subject(:button) { rendered.css('button').first }
 
-  let(:rendered) { render_inline(described_class.new(work_version: work_version)) }
+  let(:rendered) { render_inline(described_class.new(work_version:)) }
 
   context 'when the state is deposited' do
     let(:work_version) { build(:work_version, :deposited) }

--- a/spec/components/collections/detail_component_spec.rb
+++ b/spec/components/collections/detail_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collections::DetailComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(collection_version: collection_version)) }
+  let(:rendered) { render_inline(described_class.new(collection_version:)) }
 
   context 'when a first draft' do
     let(:collection_version) { build_stubbed(:collection_version, :with_contact_emails) }

--- a/spec/components/collections/draft_component_spec.rb
+++ b/spec/components/collections/draft_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collections::DraftComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(collection_version: collection_version)) }
+  let(:rendered) { render_inline(described_class.new(collection_version:)) }
 
   context 'when a first draft' do
     let(:collection_version) { build_stubbed(:collection_version, state: 'first_draft') }

--- a/spec/components/collections/edit_license_component_spec.rb
+++ b/spec/components/collections/edit_license_component_spec.rb
@@ -3,12 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Collections::EditLicenseComponent, type: :component do
-  subject(:rendered) { render_inline(described_class.new(form: form)) }
+  subject(:rendered) { render_inline(described_class.new(form:)) }
 
   let(:collection) { build(:collection) }
   let(:collection_version) { build(:collection_version) }
 
-  let(:collection_form) { CreateCollectionForm.new(collection: collection, collection_version: collection_version) }
+  let(:collection_form) { CreateCollectionForm.new(collection:, collection_version:) }
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, collection_form, controller.view_context, {}) }
 
   context 'with no license selected' do

--- a/spec/components/collections/history_component_spec.rb
+++ b/spec/components/collections/history_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collections::HistoryComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(collection: collection)) }
+  let(:rendered) { render_inline(described_class.new(collection:)) }
 
   context 'when viewing a collection' do
     let(:collection) { build_stubbed(:collection) }

--- a/spec/components/collections/information_component_spec.rb
+++ b/spec/components/collections/information_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collections::InformationComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(collection_version: collection_version)) }
+  let(:rendered) { render_inline(described_class.new(collection_version:)) }
 
   context 'when a first version collection' do
     let(:collection_version) { build_stubbed(:collection_version) }

--- a/spec/components/collections/link_to_show_component_spec.rb
+++ b/spec/components/collections/link_to_show_component_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Collections::LinkToShowComponent, type: :component do
-  let(:render) { render_inline(described_class.new(collection_version: collection_version)) }
-  let(:collection_version) { build_stubbed(:collection_version, name: name) }
+  let(:render) { render_inline(described_class.new(collection_version:)) }
+  let(:collection_version) { build_stubbed(:collection_version, name:) }
   let(:name) do
     'collection name'
   end

--- a/spec/components/collections/links_component_spec.rb
+++ b/spec/components/collections/links_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collections::LinksComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(collection_version: collection_version)) }
+  let(:rendered) { render_inline(described_class.new(collection_version:)) }
 
   context 'when it has links' do
     let(:collection_version) { build_stubbed(:collection_version, :with_related_links) }

--- a/spec/components/collections/participants_component_spec.rb
+++ b/spec/components/collections/participants_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collections::ParticipantsComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(collection: collection)) }
+  let(:rendered) { render_inline(described_class.new(collection:)) }
 
   context 'when displaying a collection' do
     let(:depositors) { collection.depositors.map(&:sunetid).join(', ') }

--- a/spec/components/collections/release_component_spec.rb
+++ b/spec/components/collections/release_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collections::ReleaseComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(collection: collection)) }
+  let(:rendered) { render_inline(described_class.new(collection:)) }
   let(:collection_version) { build_stubbed(:collection_version) }
 
   context 'when displaying a collection' do
@@ -21,7 +21,7 @@ RSpec.describe Collections::ReleaseComponent, type: :component do
       build_stubbed(:collection, release_option: 'depositor-selects', release_duration: '3 years',
                                  head: collection_version)
     end
-    let(:rendered) { render_inline(described_class.new(collection: collection)) }
+    let(:rendered) { render_inline(described_class.new(collection:)) }
     let(:message) { 'depositor selects release date at no more than 3 years from date of deposit' }
 
     it 'renders the release component with more detail regarding the release' do
@@ -33,7 +33,7 @@ RSpec.describe Collections::ReleaseComponent, type: :component do
     let(:collection) do
       build_stubbed(:collection, release_option: 'delay', release_duration: '2 years', head: collection_version)
     end
-    let(:rendered) { render_inline(described_class.new(collection: collection)) }
+    let(:rendered) { render_inline(described_class.new(collection:)) }
 
     it 'renders the release component with a delayed option' do
       expect(rendered.css('table').to_html).to include('2 years from date of deposit')
@@ -44,7 +44,7 @@ RSpec.describe Collections::ReleaseComponent, type: :component do
     let(:collection) do
       build_stubbed(:collection, doi_option: 'no', head: collection_version)
     end
-    let(:rendered) { render_inline(described_class.new(collection: collection)) }
+    let(:rendered) { render_inline(described_class.new(collection:)) }
 
     it 'renders the release component with the DOI assignment message' do
       expect(rendered.css('table').to_html).to include('Not assigned')
@@ -55,7 +55,7 @@ RSpec.describe Collections::ReleaseComponent, type: :component do
     let(:collection) do
       build_stubbed(:collection, doi_option: 'yes', head: collection_version)
     end
-    let(:rendered) { render_inline(described_class.new(collection: collection)) }
+    let(:rendered) { render_inline(described_class.new(collection:)) }
 
     it 'renders the release component with the DOI assignment message' do
       expect(rendered.css('table').to_html).to include('Automatically assigned')
@@ -66,7 +66,7 @@ RSpec.describe Collections::ReleaseComponent, type: :component do
     let(:collection) do
       build_stubbed(:collection, doi_option: 'depositor-selects', head: collection_version)
     end
-    let(:rendered) { render_inline(described_class.new(collection: collection)) }
+    let(:rendered) { render_inline(described_class.new(collection:)) }
 
     it 'renders the release component with the DOI assignment message' do
       expect(rendered.css('table').to_html).to include('Depositor selects')

--- a/spec/components/collections/show/deposits_header_component_spec.rb
+++ b/spec/components/collections/show/deposits_header_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collections::Show::DepositsHeaderComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(collection_version: collection_version)) }
+  let(:rendered) { render_inline(described_class.new(collection_version:)) }
 
   context 'with a new, first draft collection' do
     let(:collection_version) { build_stubbed(:collection_version, :first_draft) }

--- a/spec/components/collections/show/details_header_component_spec.rb
+++ b/spec/components/collections/show/details_header_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collections::Show::DetailsHeaderComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(collection_version: collection_version)) }
+  let(:rendered) { render_inline(described_class.new(collection_version:)) }
 
   context 'with a new, first draft collection' do
     let(:collection_version) { build_stubbed(:collection_version, :first_draft) }

--- a/spec/components/collections/show/settings_header_component_spec.rb
+++ b/spec/components/collections/show/settings_header_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collections::Show::SettingsHeaderComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(collection_version: collection_version)) }
+  let(:rendered) { render_inline(described_class.new(collection_version:)) }
 
   context 'with a new, first draft collection' do
     let(:collection_version) { build_stubbed(:collection_version, :first_draft) }

--- a/spec/components/collections/terms_of_use_component_spec.rb
+++ b/spec/components/collections/terms_of_use_component_spec.rb
@@ -3,13 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe Collections::TermsOfUseComponent, type: :component do
-  subject(:rendered) { render_inline(described_class.new(collection: collection)).to_html }
+  subject(:rendered) { render_inline(described_class.new(collection:)).to_html }
 
   let(:collection_version) { build_stubbed(:collection_version) }
 
   context 'with a collection that has a required license' do
     let(:collection) do
-      build_stubbed(:collection, :with_required_license, required_license: required_license,
+      build_stubbed(:collection, :with_required_license, required_license:,
                                                          head: collection_version)
     end
     let(:required_license) { 'MIT' }
@@ -20,7 +20,7 @@ RSpec.describe Collections::TermsOfUseComponent, type: :component do
 
   context 'with a collection that has a default license' do
     let(:collection) do
-      build_stubbed(:collection, default_license: default_license, head: collection_version)
+      build_stubbed(:collection, default_license:, head: collection_version)
     end
     let(:default_license) { 'Apache-2.0' }
 

--- a/spec/components/collections/version_description_component_spec.rb
+++ b/spec/components/collections/version_description_component_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Collections::VersionDescriptionComponent do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, collection_form, controller.view_context, {}) }
-  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:rendered) { render_inline(described_class.new(form:)) }
   let(:collection) { build_stubbed(:collection, head: collection_version) }
   let(:collection_form) { DraftCollectionVersionForm.new(collection_version) }
 

--- a/spec/components/collections/workflow_review_component_spec.rb
+++ b/spec/components/collections/workflow_review_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Collections::WorkflowReviewComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(collection: collection)) }
+  let(:rendered) { render_inline(described_class.new(collection:)) }
 
   context 'when displaying a collection' do
     let(:reviewers) { collection.reviewed_by.map(&:sunetid).join(', ') }

--- a/spec/components/collections/works_component_spec.rb
+++ b/spec/components/collections/works_component_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe Collections::WorksComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(collection: collection)) }
+  let(:rendered) { render_inline(described_class.new(collection:)) }
 
   context 'when displaying a collections works' do
     let(:collection) { create(:collection) }
-    let(:user_with_groups) { UserWithGroups.new(user: user, groups: groups) }
+    let(:user_with_groups) { UserWithGroups.new(user:, groups:) }
     let(:user) { create(:user) }
-    let(:work1) { create(:work, collection: collection, depositor: user) }
-    let(:work2) { create(:work, collection: collection) }
+    let(:work1) { create(:work, collection:, depositor: user) }
+    let(:work2) { create(:work, collection:) }
     let(:work_version1) { create(:work_version, work: work1) }
     let(:work_version2) { create(:work_version, work: work2) }
 
@@ -20,7 +20,7 @@ RSpec.describe Collections::WorksComponent, type: :component do
 
       allow(controller).to receive_messages(
         current_user: user,
-        user_with_groups: user_with_groups
+        user_with_groups:
       )
     end
 

--- a/spec/components/dashboard/collection_component_spec.rb
+++ b/spec/components/dashboard/collection_component_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Dashboard::CollectionComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(collection: collection)) }
+  let(:rendered) { render_inline(described_class.new(collection:)) }
   let(:collection) { build_stubbed(:collection, head: collection_version) }
   let(:collection_version) { build_stubbed(:collection_version) }
-  let(:user_with_groups) { UserWithGroups.new(user: user, groups: []) }
+  let(:user_with_groups) { UserWithGroups.new(user:, groups: []) }
   let(:user) { create(:user) }
   let(:work_path) { Rails.application.routes.url_helpers.work_path(user.owned_works.first) }
 
@@ -14,7 +14,7 @@ RSpec.describe Dashboard::CollectionComponent, type: :component do
     allow(controller).to receive_messages(
       allowed_to?: false,
       current_user: user,
-      user_with_groups: user_with_groups
+      user_with_groups:
     )
   end
 
@@ -53,8 +53,8 @@ RSpec.describe Dashboard::CollectionComponent, type: :component do
     let(:collection_version) { create(:collection_version_with_collection) }
 
     before do
-      create(:work_version_with_work, collection: collection, owner: user, title: 'my work')
-      create(:work_version_with_work, collection: collection, title: 'not mine')
+      create(:work_version_with_work, collection:, owner: user, title: 'my work')
+      create(:work_version_with_work, collection:, title: 'not mine')
     end
 
     context 'when the user is a depositor' do
@@ -80,8 +80,8 @@ RSpec.describe Dashboard::CollectionComponent, type: :component do
 
     before do
       4.times do
-        work = create(:work, collection: collection, owner: user)
-        version = create(:work_version, work: work)
+        work = create(:work, collection:, owner: user)
+        version = create(:work_version, work:)
         work.update(head: version)
       end
     end
@@ -98,8 +98,8 @@ RSpec.describe Dashboard::CollectionComponent, type: :component do
 
     before do
       5.times do
-        work = create(:work, collection: collection, owner: user)
-        version = create(:work_version, work: work)
+        work = create(:work, collection:, owner: user)
+        version = create(:work_version, work:)
         work.update(head: version)
       end
     end
@@ -112,10 +112,10 @@ RSpec.describe Dashboard::CollectionComponent, type: :component do
   context 'with a work that has a druid' do
     let(:collection) { collection_version.collection }
     let(:collection_version) { create(:collection_version_with_collection) }
-    let(:work) { create(:work, collection: collection, owner: user, druid: 'druid:yq268qt4607') }
+    let(:work) { create(:work, collection:, owner: user, druid: 'druid:yq268qt4607') }
 
     before do
-      version = create(:work_version, work: work)
+      version = create(:work_version, work:)
       work.update(head: version)
     end
 

--- a/spec/components/dashboard/collection_header_component_spec.rb
+++ b/spec/components/dashboard/collection_header_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Dashboard::CollectionHeaderComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(collection_version: collection_version)) }
+  let(:rendered) { render_inline(described_class.new(collection_version:)) }
 
   context 'with a new, first draft collection' do
     let(:collection_version) { build_stubbed(:collection_version, :first_draft) }

--- a/spec/components/dashboard/continue_deposit_modal_component_spec.rb
+++ b/spec/components/dashboard/continue_deposit_modal_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Dashboard::ContinueDepositModalComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(presenter: presenter)) }
+  let(:rendered) { render_inline(described_class.new(presenter:)) }
 
   context 'when show_popup is true' do
     let(:show_popup) { true }

--- a/spec/components/dashboard/in_progress_collection_component_spec.rb
+++ b/spec/components/dashboard/in_progress_collection_component_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Dashboard::InProgressCollectionComponent, type: :component do
   let(:presenter) do
     instance_double(DashboardPresenter, collection_managers_in_progress: collection_versions)
   end
-  let(:user_with_groups) { UserWithGroups.new(user: user, groups: []) }
+  let(:user_with_groups) { UserWithGroups.new(user:, groups: []) }
   let(:user) { create(:user) }
-  let(:rendered) { render_inline(described_class.new(presenter: presenter)) }
+  let(:rendered) { render_inline(described_class.new(presenter:)) }
 
   before do
     allow(controller).to receive_messages(
       current_user: user,
-      user_with_groups: user_with_groups
+      user_with_groups:
     )
   end
 

--- a/spec/components/dashboard/in_progress_collection_row_component_spec.rb
+++ b/spec/components/dashboard/in_progress_collection_row_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Dashboard::InProgressCollectionRowComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(collection_version: collection_version)) }
+  let(:rendered) { render_inline(described_class.new(collection_version:)) }
   let(:collection_version) { create(:collection_version_with_collection) }
 
   it 'renders the component' do

--- a/spec/components/dashboard/in_progress_component_spec.rb
+++ b/spec/components/dashboard/in_progress_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Dashboard::InProgressComponent, type: :component do
   let(:presenter) do
     instance_double(DashboardPresenter, in_progress: work_versions)
   end
-  let(:rendered) { render_inline(described_class.new(presenter: presenter)) }
+  let(:rendered) { render_inline(described_class.new(presenter:)) }
 
   before do
     allow(controller).to receive(:allowed_to?).and_return(true)
@@ -26,9 +26,9 @@ RSpec.describe Dashboard::InProgressComponent, type: :component do
 
     before do
       collection = create(:collection_version_with_collection).collection
-      create(:work_version, work: create(:work, collection: collection))
-      create(:work_version, work: create(:work, collection: collection))
-      create(:work_version, work: create(:work, collection: collection))
+      create(:work_version, work: create(:work, collection:))
+      create(:work_version, work: create(:work, collection:))
+      create(:work_version, work: create(:work, collection:))
     end
 
     it 'renders the component with works' do

--- a/spec/components/dashboard/in_progress_row_component_spec.rb
+++ b/spec/components/dashboard/in_progress_row_component_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Dashboard::InProgressRowComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(work_version: work_version)) }
-  let(:work_version) { build_stubbed(:work_version, work: work) }
-  let(:work) { build_stubbed(:work, collection: collection) }
+  let(:rendered) { render_inline(described_class.new(work_version:)) }
+  let(:work_version) { build_stubbed(:work_version, work:) }
+  let(:work) { build_stubbed(:work, collection:) }
   let(:collection_version) { build_stubbed(:collection_version) }
   let(:collection) { build_stubbed(:collection, head: collection_version) }
 

--- a/spec/components/first_draft_collections/buttons_component_spec.rb
+++ b/spec/components/first_draft_collections/buttons_component_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe FirstDraftCollections::ButtonsComponent do
-  let(:component) { described_class.new(form: form) }
+  let(:component) { described_class.new(form:) }
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
   let(:collection) { build(:collection) }
   let(:collection_version) { build(:collection_version) }
-  let(:work_form) { CreateCollectionForm.new(collection: collection, collection_version: collection_version) }
+  let(:work_form) { CreateCollectionForm.new(collection:, collection_version:) }
   let(:rendered) { render_inline(component) }
 
   before do

--- a/spec/components/related_link_component_spec.rb
+++ b/spec/components/related_link_component_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe RelatedLinkComponent, type: :component do
       build_stubbed(:related_link, link_title: 'Second Link')
     ]
   end
-  let(:rendered) { render_inline(described_class.new(form: form, key: 'foo')) }
+  let(:rendered) { render_inline(described_class.new(form:, key: 'foo')) }
 
   context 'with a work' do
     let(:work) { work_version.work }
-    let(:work_version) { build_stubbed(:work_version, related_links: related_links) }
-    let(:model_form) { WorkForm.new(work_version: work_version, work: work) }
+    let(:work_version) { build_stubbed(:work_version, related_links:) }
+    let(:model_form) { WorkForm.new(work_version:, work:) }
 
     it 'renders a delete button for all links' do
       expect(rendered.css('button[@aria-label="Remove Second Link"]')).to be_present
@@ -24,9 +24,9 @@ RSpec.describe RelatedLinkComponent, type: :component do
   end
 
   context 'with a collection' do
-    let(:model_form) { CreateCollectionForm.new(collection: collection, collection_version: collection_version) }
+    let(:model_form) { CreateCollectionForm.new(collection:, collection_version:) }
     let(:collection) { collection_version.collection }
-    let(:collection_version) { build_stubbed(:collection_version, related_links: related_links) }
+    let(:collection_version) { build_stubbed(:collection_version, related_links:) }
 
     it 'renders a delete button for all links' do
       expect(rendered.css('button[@aria-label="Remove Second Link"]')).to be_present

--- a/spec/components/works/access_component_spec.rb
+++ b/spec/components/works/access_component_spec.rb
@@ -5,10 +5,10 @@ require 'rails_helper'
 RSpec.describe Works::AccessComponent, type: :component do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
   let(:collection) { build(:collection, release_option: 'immediate') }
-  let(:work) { build(:work, collection: collection) }
-  let(:work_version) { build(:work_version, work: work) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
-  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:work) { build(:work, collection:) }
+  let(:work_version) { build(:work_version, work:) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
+  let(:rendered) { render_inline(described_class.new(form:)) }
 
   before do
     work_form.prepopulate!
@@ -20,7 +20,7 @@ RSpec.describe Works::AccessComponent, type: :component do
   end
 
   context 'when collection access is depositor selects' do
-    let(:work) { build(:work, collection: collection) }
+    let(:work) { build(:work, collection:) }
     let(:collection) { build(:collection, :depositor_selects_access, release_option: 'immediate') }
 
     it 'renders the access selector' do

--- a/spec/components/works/add_files_component_spec.rb
+++ b/spec/components/works/add_files_component_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 
 RSpec.describe Works::AddFilesComponent do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
-  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:rendered) { render_inline(described_class.new(form:)) }
   let(:work) { build(:work) }
-  let(:work_version) { build(:work_version, work: work) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
+  let(:work_version) { build(:work_version, work:) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
 
   context 'with an unpersisted file component' do
     it 'renders the component' do

--- a/spec/components/works/agreement_component_spec.rb
+++ b/spec/components/works/agreement_component_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 
 RSpec.describe Works::AgreementComponent do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
-  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:rendered) { render_inline(described_class.new(form:)) }
   let(:work) { build(:work) }
-  let(:work_version) { build(:work_version, work: work) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
+  let(:work_version) { build(:work_version, work:) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
 
   it 'renders the component' do
     expect(rendered.to_html)

--- a/spec/components/works/approval_component_spec.rb
+++ b/spec/components/works/approval_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Works::ApprovalComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(work_version: work_version)) }
+  let(:rendered) { render_inline(described_class.new(work_version:)) }
   let(:work_version) { build_stubbed(:work_version) }
 
   context 'when not needing approval' do

--- a/spec/components/works/available_date_component_spec.rb
+++ b/spec/components/works/available_date_component_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Works::AvailableDateComponent, type: :component do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
   let(:work) { work_version.work }
   let(:work_version) { build(:work_version) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
-  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
+  let(:rendered) { render_inline(described_class.new(form:)) }
 
   before do
     work_form.prepopulate!

--- a/spec/components/works/buttons_component_spec.rb
+++ b/spec/components/works/buttons_component_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Works::ButtonsComponent do
-  let(:component) { described_class.new(form: form) }
+  let(:component) { described_class.new(form:) }
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
   let(:rendered) { render_inline(component) }
 
   before do
@@ -14,7 +14,7 @@ RSpec.describe Works::ButtonsComponent do
 
   context 'when work is not persisted' do
     let(:work) { build(:work, collection: build(:collection, id: 7)) }
-    let(:work_version) { build(:work_version, work: work, state: 'new') }
+    let(:work_version) { build(:work_version, work:, state: 'new') }
 
     it 'renders cancel button with target location as work show page' do
       expect(rendered.css('a[text()="Cancel"]')).to be_present
@@ -24,7 +24,7 @@ RSpec.describe Works::ButtonsComponent do
 
   context 'when work is persisted' do
     let(:work) { build_stubbed(:work, collection: build(:collection, id: 7)) }
-    let(:work_version) { build(:work_version, work: work) }
+    let(:work_version) { build(:work_version, work:) }
 
     it 'renders cancel button with target location as work show page' do
       expect(rendered.css('a[text()="Cancel"]')).to be_present

--- a/spec/components/works/contact_email_component_spec.rb
+++ b/spec/components/works/contact_email_component_spec.rb
@@ -5,9 +5,9 @@ require 'rails_helper'
 RSpec.describe Works::ContactEmailComponent, type: :component do
   let(:work) { work_version.work }
   let(:work_version) { build_stubbed(:work_version) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
   let(:form) { ActionView::Helpers::FormBuilder.new('work', work_form, controller.view_context, {}) }
-  let(:rendered) { render_inline(described_class.new(form: form, key: 'work.contact_email')) }
+  let(:rendered) { render_inline(described_class.new(form:, key: 'work.contact_email')) }
 
   it 'renders the component' do
     expect(rendered.to_html).to include('Contact email')

--- a/spec/components/works/contact_email_row_component_spec.rb
+++ b/spec/components/works/contact_email_row_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Works::ContactEmailRowComponent, type: :component do
   let(:collection) { build(:collection) }
   let(:collection_version) { build(:collection_version) }
 
-  let(:parent_form) { CreateCollectionForm.new(collection: collection, collection_version: collection_version) }
+  let(:parent_form) { CreateCollectionForm.new(collection:, collection_version:) }
   let(:email_form) do
     parent_form.prepopulate!
     parent_form.contact_emails.first

--- a/spec/components/works/contributor_role_component_spec.rb
+++ b/spec/components/works/contributor_role_component_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Works::ContributorRoleComponent do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, nil, controller.view_context, {}) }
-  let(:rendered) { render_inline(described_class.new(form: form, data_options: { contributors_target: 'role' })) }
+  let(:rendered) { render_inline(described_class.new(form:, data_options: { contributors_target: 'role' })) }
 
   it 'makes groups with headings including Department' do
     expected = <<~HTML

--- a/spec/components/works/contributor_row_component_spec.rb
+++ b/spec/components/works/contributor_row_component_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 
 RSpec.describe Works::ContributorRowComponent do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, author, controller.view_context, {}) }
-  let(:component) { described_class.new(form: form, is_author: is_author) }
+  let(:component) { described_class.new(form:, is_author:) }
   let(:rendered) { render_inline(component) }
-  let(:author) { build_stubbed(:person_author, orcid: orcid) }
+  let(:author) { build_stubbed(:person_author, orcid:) }
   let(:is_author) { true }
   let(:orcid) { nil }
 

--- a/spec/components/works/contributors_component_spec.rb
+++ b/spec/components/works/contributors_component_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Works::ContributorsComponent do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
   let(:work) { work_version.work }
   let(:work_version) { build(:work_version) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
-  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
+  let(:rendered) { render_inline(described_class.new(form:)) }
 
   it 'renders the component' do
     expect(rendered.to_html).to include 'Additional contributors'

--- a/spec/components/works/dates_component_spec.rb
+++ b/spec/components/works/dates_component_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Works::DatesComponent do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
   let(:work) { work_version.work }
   let(:work_version) { build(:work_version) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
-  let(:rendered) { render_inline(described_class.new(form: form, min_year: 1000, max_year: 2020)) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
+  let(:rendered) { render_inline(described_class.new(form:, min_year: 1000, max_year: 2020)) }
 
   before do
     work_form.prepopulate!

--- a/spec/components/works/description_component_spec.rb
+++ b/spec/components/works/description_component_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Works::DescriptionComponent do
   let(:form) { ActionView::Helpers::FormBuilder.new('work', work_form, controller.view_context, {}) }
   let(:work) { work_version.work }
   let(:work_version) { build_stubbed(:work_version) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
-  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
+  let(:rendered) { render_inline(described_class.new(form:)) }
 
   it 'renders the component' do
-    expect(render_inline(described_class.new(form: form)).to_html)
+    expect(render_inline(described_class.new(form:)).to_html)
       .to include('Describe your deposit')
   end
 

--- a/spec/components/works/detail_component_spec.rb
+++ b/spec/components/works/detail_component_spec.rb
@@ -3,15 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe Works::DetailComponent, type: :component do
-  let(:instance) { described_class.new(work_version: work_version) }
+  let(:instance) { described_class.new(work_version:) }
   let(:rendered) { render_inline(instance) }
   let(:user) { build(:user, name: 'Pyotr Kropotkin', email: 'kropot00@stanford.edu') }
-  let(:user_with_groups) { UserWithGroups.new(user: user, groups: []) }
+  let(:user_with_groups) { UserWithGroups.new(user:, groups: []) }
 
   before do
     allow(controller).to receive_messages(
       current_user: user,
-      user_with_groups: user_with_groups
+      user_with_groups:
     )
     allow(work_version.work.collection).to receive(:head).and_return(build_stubbed(:collection_version))
   end
@@ -54,7 +54,7 @@ RSpec.describe Works::DetailComponent, type: :component do
   context 'when rejected' do
     let(:rejection_reason) { 'Why did you dye your hair chartreuse?' }
     let(:work) { build_stubbed(:work) }
-    let(:work_version) { build_stubbed(:work_version, :rejected, work: work) }
+    let(:work_version) { build_stubbed(:work_version, :rejected, work:) }
 
     before do
       create(:event, description: rejection_reason, event_type: 'reject', eventable: work)
@@ -66,14 +66,14 @@ RSpec.describe Works::DetailComponent, type: :component do
   end
 
   describe 'events' do
-    let(:work) { build_stubbed(:work, events: events) }
+    let(:work) { build_stubbed(:work, events:) }
     let(:events) do
       [
         build_stubbed(:event, description: 'Add more keywords'),
         build_stubbed(:embargo_lifted_event)
       ]
     end
-    let(:work_version) { build_stubbed(:work_version, work: work) }
+    let(:work_version) { build_stubbed(:work_version, work:) }
 
     it 'renders the event' do
       expect(rendered.css('#events').to_html).to include('Add more keywords', 'Embargo lifted')
@@ -97,7 +97,7 @@ RSpec.describe Works::DetailComponent, type: :component do
 
   describe 'DOI settings' do
     context 'with a DOI' do
-      let(:work_version) { build_stubbed(:work_version, :deposited, version: 2, work: work) }
+      let(:work_version) { build_stubbed(:work_version, :deposited, version: 2, work:) }
       let(:work) { build_stubbed(:work, doi: '10.25740/bc123df4567') }
 
       it 'renders the doi_link' do
@@ -106,7 +106,7 @@ RSpec.describe Works::DetailComponent, type: :component do
     end
 
     context 'when DOI was requested' do
-      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
+      let(:work_version) { build_stubbed(:work_version, :first_draft, work:) }
       let(:work) { build_stubbed(:work, assign_doi: true) }
 
       it 'renders the doi setting' do
@@ -115,8 +115,8 @@ RSpec.describe Works::DetailComponent, type: :component do
     end
 
     context 'when DOI was refused' do
-      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
-      let(:work) { build_stubbed(:work, assign_doi: false, collection: collection) }
+      let(:work_version) { build_stubbed(:work_version, :first_draft, work:) }
+      let(:work) { build_stubbed(:work, assign_doi: false, collection:) }
       let(:collection) { build_stubbed(:collection, doi_option: 'depositor-selects') }
 
       it 'renders the doi setting' do
@@ -125,8 +125,8 @@ RSpec.describe Works::DetailComponent, type: :component do
     end
 
     context "when collection doesn't permit DOIs" do
-      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
-      let(:work) { build_stubbed(:work, collection: collection, assign_doi: true) }
+      let(:work_version) { build_stubbed(:work_version, :first_draft, work:) }
+      let(:work) { build_stubbed(:work, collection:, assign_doi: true) }
       let(:collection) { build_stubbed(:collection, doi_option: 'no') }
 
       it 'renders the doi setting' do
@@ -135,8 +135,8 @@ RSpec.describe Works::DetailComponent, type: :component do
     end
 
     context 'when collection automatically assigns DOI' do
-      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
-      let(:work) { build_stubbed(:work, collection: collection, assign_doi: false) }
+      let(:work_version) { build_stubbed(:work_version, :first_draft, work:) }
+      let(:work) { build_stubbed(:work, collection:, assign_doi: false) }
       let(:collection) { build_stubbed(:collection, doi_option: 'yes') }
 
       it 'renders the doi setting' do

--- a/spec/components/works/doi_component_spec.rb
+++ b/spec/components/works/doi_component_spec.rb
@@ -5,13 +5,13 @@ require 'rails_helper'
 
 RSpec.describe Works::DoiComponent do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
-  let(:collection) { build(:collection, doi_option: doi_option) }
+  let(:collection) { build(:collection, doi_option:) }
   let(:doi_option) { 'yes' }
-  let(:work) { build(:work, collection: collection, doi: doi) }
+  let(:work) { build(:work, collection:, doi:) }
   let(:doi) { nil }
-  let(:work_version) { build(:work_version, work: work) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
-  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:work_version) { build(:work_version, work:) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
+  let(:rendered) { render_inline(described_class.new(form:)) }
 
   before do
     work_form.prepopulate!

--- a/spec/components/works/edit_button_component_spec.rb
+++ b/spec/components/works/edit_button_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Works::EditButtonComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(work_version: work_version)) }
+  let(:rendered) { render_inline(described_class.new(work_version:)) }
 
   context 'when the work is a draft' do
     let(:work_version) { build_stubbed(:work_version, :first_draft) }

--- a/spec/components/works/embargo_component_spec.rb
+++ b/spec/components/works/embargo_component_spec.rb
@@ -5,10 +5,10 @@ require 'rails_helper'
 RSpec.describe Works::EmbargoComponent do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
   let(:collection) { build(:collection, :depositor_selects_access, release_option: 'immediate') }
-  let(:work) { build(:work, collection: collection) }
-  let(:work_version) { build(:work_version, work: work) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
-  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:work) { build(:work, collection:) }
+  let(:work_version) { build(:work_version, work:) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
+  let(:rendered) { render_inline(described_class.new(form:)) }
 
   before do
     work.head = work_version
@@ -39,7 +39,7 @@ RSpec.describe Works::EmbargoComponent do
 
   context 'when the collection allows depositor to select release timing' do
     let(:collection) do
-      build(:collection, :depositor_selects_access, release_option: 'depositor-selects', review_enabled: review_enabled)
+      build(:collection, :depositor_selects_access, release_option: 'depositor-selects', review_enabled:)
     end
 
     context 'when collection does not require review' do
@@ -69,7 +69,7 @@ RSpec.describe Works::EmbargoComponent do
   end
 
   context 'when the collection has been deposited and release is immediate' do
-    let(:work_version) { build(:work_version, work: work, state: 'deposited') }
+    let(:work_version) { build(:work_version, work:, state: 'deposited') }
 
     it 'renders the component' do
       expect(rendered.to_html).to include 'This item was released immediately upon deposit.'
@@ -77,7 +77,7 @@ RSpec.describe Works::EmbargoComponent do
   end
 
   context 'when the collection has been deposited and embargo has elapsed' do
-    let(:work_version) { build(:work_version, work: work, state: 'deposited', embargo_date: Time.zone.today - 1.month) }
+    let(:work_version) { build(:work_version, work:, state: 'deposited', embargo_date: Time.zone.today - 1.month) }
 
     it 'renders the component' do
       expect(rendered.to_html).to include 'This item has been released from embargo.'
@@ -85,7 +85,7 @@ RSpec.describe Works::EmbargoComponent do
   end
 
   context 'when the collection has been deposited and embargo date is today' do
-    let(:work_version) { build(:work_version, work: work, state: 'deposited', embargo_date: Time.zone.today) }
+    let(:work_version) { build(:work_version, work:, state: 'deposited', embargo_date: Time.zone.today) }
 
     it 'renders the component' do
       expect(rendered.to_html).to include 'This item has been released from embargo.'
@@ -94,7 +94,7 @@ RSpec.describe Works::EmbargoComponent do
 
   context 'when the collection has been deposited and embargo has not elapsed' do
     let(:collection) { build(:collection, :depositor_selects_access, release_option: 'depositor-selects') }
-    let(:work_version) { build(:work_version, work: work, state: 'deposited', embargo_date: Time.zone.today + 1.month) }
+    let(:work_version) { build(:work_version, work:, state: 'deposited', embargo_date: Time.zone.today + 1.month) }
 
     it 'renders the component' do
       expect(rendered.to_html)

--- a/spec/components/works/form_component_spec.rb
+++ b/spec/components/works/form_component_spec.rb
@@ -3,12 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Works::FormComponent do
-  let(:component) { described_class.new(work_form: work_form) }
+  let(:component) { described_class.new(work_form:) }
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
   let(:collection) { build_stubbed(:collection, :depositor_selects_access, id: 7) }
-  let(:work) { build_stubbed(:work, collection: collection) }
-  let(:work_version) { build_stubbed(:work_version, work: work) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
+  let(:work) { build_stubbed(:work, collection:) }
+  let(:work_version) { build_stubbed(:work_version, work:) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
   let(:rendered) { render_inline(component) }
 
   before do

--- a/spec/components/works/keywords_component_spec.rb
+++ b/spec/components/works/keywords_component_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Works::KeywordsComponent do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
   let(:work) { work_version.work }
   let(:work_version) { build_stubbed(:work_version) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
-  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
+  let(:rendered) { render_inline(described_class.new(form:)) }
 
   it 'renders the component' do
     expect(rendered.to_html).to include('Keyword')

--- a/spec/components/works/keywords_row_component_spec.rb
+++ b/spec/components/works/keywords_row_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Works::KeywordsRowComponent do
 
   let(:work) { work_version.work }
   let(:work_version) { build_stubbed(:work_version) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
   let(:keyword_form) do
     work_form.prepopulate!
     work_form.keywords.first

--- a/spec/components/works/license_component_spec.rb
+++ b/spec/components/works/license_component_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 
 RSpec.describe Works::LicenseComponent do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
-  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:rendered) { render_inline(described_class.new(form:)) }
   let(:work) { work_version.work }
   let(:work_version) { build(:work_version) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
 
   context 'when the collection permits selecting a license' do
     context 'with no license selected' do
@@ -29,8 +29,8 @@ RSpec.describe Works::LicenseComponent do
 
     context 'when collection has a default license' do
       let(:collection) { build(:collection, default_license: 'PDDL-1.0') }
-      let(:work) { build(:work, collection: collection) }
-      let(:work_version) { build(:work_version, work: work, license: nil) }
+      let(:work) { build(:work, collection:) }
+      let(:work_version) { build(:work_version, work:, license: nil) }
 
       it 'renders the component with the collection default' do
         expect(rendered.css('option[selected]')).not_to be_empty

--- a/spec/components/works/link_to_show_component_spec.rb
+++ b/spec/components/works/link_to_show_component_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Works::LinkToShowComponent, type: :component do
-  let(:render) { render_inline(described_class.new(work_version: work_version)) }
-  let(:work_version) { build_stubbed(:work_version, title: title) }
+  let(:render) { render_inline(described_class.new(work_version:)) }
+  let(:work_version) { build_stubbed(:work_version, title:) }
   let(:title) do
     "Marfa gochujang 90's, normcore lomo chartreuse ethical man bun fashion axe " \
       'palo santo asymmetrical post-ironic. Kitsch sriracha affogato wayfarers woke neutra.'

--- a/spec/components/works/publication_date_component_spec.rb
+++ b/spec/components/works/publication_date_component_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Works::PublicationDateComponent, type: :component do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
   let(:work) { work_version.work }
   let(:work_version) { build(:work_version) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
-  let(:rendered) { render_inline(described_class.new(form: form, min_year: 999, max_year: 2040)) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
+  let(:rendered) { render_inline(described_class.new(form:, min_year: 999, max_year: 2040)) }
 
   context 'when there is an error' do
     before do

--- a/spec/components/works/related_work_component_spec.rb
+++ b/spec/components/works/related_work_component_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe Works::RelatedWorkComponent, type: :component do
       build_stubbed(:related_work, citation: 'Second Citation')
     ]
   end
-  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:rendered) { render_inline(described_class.new(form:)) }
   let(:work) { work_version.work }
-  let(:work_version) { build_stubbed(:work_version, related_works: related_works) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
+  let(:work_version) { build_stubbed(:work_version, related_works:) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
 
   it 'renders a delete button for all works' do
     expect(rendered.css('button[@aria-label="Remove Second Citation"]')).to be_present

--- a/spec/components/works/selected_keyword_component_spec.rb
+++ b/spec/components/works/selected_keyword_component_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Works::SelectedKeywordComponent, type: :component do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, keyword, controller.view_context, {}) }
   let(:keyword) { build(:keyword, label: 'computers') }
-  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:rendered) { render_inline(described_class.new(form:)) }
 
   it 'renders the component' do
     expect(rendered.css('.btn.remove').to_html)

--- a/spec/components/works/show/doi_component_spec.rb
+++ b/spec/components/works/show/doi_component_spec.rb
@@ -5,10 +5,10 @@ require 'rails_helper'
 RSpec.describe Works::Show::DoiComponent, type: :component do
   subject(:details) { render_inline(instance) }
 
-  let(:instance) { described_class.new(work_version: work_version) }
+  let(:instance) { described_class.new(work_version:) }
 
   context 'with a DOI' do
-    let(:work_version) { build_stubbed(:work_version, :deposited, version: 2, work: work) }
+    let(:work_version) { build_stubbed(:work_version, :deposited, version: 2, work:) }
     let(:work) { build_stubbed(:work, doi: '10.25740/bc123df4567') }
 
     it 'renders the doi_link' do
@@ -21,8 +21,8 @@ RSpec.describe Works::Show::DoiComponent, type: :component do
     let(:collection) { build_stubbed(:collection, doi_option: 'yes') }
 
     context 'with reserved PURL' do
-      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
-      let(:work) { build_stubbed(:work, collection: collection, assign_doi: false, druid: 'druid:bc123df4567') }
+      let(:work_version) { build_stubbed(:work_version, :first_draft, work:) }
+      let(:work) { build_stubbed(:work, collection:, assign_doi: false, druid: 'druid:bc123df4567') }
 
       it 'renders the doi setting' do
         expect(details.to_html).to include 'DOI will become available once the work has been deposited.'
@@ -30,8 +30,8 @@ RSpec.describe Works::Show::DoiComponent, type: :component do
     end
 
     context 'when it is a first_draft without a reserved PURL' do
-      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
-      let(:work) { build_stubbed(:work, collection: collection, assign_doi: false) }
+      let(:work_version) { build_stubbed(:work_version, :first_draft, work:) }
+      let(:work) { build_stubbed(:work, collection:, assign_doi: false) }
 
       it 'renders the doi setting' do
         expect(details.to_html).to include 'DOI will become available once the work has been deposited.'
@@ -39,8 +39,8 @@ RSpec.describe Works::Show::DoiComponent, type: :component do
     end
 
     context 'when it is a version_draft without a reserved PURL' do
-      let(:work_version) { build_stubbed(:work_version, :version_draft, work: work) }
-      let(:work) { build_stubbed(:work, collection: collection, assign_doi: false) }
+      let(:work_version) { build_stubbed(:work_version, :version_draft, work:) }
+      let(:work) { build_stubbed(:work, collection:, assign_doi: false) }
 
       it 'renders the doi setting' do
         expect(details.to_html).to include 'DOI will become available once a new version is deposited.'
@@ -52,8 +52,8 @@ RSpec.describe Works::Show::DoiComponent, type: :component do
     let(:collection) { build_stubbed(:collection, doi_option: 'depositor-selects') }
 
     context 'when they choose no and have a reserved purl' do
-      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
-      let(:work) { build_stubbed(:work, collection: collection, assign_doi: false, druid: 'druid:bc123df4567') }
+      let(:work_version) { build_stubbed(:work_version, :first_draft, work:) }
+      let(:work) { build_stubbed(:work, collection:, assign_doi: false, druid: 'druid:bc123df4567') }
 
       it 'renders the doi setting' do
         expect(details.to_html).to include 'A DOI has not been assigned to this item.'
@@ -61,8 +61,8 @@ RSpec.describe Works::Show::DoiComponent, type: :component do
     end
 
     context 'when they choose yes without a reserved purl' do
-      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
-      let(:work) { build_stubbed(:work, collection: collection, assign_doi: true) }
+      let(:work_version) { build_stubbed(:work_version, :first_draft, work:) }
+      let(:work) { build_stubbed(:work, collection:, assign_doi: true) }
 
       it 'renders the doi setting' do
         expect(details.to_html).to include 'DOI will become available once the work has been deposited.'
@@ -74,8 +74,8 @@ RSpec.describe Works::Show::DoiComponent, type: :component do
     let(:collection) { build_stubbed(:collection, doi_option: 'no') }
 
     context 'when the work does not have a doi' do
-      let(:work_version) { build_stubbed(:work_version, :first_draft, work: work) }
-      let(:work) { build_stubbed(:work, collection: collection) }
+      let(:work_version) { build_stubbed(:work_version, :first_draft, work:) }
+      let(:work) { build_stubbed(:work, collection:) }
 
       it 'renders the DOI setting' do
         expect(details.to_html).to include 'A DOI will not be assigned.'
@@ -83,8 +83,8 @@ RSpec.describe Works::Show::DoiComponent, type: :component do
     end
 
     context 'when the work has a DOI' do
-      let(:work_version) { build_stubbed(:work_version, :deposited, work: work) }
-      let(:work) { build_stubbed(:work, collection: collection, doi: '10.25740/bc123df4567') }
+      let(:work_version) { build_stubbed(:work_version, :deposited, work:) }
+      let(:work) { build_stubbed(:work, collection:, doi: '10.25740/bc123df4567') }
 
       it 'renders the doi_link' do
         expect(details.css('a[href="https://doi.org/10.25740/bc123df4567"]').to_html)

--- a/spec/components/works/show/files_component_spec.rb
+++ b/spec/components/works/show/files_component_spec.rb
@@ -3,12 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Works::Show::FilesComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(work_version: work_version)) }
+  let(:rendered) { render_inline(described_class.new(work_version:)) }
   let(:work_version) { create(:work_version) }
 
   context 'with an attached file' do
     before do
-      create(:attached_file, :with_file, work_version: work_version)
+      create(:attached_file, :with_file, work_version:)
     end
 
     it 'shows a download link and the hide status' do

--- a/spec/components/works/subtypes_component_spec.rb
+++ b/spec/components/works/subtypes_component_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe Works::SubtypesComponent do
   let(:form) { ActionView::Helpers::FormBuilder.new('work', work_form, controller.view_context, {}) }
   let(:work_version) { build_stubbed(:work_version) }
-  let(:work_form) { WorkForm.new(work: work_version.work, work_version: work_version) }
-  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:work_form) { WorkForm.new(work: work_version.work, work_version:) }
+  let(:rendered) { render_inline(described_class.new(form:)) }
 
   context 'when work type is "other"' do
     let(:work_version) { build_stubbed(:work_version, work_type: 'other', subtype: ['femur']) }

--- a/spec/components/works/title_component_spec.rb
+++ b/spec/components/works/title_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Works::TitleComponent do
   end
 
   it 'renders the component' do
-    expect(render_inline(described_class.new(form: form)).to_html)
+    expect(render_inline(described_class.new(form:)).to_html)
       .to include('Title of deposit and contact information')
   end
 end

--- a/spec/components/works/version_description_component_spec.rb
+++ b/spec/components/works/version_description_component_spec.rb
@@ -4,12 +4,12 @@ require 'rails_helper'
 
 RSpec.describe Works::VersionDescriptionComponent do
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
-  let(:rendered) { render_inline(described_class.new(form: form)) }
+  let(:rendered) { render_inline(described_class.new(form:)) }
   let(:work) { build(:work) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
 
   context 'with a first draft' do
-    let(:work_version) { build(:work_version, work: work) }
+    let(:work_version) { build(:work_version, work:) }
 
     it 'does not render the component' do
       expect(rendered.to_html).not_to include('Version your work')
@@ -17,7 +17,7 @@ RSpec.describe Works::VersionDescriptionComponent do
   end
 
   context 'with a deposited work' do
-    let(:work_version) { build(:work_version, work: work, state: 'deposited') }
+    let(:work_version) { build(:work_version, work:, state: 'deposited') }
 
     it 'renders the component' do
       expect(rendered.to_html).to include('Version your work')

--- a/spec/factories/collection_versions.rb
+++ b/spec/factories/collection_versions.rb
@@ -20,10 +20,10 @@ FactoryBot.define do
       end
       state { 'deposited' }
       collection do
-        association(:collection, depositors: depositors,
-                                 managed_by: managed_by,
-                                 reviewed_by: reviewed_by,
-                                 review_enabled: review_enabled)
+        association(:collection, depositors:,
+                                 managed_by:,
+                                 reviewed_by:,
+                                 review_enabled:)
       end
 
       after(:create) do |collection_version, _evaluator|

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
           collection { nil }
           owner { association(:user) }
         end
-        work { association :work, collection: collection, owner: owner }
+        work { association :work, collection:, owner: }
 
         after(:create) do |work_version, _evaluator|
           work_version.work.update(head: work_version)
@@ -40,11 +40,11 @@ FactoryBot.define do
         transient do
           collection { association(:collection) }
           collection_version do
-            association(:collection_version_with_collection, state: 'first_draft', collection: collection)
+            association(:collection_version_with_collection, state: 'first_draft', collection:)
           end
           owner { association(:user) }
         end
-        work { association :work, collection: collection_version.collection, owner: owner }
+        work { association :work, collection: collection_version.collection, owner: }
 
         after(:create) do |work_version, _evaluator|
           work_version.work.update(head: work_version)
@@ -186,7 +186,7 @@ FactoryBot.define do
       collection { nil }
       owner { association(:user) }
     end
-    work { association :work, collection: collection, owner: owner, work_versions: [instance] }
+    work { association :work, collection:, owner:, work_versions: [instance] }
 
     after(:create) do |work_version, _evaluator|
       work_version.work.update(head: work_version)

--- a/spec/features/auto_citation_spec.rb
+++ b/spec/features/auto_citation_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Automatically generate a citation', js: true do
   let(:user) { create(:user) }
   let(:collection) { create(:collection, release_option: 'depositor-selects', depositors: [user]) }
-  let(:collection_version) { create(:collection_version, :deposited, collection: collection) }
+  let(:collection_version) { create(:collection_version, :deposited, collection:) }
 
   before do
     collection.update(head: collection_version)

--- a/spec/features/create_new_draft_work_spec.rb
+++ b/spec/features/create_new_draft_work_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Create a new work in a deposited collection', js: true do
   let(:user) { create(:user) }
-  let(:collection_version) { create(:collection_version, :deposited, collection: collection) }
+  let(:collection_version) { create(:collection_version, :deposited, collection:) }
   let(:collection) { create(:collection, :depositor_selects_access, depositors: [user]) }
   let(:second_email) { 'second@example.com' }
 

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Create a new work in a deposited collection', js: true do
   let(:user) { create(:user) }
-  let(:collection_version) { create(:collection_version, :deposited, collection: collection) }
+  let(:collection_version) { create(:collection_version, :deposited, collection:) }
   let(:collection) { create(:collection, :depositor_selects_access, depositors: [user]) }
   let(:second_email) { 'second@example.com' }
 

--- a/spec/features/decommission_work_spec.rb
+++ b/spec/features/decommission_work_spec.rb
@@ -5,13 +5,13 @@ require 'rails_helper'
 RSpec.describe 'Decommission a work', js: true do
   let(:user) { create(:user) }
   let(:orig_owner) { create(:user) }
-  let(:work_version) { create(:work_version, work: work) }
+  let(:work_version) { create(:work_version, work:) }
   let(:collection_version) { create(:collection_version_with_collection) }
   let(:work) { create(:work, owner: orig_owner, collection: collection_version.collection) }
 
   before do
     work.update(head: work_version)
-    create(:attached_file, :with_file, work_version: work_version)
+    create(:attached_file, :with_file, work_version:)
     sign_in user, groups: ['dlss:hydrus-app-administrators']
   end
 

--- a/spec/features/delete_draft_collection_spec.rb
+++ b/spec/features/delete_draft_collection_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Delete a draft collection', js: true do
   let(:user) { create(:user) }
   let(:collection) { create(:collection, managed_by: [user]) }
-  let(:collection_version) { create(:collection_version, collection: collection) }
+  let(:collection_version) { create(:collection_version, collection:) }
 
   before do
     collection.update(head: collection_version)

--- a/spec/features/delete_draft_work_spec.rb
+++ b/spec/features/delete_draft_work_spec.rb
@@ -4,18 +4,18 @@ require 'rails_helper'
 
 RSpec.describe 'Delete a draft work', js: true do
   let(:collection) { create(:collection, :with_depositors, depositor_count: 1) }
-  let(:work) { create(:work, collection: collection, owner: user) }
-  let(:work_version) { create(:work_version, title: 'Delete me', work: work) }
-  let(:work_pending_approval) { create(:work, collection: collection, owner: user) }
+  let(:work) { create(:work, collection:, owner: user) }
+  let(:work_version) { create(:work_version, title: 'Delete me', work:) }
+  let(:work_pending_approval) { create(:work, collection:, owner: user) }
   let(:work_version_pending_approval) do
     create(:work_version, :pending_approval, title: 'Pending Approval - Delete me', work: work_pending_approval)
   end
-  let(:work_rejected) { create(:work, collection: collection, owner: user) }
+  let(:work_rejected) { create(:work, collection:, owner: user) }
   let(:work_version_rejected) { create(:work_version, :rejected, title: 'Rejected - Delete me', work: work_rejected) }
   let(:user) { collection.depositors.first }
 
   before do
-    create(:collection_version_with_collection, collection: collection)
+    create(:collection_version_with_collection, collection:)
     sign_in user
   end
 

--- a/spec/features/edit_draft_work_spec.rb
+++ b/spec/features/edit_draft_work_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Edit a draft work', js: true do
   let!(:work_version) do
     create(:work_version, :with_keywords,
            work_type: 'other', subtype: ['Graphic novel'],
-           state: 'version_draft', work: work)
+           state: 'version_draft', work:)
   end
   # create a collection that allows embargo access selection
   let(:collection) do
@@ -15,13 +15,13 @@ RSpec.describe 'Edit a draft work', js: true do
                                                                                     head: collection_version)
   end
   let(:collection_version) { create(:collection_version, :deposited) }
-  let(:work) { create(:work, owner: depositor, collection: collection) }
+  let(:work) { create(:work, owner: depositor, collection:) }
 
   context 'when a user has previously accepted the terms of agreement less than 1 year ago' do
     before do
       depositor.update(last_work_terms_agreement: Time.zone.now.days_ago(2))
       work.update(head: work_version)
-      create(:attached_file, :with_file, work_version: work_version)
+      create(:attached_file, :with_file, work_version:)
       work.collection.depositors = [depositor]
       sign_in depositor
     end
@@ -96,7 +96,7 @@ RSpec.describe 'Edit a draft work', js: true do
     context 'when successful deposit of "music" type work' do
       let(:work_version) do
         create(:valid_work_version, title: 'My Preprint/Data',
-                                    work: work,
+                                    work:,
                                     work_type: 'music',
                                     subtype: %w[Data Preprint])
       end
@@ -131,7 +131,7 @@ RSpec.describe 'Edit a draft work', js: true do
     before do
       depositor.update(last_work_terms_agreement: nil)
       work.update(head: work_version)
-      create(:attached_file, :with_file, work_version: work_version)
+      create(:attached_file, :with_file, work_version:)
       work.collection.depositors = [depositor]
       sign_in depositor
     end
@@ -209,7 +209,7 @@ RSpec.describe 'Edit a draft work', js: true do
     before do
       depositor.update(last_work_terms_agreement: Time.zone.now.years_ago(2))
       work.update(head: work_version)
-      create(:attached_file, :with_file, work_version: work_version)
+      create(:attached_file, :with_file, work_version:)
       work.collection.depositors = [depositor]
       sign_in depositor
     end

--- a/spec/features/lock_work_spec.rb
+++ b/spec/features/lock_work_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Lock and unlock a work', js: true do
   let(:user) { create(:user) }
-  let(:work_version) { create(:work_version, work: work) }
+  let(:work_version) { create(:work_version, work:) }
   let(:collection_version) { create(:collection_version_with_collection) }
 
   before do

--- a/spec/features/mediated_deposit_versioning_spec.rb
+++ b/spec/features/mediated_deposit_versioning_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe 'Edit a new version of a work in a collection using mediated depo
   let(:reviewer) { create(:user) }
 
   # Work, WorkVersion, and Collection need to exist before user hits dashboard
-  let!(:work_version) { create(:valid_deposited_work_version, work: work) }
+  let!(:work_version) { create(:valid_deposited_work_version, work:) }
   let(:work) do
     create(:work, druid: 'druid:bc123df4567', owner: depositor, collection: collection_version.collection)
   end
 
   before do
     work.update(head: work_version)
-    create(:attached_file, :with_file, work_version: work_version)
+    create(:attached_file, :with_file, work_version:)
   end
 
   context 'when reviewer rejects, then approves work' do

--- a/spec/features/purl_reservation_spec.rb
+++ b/spec/features/purl_reservation_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Reserve a PURL for a work in a deposited collection', js: true do
   let(:user) { create(:user) }
   let!(:collection) do
-    create(:collection, :depositor_selects_access, managed_by: [user], head: collection_version, doi_option: doi_option)
+    create(:collection, :depositor_selects_access, managed_by: [user], head: collection_version, doi_option:)
   end
   let(:collection_version) { create(:collection_version, :deposited) }
   let(:druid) { 'druid:bc123df4567' }
@@ -28,7 +28,7 @@ RSpec.describe 'Reserve a PURL for a work in a deposited collection', js: true d
     expect(page).to have_content title
     expect(page).to have_content 'Reserving PURL'
 
-    work_version = WorkVersion.find_by!(title: title)
+    work_version = WorkVersion.find_by!(title:)
     expect(work_version.work.collection).to eq collection
     expect(work_version.work.depositor).to eq user
     expect(work_version.work_type).to eq WorkType.purl_reservation_type.id
@@ -38,7 +38,7 @@ RSpec.describe 'Reserve a PURL for a work in a deposited collection', js: true d
     # for processing by AssignPidJob, so we'll just fake that by running the job manually
     source_id = "hydrus:object-#{work_version.work.id}"
     identification = instance_double(Cocina::Models::Identification, sourceId: source_id)
-    model = instance_double(Cocina::Models::DRO, identification: identification, externalIdentifier: druid)
+    model = instance_double(Cocina::Models::DRO, identification:, externalIdentifier: druid)
     assign_pid_job = AssignPidJob.new
     allow(assign_pid_job).to receive(:build_cocina_model_from_json_str).and_return(model)
     assign_pid_job.work('{}') # don't need to fake JSON for fully valid Cocina model, just mock resulting DRO
@@ -70,14 +70,14 @@ RSpec.describe 'Reserve a PURL for a work in a deposited collection', js: true d
       expect(page).to have_content title
       expect(page).to have_content 'Reserving PURL'
 
-      work_version = WorkVersion.find_by!(title: title)
+      work_version = WorkVersion.find_by!(title:)
       expect(work_version.work.assign_doi?).to be false
     end
   end
 
   describe 'setting the type for a reserved purl' do
     let!(:work_version) do
-      create(:work_version_with_work, :purl_reserved, collection: collection, owner: user)
+      create(:work_version_with_work, :purl_reserved, collection:, owner: user)
     end
 
     it 'from the dashboard' do
@@ -134,6 +134,6 @@ RSpec.describe 'Reserve a PURL for a work in a deposited collection', js: true d
 
     visit dashboard_path
     expect(page).not_to have_content title
-    expect(WorkVersion.find_by(title: title)).to be_nil
+    expect(WorkVersion.find_by(title:)).to be_nil
   end
 end

--- a/spec/features/revert_collection_to_previous_version_spec.rb
+++ b/spec/features/revert_collection_to_previous_version_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 RSpec.describe 'Delete a draft collection', js: true do
   let(:collection) { create(:collection, :with_managers, manager_count: 1) }
-  let!(:version1) { create(:collection_version, :deposited, version: 1, collection: collection) }
-  let(:version2) { create(:collection_version, :version_draft, version: 2, collection: collection) }
+  let!(:version1) { create(:collection_version, :deposited, version: 1, collection:) }
+  let(:version2) { create(:collection_version, :version_draft, version: 2, collection:) }
   let(:user) { collection.managed_by.first }
 
   before do

--- a/spec/features/revert_work_to_previous_version_spec.rb
+++ b/spec/features/revert_work_to_previous_version_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 
 RSpec.describe 'Delete a draft work', js: true do
   let(:collection) { create(:collection_version_with_collection).collection }
-  let(:work) { create(:work, collection: collection) }
-  let!(:version1) { create(:work_version, :deposited, version: 1, work: work) }
-  let(:version2) { create(:work_version, :version_draft, version: 2, work: work) }
+  let(:work) { create(:work, collection:) }
+  let!(:version1) { create(:work_version, :deposited, version: 1, work:) }
+  let(:version2) { create(:work_version, :version_draft, version: 2, work:) }
   let(:user) { work.owner }
 
   before do

--- a/spec/features/single_radio_selection_spec.rb
+++ b/spec/features/single_radio_selection_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Selecting a radio button causes other radio button inputs to be 
       let(:collection) { create(:collection, managed_by: [user], release_option: 'depositor-selects') }
 
       before do
-        create(:collection_version_with_collection, :version_draft, collection: collection)
+        create(:collection_version_with_collection, :version_draft, collection:)
         visit edit_collection_path(collection)
       end
 
@@ -51,7 +51,7 @@ RSpec.describe 'Selecting a radio button causes other radio button inputs to be 
       let(:collection) { create(:collection, managed_by: [user], license_option: 'required') }
 
       before do
-        create(:collection_version_with_collection, :version_draft, collection: collection)
+        create(:collection_version_with_collection, :version_draft, collection:)
         visit edit_collection_path(collection)
       end
 

--- a/spec/features/update_existing_collection_spec.rb
+++ b/spec/features/update_existing_collection_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Update an existing collection', js: true do
   let(:user) { create(:user) }
   let(:collection) { create(:collection, managed_by: [user]) }
-  let(:collection_version) { create(:collection_version, :deposited, collection: collection, name: original_name) }
+  let(:collection_version) { create(:collection_version, :deposited, collection:, name: original_name) }
   let(:original_name) { 'Not an interesting name' }
   let(:new_name) { 'A much better name' }
   let(:new_version_description) { 'Editing the name and description' }

--- a/spec/features/update_existing_work_spec.rb
+++ b/spec/features/update_existing_work_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 
 RSpec.describe 'Update an existing work in a deposited collection', js: true do
   let(:user) { create(:user) }
-  let(:collection_version) { create(:collection_version, :deposited, collection: collection) }
+  let(:collection_version) { create(:collection_version, :deposited, collection:) }
   let(:collection) { create(:collection, :depositor_selects_access, creator: user, depositors: [user]) }
-  let(:work_version) { create(:work_version_with_work, collection: collection, owner: user, title: original_title) }
+  let(:work_version) { create(:work_version_with_work, collection:, owner: user, title: original_title) }
   let(:original_title) { 'Not an interesting title' }
   let(:new_title) { 'A much better title' }
 

--- a/spec/features/user_return_location_spec.rb
+++ b/spec/features/user_return_location_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'User return location' do
   let(:user) { create(:user) }
 
   before do
-    collection.update(head: create(:collection_version, :deposited, collection: collection))
+    collection.update(head: create(:collection_version, :deposited, collection:))
     sign_in user, groups: ['dlss:hydrus-app-collection-creators']
     allow(Settings).to receive(:allow_sdr_content_changes).and_return(true)
   end

--- a/spec/forms/contact_emails_populator_spec.rb
+++ b/spec/forms/contact_emails_populator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ContactEmailsPopulator do
 
   let(:work) { work_version.work }
   let(:work_version) { build(:work_version) }
-  let(:work_form) { WorkForm.new(work_version: work_version, work: work) }
+  let(:work_form) { WorkForm.new(work_version:, work:) }
 
   it 'renders a contact email row' do
     keep_fragment = ActionController::Parameters.new({ _destroy: 'false', email: 'test@local.edu' })

--- a/spec/forms/create_collection_form_spec.rb
+++ b/spec/forms/create_collection_form_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe CreateCollectionForm do
-  subject(:form) { described_class.new(collection: collection, collection_version: collection_version) }
+  subject(:form) { described_class.new(collection:, collection_version:) }
 
-  let(:collection) { build(:collection, required_license: required_license, default_license: default_license) }
+  let(:collection) { build(:collection, required_license:, default_license:) }
   let(:collection_version) { build(:collection_version) }
   let(:default_license) { nil }
   let(:required_license) { nil }

--- a/spec/forms/draft_work_form_spec.rb
+++ b/spec/forms/draft_work_form_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe DraftWorkForm do
-  subject(:form) { described_class.new(work_version: work_version, work: work) }
+  subject(:form) { described_class.new(work_version:, work:) }
 
   let(:work) { work_version.work }
   let(:work_version) { build(:work_version) }

--- a/spec/forms/reservation_form_spec.rb
+++ b/spec/forms/reservation_form_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe ReservationForm do
-  subject(:form) { described_class.new(work_version: work_version, work: work) }
+  subject(:form) { described_class.new(work_version:, work:) }
 
   let(:work) { work_version.work }
   let(:work_version) { build(:work_version) }
 
   describe 'title validation' do
     before do
-      form.validate(title: title)
+      form.validate(title:)
     end
 
     context 'with an blank title' do

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe WorkForm do
-  subject(:form) { described_class.new(work_version: work_version, work: work) }
+  subject(:form) { described_class.new(work_version:, work:) }
 
   let(:work) { work_version.work }
   let(:work_version) { build(:work_version) }
@@ -45,7 +45,7 @@ RSpec.describe WorkForm do
     end
 
     it 'filters out name values for the wrong type' do
-      form.validate(contributors: contributors)
+      form.validate(contributors:)
       expect(form.contributors.size).to eq 2
       expect(form.contributors.first.full_name).to be_nil
       expect(form.contributors.last.first_name).to be_nil
@@ -57,7 +57,7 @@ RSpec.describe WorkForm do
     let(:author_error) { 'Please add at least one author.' }
 
     before do
-      form.validate(authors: authors)
+      form.validate(authors:)
     end
 
     context 'with no authors' do
@@ -224,7 +224,7 @@ RSpec.describe WorkForm do
 
       context 'when release has already been set to immediate' do
         let(:collection) { build(:collection, release_option: 'depositor-selects') }
-        let(:work_version) { create(:work_version_with_work, :deposited, collection: collection) }
+        let(:work_version) { create(:work_version_with_work, :deposited, collection:) }
 
         context 'when release is nil' do
           it 'validates' do
@@ -244,7 +244,7 @@ RSpec.describe WorkForm do
       context 'when release has already been set to embargo and it elapsed' do
         let(:collection) { build(:collection, release_option: 'depositor-selects') }
         let(:work_version) do
-          create(:work_version_with_work, :deposited, embargo_date: 2.weeks.ago, collection: collection)
+          create(:work_version_with_work, :deposited, embargo_date: 2.weeks.ago, collection:)
         end
 
         context 'when release is nil' do

--- a/spec/jobs/assign_pid_job_spec.rb
+++ b/spec/jobs/assign_pid_job_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe AssignPidJob do
-  let(:message) { { model: model }.to_json }
+  let(:message) { { model: }.to_json }
   let(:druid) { 'druid:bc123df4567' }
 
   context "with a work that doesn't have a doi (and hasn't requested one)" do
@@ -25,7 +25,7 @@ RSpec.describe AssignPidJob do
                                 contains: []
                               })
     end
-    let(:work) { create(:work_version_with_work, :depositing, collection: collection).work }
+    let(:work) { create(:work_version_with_work, :depositing, collection:).work }
     let(:collection) { create(:collection_version_with_collection).collection }
 
     it 'updates the druid' do
@@ -54,7 +54,7 @@ RSpec.describe AssignPidJob do
                                 contains: []
                               })
     end
-    let(:work) { create(:work_version_with_work, :reserving_purl, collection: collection).work }
+    let(:work) { create(:work_version_with_work, :reserving_purl, collection:).work }
     let(:collection) { create(:collection_version_with_collection).collection }
 
     it 'updates the druid' do
@@ -84,7 +84,7 @@ RSpec.describe AssignPidJob do
                                 contains: []
                               })
     end
-    let(:work) { create(:work_version_with_work, collection: collection, state: 'depositing').work }
+    let(:work) { create(:work_version_with_work, collection:, state: 'depositing').work }
     let(:collection) { create(:collection_version_with_collection).collection }
 
     it 'updates the druid' do

--- a/spec/jobs/deposit_collection_job_spec.rb
+++ b/spec/jobs/deposit_collection_job_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe DepositCollectionJob do
 
   context 'when the deposit update request is successful' do
     let(:collection) { build_stubbed(:collection, :with_collection_druid) }
-    let(:collection_version) { build_stubbed(:collection_version, :with_version_description, collection: collection) }
+    let(:collection_version) { build_stubbed(:collection_version, :with_version_description, collection:) }
 
     before do
       allow(SdrClient::Deposit::UpdateResource).to receive(:run).and_return(1234)

--- a/spec/jobs/deposit_job_spec.rb
+++ b/spec/jobs/deposit_job_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe DepositJob do
   end
   let(:attached_file) { build(:attached_file) }
   let(:attached_file2) { build(:attached_file) }
-  let(:work) { build(:work, collection: collection, assign_doi: false) }
+  let(:work) { build(:work, collection:, assign_doi: false) }
   let(:first_work_version) do
-    build(:work_version, work: work, attached_files: [attached_file], version: 1)
+    build(:work_version, work:, attached_files: [attached_file], version: 1)
   end
   let(:second_work_version) do
-    build(:work_version, work: work, attached_files: [attached_file2], version: 2, version_description: 'Changed files')
+    build(:work_version, work:, attached_files: [attached_file2], version: 2, version_description: 'Changed files')
   end
 
   let(:collection) { build(:collection, druid: 'druid:bc123df4567', doi_option: 'depositor-selects') }
@@ -61,7 +61,7 @@ RSpec.describe DepositJob do
     end
 
     context 'when the deposit wants a doi' do
-      let(:work) { build(:work, collection: collection, assign_doi: true) }
+      let(:work) { build(:work, collection:, assign_doi: true) }
 
       it 'calls CreateResource.run with true for the assign_doi param' do
         described_class.perform_now(first_work_version)
@@ -72,7 +72,7 @@ RSpec.describe DepositJob do
   end
 
   context 'when updating the deposit' do
-    let(:work) { build(:work, collection: collection, assign_doi: false, druid: druid) }
+    let(:work) { build(:work, collection:, assign_doi: false, druid:) }
     let(:druid) { 'druid:bf024yb8975' }
 
     # The job fetches the existing cocina model from the SDR API to copy structural > contains.
@@ -130,7 +130,7 @@ RSpec.describe DepositJob do
     context 'when files have not changed' do
       # The attached files for this version are the same as the previous version.
       let(:second_work_version_metadata_only) do
-        build(:work_version, work: work, attached_files: [attached_file], version: 2,
+        build(:work_version, work:, attached_files: [attached_file], version: 2,
                              version_description: 'Updated metadata')
       end
 

--- a/spec/jobs/deposit_status_job_spec.rb
+++ b/spec/jobs/deposit_status_job_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe DepositStatusJob do
 
   context 'with a work that is depositing' do
     let(:work_version) do
-      build(:work_version, :depositing, work: work, version_description: 'A new version description')
+      build(:work_version, :depositing, work:, version_description: 'A new version description')
     end
-    let(:work) { create(:work, :with_druid, collection: collection, depositor: collection.managed_by.first) }
+    let(:work) { create(:work, :with_druid, collection:, depositor: collection.managed_by.first) }
     let(:collection) { build(:collection, :with_managers) }
-    let(:collection_version) { create(:collection_version, collection: collection) }
+    let(:collection_version) { create(:collection_version, collection:) }
     let(:message) { "{\"druid\":\"#{work.druid}\"}" }
 
     before do
@@ -36,7 +36,7 @@ RSpec.describe DepositStatusJob do
         { params: {
           user: collection.managed_by.last,
           owner: work.owner,
-          collection_version: collection_version
+          collection_version:
         }, args: [] }
       )
 
@@ -49,7 +49,7 @@ RSpec.describe DepositStatusJob do
 
   context 'with a work that is already deposited (embargo was released by DSA)' do
     let(:work_version) do
-      build(:work_version, :deposited, work: work)
+      build(:work_version, :deposited, work:)
     end
     let(:work) { create(:work, :with_druid) }
     let(:message) { "{\"druid\":\"#{work.druid}\"}" }
@@ -66,7 +66,7 @@ RSpec.describe DepositStatusJob do
 
   context 'with a work that is in a version_draft state (embargo was released by DSA)' do
     let(:work_version) do
-      build(:work_version, :version_draft, work: work)
+      build(:work_version, :version_draft, work:)
     end
     let(:work) { create(:work, :with_druid) }
     let(:message) { "{\"druid\":\"#{work.druid}\"}" }
@@ -83,7 +83,7 @@ RSpec.describe DepositStatusJob do
 
   context 'with a collection' do
     let(:collection) { create(:collection, :with_druid) }
-    let(:collection_version) { build(:collection_version, :depositing, collection: collection) }
+    let(:collection_version) { build(:collection_version, :depositing, collection:) }
     let(:message) { "{\"druid\":\"#{collection.druid}\"}" }
 
     before do

--- a/spec/jobs/record_embargo_release_job_spec.rb
+++ b/spec/jobs/record_embargo_release_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RecordEmbargoReleaseJob do
   subject(:run) { described_class.new.work(message) }
 
   let(:work) { create(:work, :with_druid) }
-  let(:message) { { model: model }.to_json }
+  let(:message) { { model: }.to_json }
   let(:model) do
     Cocina::Models::DRO.new(externalIdentifier: work.druid,
                             type: Cocina::Models::ObjectType.object,

--- a/spec/jobs/reserve_job_spec.rb
+++ b/spec/jobs/reserve_job_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe ReserveJob do
   include Dry::Monads[:result]
 
   let(:conn) { instance_double(SdrClient::Connection) }
-  let(:work) { build(:work, collection: collection, assign_doi: false) }
+  let(:work) { build(:work, collection:, assign_doi: false) }
   let(:work_version) do
-    build(:work_version, :reserving_purl, work: work)
+    build(:work_version, :reserving_purl, work:)
   end
   let(:collection) { build(:collection, druid: 'druid:bc123df4567', doi_option: 'depositor-selects') }
 

--- a/spec/mailers/collections_mailer_spec.rb
+++ b/spec/mailers/collections_mailer_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe CollectionsMailer, type: :mailer do
-  let(:collection_version) { build_stubbed(:collection_version, collection: collection) }
+  let(:collection_version) { build_stubbed(:collection_version, collection:) }
   let(:collection_name) { collection_version.name }
   let(:collection) { build_stubbed(:collection) }
   let(:a_user) { build_stubbed(:user, name: 'Al Dente', first_name: 'Fred') }
 
   describe '#invitation_to_deposit_email for new user with no name' do
     let(:user) { collection.depositors.first }
-    let(:mail) { described_class.with(user: user, collection_version: collection_version).invitation_to_deposit_email }
+    let(:mail) { described_class.with(user:, collection_version:).invitation_to_deposit_email }
     let(:collection) { build_stubbed(:collection, :with_depositors) }
 
     it 'renders the headers' do
@@ -27,7 +27,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
 
   describe '#invitation_to_deposit_email for user with a name' do
     let(:user) { collection.depositors.first }
-    let(:mail) { described_class.with(user: user, collection_version: collection_version).invitation_to_deposit_email }
+    let(:mail) { described_class.with(user:, collection_version:).invitation_to_deposit_email }
     let(:collection) { build_stubbed(:collection, :with_depositors) }
 
     before { user.update(name: 'Smart Person', first_name: 'Maxwell') }
@@ -46,7 +46,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
 
   describe '#deposit_access_removed_email' do
     let(:user) { a_user }
-    let(:mail) { described_class.with(user: user, collection_version: collection_version).deposit_access_removed_email }
+    let(:mail) { described_class.with(user:, collection_version:).deposit_access_removed_email }
 
     it 'renders the headers' do
       expect(mail.subject).to eq "Your Depositor permissions for the #{collection_name} " \
@@ -67,7 +67,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
 
   describe '#manage_access_granted_email' do
     let(:user) { a_user }
-    let(:mail) { described_class.with(user: user, collection_version: collection_version).manage_access_granted_email }
+    let(:mail) { described_class.with(user:, collection_version:).manage_access_granted_email }
     let(:collection) { build(:collection) }
 
     it 'renders the headers' do
@@ -90,7 +90,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
 
   describe '#manage_access_removed_email' do
     let(:user) { a_user }
-    let(:mail) { described_class.with(user: user, collection_version: collection_version).manage_access_removed_email }
+    let(:mail) { described_class.with(user:, collection_version:).manage_access_removed_email }
     let(:collection) { build(:collection) }
 
     it 'renders the headers' do
@@ -112,7 +112,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
 
   describe '#review_access_granted_email' do
     let(:user) { a_user }
-    let(:mail) { described_class.with(user: user, collection_version: collection_version).review_access_granted_email }
+    let(:mail) { described_class.with(user:, collection_version:).review_access_granted_email }
     let(:collection) { build(:collection) }
 
     it 'renders the headers' do
@@ -135,7 +135,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
 
   describe '#review_access_removed_email' do
     let(:user) { a_user }
-    let(:mail) { described_class.with(user: user, collection_version: collection_version).review_access_removed_email }
+    let(:mail) { described_class.with(user:, collection_version:).review_access_removed_email }
     let(:collection) { build(:collection) }
 
     it 'renders the headers' do
@@ -160,8 +160,8 @@ RSpec.describe CollectionsMailer, type: :mailer do
     let(:owner) { build(:user, name: 'Audre Lorde', first_name: 'Queueueue') }
 
     let(:mail) do
-      described_class.with(user: user, collection_version: collection_version,
-                           owner: owner).first_draft_created
+      described_class.with(user:, collection_version:,
+                           owner:).first_draft_created
     end
     let(:collection) { build(:collection) }
 
@@ -183,7 +183,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
   end
 
   describe '#first_draft_reminder_email' do
-    let(:mail) { described_class.with(collection_version: collection_version, user: a_user).first_draft_reminder_email }
+    let(:mail) { described_class.with(collection_version:, user: a_user).first_draft_reminder_email }
     let(:collection) { build_stubbed(:collection, head: collection_version) }
     let(:collection_version) { build_stubbed(:collection_version, state: 'first_draft') }
 
@@ -200,7 +200,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
   end
 
   describe '#new_version_reminder_email' do
-    let(:mail) { described_class.with(collection_version: collection_version, user: a_user).new_version_reminder_email }
+    let(:mail) { described_class.with(collection_version:, user: a_user).new_version_reminder_email }
     let(:collection) { build_stubbed(:collection, head: collection_version) }
     let(:collection_version) { build_stubbed(:collection_version) }
 
@@ -221,7 +221,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
     let(:owner) { build(:user, name: 'Audre Lorde', first_name: 'Queueueue') }
 
     let(:mail) do
-      described_class.with(user: user, collection_version: collection_version, owner: owner).item_deposited
+      described_class.with(user:, collection_version:, owner:).item_deposited
     end
     let(:collection) { build(:collection) }
 
@@ -247,8 +247,8 @@ RSpec.describe CollectionsMailer, type: :mailer do
     let(:owner) { build(:user, name: 'Audre Lorde') }
 
     let(:mail) do
-      described_class.with(user: user, collection_version: collection_version,
-                           owner: owner).version_draft_created
+      described_class.with(user:, collection_version:,
+                           owner:).version_draft_created
     end
     let(:collection) { build(:collection) }
 
@@ -271,7 +271,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
 
   describe '#participants_changed_email' do
     let(:user) { a_user }
-    let(:mail) { described_class.with(user: user, collection_version: collection_version).participants_changed_email }
+    let(:mail) { described_class.with(user:, collection_version:).participants_changed_email }
     let(:collection) { build(:collection) }
 
     it 'renders the headers' do

--- a/spec/mailers/first_draft_collections_mailer_spec.rb
+++ b/spec/mailers/first_draft_collections_mailer_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 
 RSpec.describe FirstDraftCollectionsMailer, type: :mailer do
   let(:creator) { build_stubbed(:user, name: 'Peter Lorre', email: 'psl@example.org') }
-  let(:collection) { build_stubbed(:collection, creator: creator) }
-  let(:collection_version) { build_stubbed(:collection_version, collection: collection) }
+  let(:collection) { build_stubbed(:collection, creator:) }
+  let(:collection_version) { build_stubbed(:collection_version, collection:) }
   let(:collection_name) { collection_version.name }
 
   describe '#first_draft_created' do
     let(:mail) do
-      described_class.with(collection_version: collection_version).first_draft_created
+      described_class.with(collection_version:).first_draft_created
     end
 
     it 'renders the headers' do

--- a/spec/mailers/previews/collections_mailer_preview.rb
+++ b/spec/mailers/previews/collections_mailer_preview.rb
@@ -11,6 +11,6 @@ class CollectionsMailerPreview < ActionMailer::Preview
 
   def mailer_with_collection
     collection = Collection.first
-    CollectionsMailer.with(user: collection.creator, collection: collection)
+    CollectionsMailer.with(user: collection.creator, collection:)
   end
 end

--- a/spec/mailers/previews/reviewers_preview.rb
+++ b/spec/mailers/previews/reviewers_preview.rb
@@ -4,6 +4,6 @@
 class ReviewersPreview < ActionMailer::Preview
   def submitted_email
     work = Work.first
-    ReviewersMailer.with(user: work.depositor, work: work).submitted_email
+    ReviewersMailer.with(user: work.depositor, work:).submitted_email
   end
 end

--- a/spec/mailers/previews/works_mailer_preview.rb
+++ b/spec/mailers/previews/works_mailer_preview.rb
@@ -17,11 +17,11 @@ class WorksMailerPreview < ActionMailer::Preview
 
   def mailer_with_work
     work = Work.first
-    WorksMailer.with(user: work.depositor, work: work)
+    WorksMailer.with(user: work.depositor, work:)
   end
 
   def first_draft_reminder_email
     work = Work.first
-    WorksMailer.with(work: work).first_draft_reminder_email
+    WorksMailer.with(work:).first_draft_reminder_email
   end
 end

--- a/spec/mailers/reviewers_mailer_spec.rb
+++ b/spec/mailers/reviewers_mailer_spec.rb
@@ -5,9 +5,9 @@ require 'rails_helper'
 RSpec.describe ReviewersMailer, type: :mailer do
   describe 'submitted_email' do
     let(:user) { build(:user, name: 'Al Dente', first_name: 'Fred') }
-    let(:mail) { described_class.with(user: user, work_version: work_version).submitted_email }
-    let(:work) { build_stubbed(:work, collection: collection, depositor: user, owner: user) }
-    let(:work_version) { build_stubbed(:work_version, :pending_approval, work: work, title: 'Test title') }
+    let(:mail) { described_class.with(user:, work_version:).submitted_email }
+    let(:work) { build_stubbed(:work, collection:, depositor: user, owner: user) }
+    let(:work_version) { build_stubbed(:work_version, :pending_approval, work:, title: 'Test title') }
     let(:collection) { build(:collection, :with_reviewers, head: collection_version) }
     let(:collection_version) { build(:collection_version, name: 'small batch organic') }
 

--- a/spec/mailers/works_mailer_spec.rb
+++ b/spec/mailers/works_mailer_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe WorksMailer, type: :mailer do
 
   describe 'reject_email' do
     let(:user) { work_depositor }
-    let(:mail) { described_class.with(user: user, work_version: work_version).reject_email }
+    let(:mail) { described_class.with(user:, work_version:).reject_email }
     let(:work) do
-      create(:work, collection: collection,
+      create(:work, collection:,
                     events: [build(:event, event_type: 'reject', description: 'Add something to make it pop.')])
     end
-    let(:work_version) { build_stubbed(:work_version, :rejected, work: work) }
+    let(:work_version) { build_stubbed(:work_version, :rejected, work:) }
     let(:collection) { create(:collection, head: collection_version) }
     let(:collection_version) { create(:collection_version, name: 'gastropub humblebrag taiyaki') }
 
@@ -36,9 +36,9 @@ RSpec.describe WorksMailer, type: :mailer do
 
   describe 'deposited_email' do
     let(:user) { work_depositor }
-    let(:mail) { described_class.with(user: user, work_version: work_version).deposited_email }
-    let(:work) { build_stubbed(:work, collection: collection, druid: 'druid:bc123df4567', doi: '10.001/bc123df4567') }
-    let(:work_version) { build_stubbed(:work_version, :deposited, title: 'Photo booth activated charcoal', work: work) }
+    let(:mail) { described_class.with(user:, work_version:).deposited_email }
+    let(:work) { build_stubbed(:work, collection:, druid: 'druid:bc123df4567', doi: '10.001/bc123df4567') }
+    let(:work_version) { build_stubbed(:work_version, :deposited, title: 'Photo booth activated charcoal', work:) }
     let(:collection) { build_stubbed(:collection, head: collection_version) }
     let(:collection_version) { build_stubbed(:collection_version, name: 'gastropub humblebrag taiyaki') }
 
@@ -62,9 +62,9 @@ RSpec.describe WorksMailer, type: :mailer do
 
   describe 'new_version_deposited_email' do
     let(:user) { work_depositor }
-    let(:mail) { described_class.with(user: user, work_version: work_version).new_version_deposited_email }
-    let(:work) { build_stubbed(:work, collection: collection, druid: 'druid:bc123df4567', doi: '10.001/bc123df4567') }
-    let(:work_version) { build_stubbed(:work_version, :deposited, title: 'twee retro man braid', work: work) }
+    let(:mail) { described_class.with(user:, work_version:).new_version_deposited_email }
+    let(:work) { build_stubbed(:work, collection:, druid: 'druid:bc123df4567', doi: '10.001/bc123df4567') }
+    let(:work_version) { build_stubbed(:work_version, :deposited, title: 'twee retro man braid', work:) }
     let(:collection) { build_stubbed(:collection, head: collection_version) }
     let(:collection_version) { build_stubbed(:collection_version, name: 'listicle fam ramps flannel') }
 
@@ -88,9 +88,9 @@ RSpec.describe WorksMailer, type: :mailer do
 
   describe 'approved_email' do
     let(:user) { work_depositor }
-    let(:mail) { described_class.with(user: user, work_version: work_version).approved_email }
-    let(:work) { build_stubbed(:work, collection: collection, druid: 'druid:bc123df4567', doi: '10.001/bc123df4567') }
-    let(:work_version) { build_stubbed(:work_version, :deposited, title: 'Hammock kombucha mustache', work: work) }
+    let(:mail) { described_class.with(user:, work_version:).approved_email }
+    let(:work) { build_stubbed(:work, collection:, druid: 'druid:bc123df4567', doi: '10.001/bc123df4567') }
+    let(:work_version) { build_stubbed(:work_version, :deposited, title: 'Hammock kombucha mustache', work:) }
     let(:collection) { build_stubbed(:collection, :with_reviewers, head: collection_version) }
     let(:collection_version) { build_stubbed(:collection_version, name: 'Farm-to-table beard aesthetic') }
 
@@ -114,10 +114,10 @@ RSpec.describe WorksMailer, type: :mailer do
 
   describe 'submitted_email' do
     let(:user) { a_user }
-    let(:mail) { described_class.with(user: user, work_version: work_version).submitted_email }
-    let(:work) { build_stubbed(:work, collection: collection, depositor: user) }
+    let(:mail) { described_class.with(user:, work_version:).submitted_email }
+    let(:work) { build_stubbed(:work, collection:, depositor: user) }
     let(:work_version) do
-      build_stubbed(:work_version, :pending_approval, title: 'Tiramisu lemon drops chocolate cake', work: work)
+      build_stubbed(:work_version, :pending_approval, title: 'Tiramisu lemon drops chocolate cake', work:)
     end
 
     let(:collection) { build_stubbed(:collection, :with_reviewers, head: collection_version) }
@@ -142,9 +142,9 @@ RSpec.describe WorksMailer, type: :mailer do
   end
 
   describe 'first_draft_reminder_email' do
-    let(:work) { build_stubbed(:work, collection: collection, depositor: a_user, owner: b_user) }
-    let(:work_version) { build_stubbed(:work_version, work: work) }
-    let(:mail) { described_class.with(work_version: work_version).first_draft_reminder_email }
+    let(:work) { build_stubbed(:work, collection:, depositor: a_user, owner: b_user) }
+    let(:work_version) { build_stubbed(:work_version, work:) }
+    let(:mail) { described_class.with(work_version:).first_draft_reminder_email }
     let(:collection) { build_stubbed(:collection, head: collection_version) }
     let(:collection_version) { build_stubbed(:collection_version) }
 
@@ -165,9 +165,9 @@ RSpec.describe WorksMailer, type: :mailer do
   end
 
   describe 'new_version_reminder_email' do
-    let(:work) { build_stubbed(:work, collection: collection, depositor: a_user, owner: a_user) }
-    let(:work_version) { build_stubbed(:work_version, work: work) }
-    let(:mail) { described_class.with(work_version: work_version).new_version_reminder_email }
+    let(:work) { build_stubbed(:work, collection:, depositor: a_user, owner: a_user) }
+    let(:work_version) { build_stubbed(:work_version, work:) }
+    let(:mail) { described_class.with(work_version:).new_version_reminder_email }
     let(:collection) { build_stubbed(:collection, head: collection_version) }
     let(:collection_version) { build_stubbed(:collection_version) }
 
@@ -190,9 +190,9 @@ RSpec.describe WorksMailer, type: :mailer do
   end
 
   describe 'changed_owner_email' do
-    let(:work) { build_stubbed(:work, collection: collection, owner: a_user, head: work_version) }
+    let(:work) { build_stubbed(:work, collection:, owner: a_user, head: work_version) }
     let(:work_version) { build_stubbed(:work_version) }
-    let(:mail) { described_class.with(work: work).changed_owner_email }
+    let(:mail) { described_class.with(work:).changed_owner_email }
     let(:collection) { build_stubbed(:collection, head: collection_version) }
     let(:collection_version) { build_stubbed(:collection_version) }
 
@@ -214,9 +214,9 @@ RSpec.describe WorksMailer, type: :mailer do
   end
 
   describe 'changed_owner_collection_manager_email' do
-    let(:work) { build_stubbed(:work, collection: collection, head: work_version) }
+    let(:work) { build_stubbed(:work, collection:, head: work_version) }
     let(:work_version) { build_stubbed(:work_version) }
-    let(:mail) { described_class.with(work: work, user: a_user).changed_owner_collection_manager_email }
+    let(:mail) { described_class.with(work:, user: a_user).changed_owner_collection_manager_email }
     let(:collection) { build_stubbed(:collection, head: collection_version) }
     let(:collection_version) { build_stubbed(:collection_version) }
 
@@ -238,9 +238,9 @@ RSpec.describe WorksMailer, type: :mailer do
   end
 
   describe 'globus_deposited_email' do
-    let(:work) { build_stubbed(:work, collection: collection, depositor: a_user, owner: a_user) }
-    let(:work_version) { build_stubbed(:work_version, work: work) }
-    let(:mail) { described_class.with(work_version: work_version).globus_deposited_email }
+    let(:work) { build_stubbed(:work, collection:, depositor: a_user, owner: a_user) }
+    let(:work_version) { build_stubbed(:work_version, work:) }
+    let(:mail) { described_class.with(work_version:).globus_deposited_email }
     let(:collection) { build_stubbed(:collection, head: collection_version) }
     let(:collection_version) { build_stubbed(:collection_version) }
 
@@ -259,9 +259,9 @@ RSpec.describe WorksMailer, type: :mailer do
   end
 
   describe 'decommission_owner_email' do
-    let(:work) { build_stubbed(:work, collection: collection, owner: a_user) }
-    let(:work_version) { build_stubbed(:work_version, work: work) }
-    let(:mail) { described_class.with(work_version: work_version).decommission_owner_email }
+    let(:work) { build_stubbed(:work, collection:, owner: a_user) }
+    let(:work_version) { build_stubbed(:work_version, work:) }
+    let(:mail) { described_class.with(work_version:).decommission_owner_email }
     let(:collection) { build_stubbed(:collection, head: collection_version) }
     let(:collection_version) { build_stubbed(:collection_version) }
 
@@ -283,9 +283,9 @@ RSpec.describe WorksMailer, type: :mailer do
   end
 
   describe 'decommission_manager_email' do
-    let(:work) { build_stubbed(:work, collection: collection) }
-    let(:work_version) { build_stubbed(:work_version, work: work) }
-    let(:mail) { described_class.with(work_version: work_version, user: a_user).decommission_manager_email }
+    let(:work) { build_stubbed(:work, collection:) }
+    let(:work_version) { build_stubbed(:work_version, work:) }
+    let(:mail) { described_class.with(work_version:, user: a_user).decommission_manager_email }
     let(:collection) { build_stubbed(:collection, head: collection_version) }
     let(:collection_version) { build_stubbed(:collection_version) }
 

--- a/spec/models/abstract_contributor_spec.rb
+++ b/spec/models/abstract_contributor_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe AbstractContributor, type: :model do
   describe '.valid?' do
     context 'when a person' do
-      let(:contributor) { build(:person_contributor, orcid: orcid) }
+      let(:contributor) { build(:person_contributor, orcid:) }
 
       context 'when valid ORCID' do
         let(:orcid) { 'https://orcid.org/0000-0003-1527-0030' }
@@ -33,7 +33,7 @@ RSpec.describe AbstractContributor, type: :model do
     end
 
     context 'when an organization' do
-      let(:contributor) { build(:org_contributor, orcid: orcid) }
+      let(:contributor) { build(:org_contributor, orcid:) }
 
       context 'when ORCID' do
         let(:orcid) { 'https://orcid.org/0000-0003-1527-0030' }

--- a/spec/models/collection_version_spec.rb
+++ b/spec/models/collection_version_spec.rb
@@ -60,14 +60,14 @@ RSpec.describe CollectionVersion do
                                            'CollectionsMailer', 'manage_access_granted_email', 'deliver_now',
                                            { params: {
                                              user: manager1,
-                                             collection_version: collection_version
+                                             collection_version:
                                            }, args: [] }
                                          ))
                                     .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                                            'CollectionsMailer', 'manage_access_granted_email', 'deliver_now',
                                            { params: {
                                              user: manager2,
-                                             collection_version: collection_version
+                                             collection_version:
                                            }, args: [] }
                                          ))
         expect(DepositCollectionJob).to have_received(:perform_later).with(collection_version)
@@ -100,7 +100,7 @@ RSpec.describe CollectionVersion do
                                         .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                                                'FirstDraftCollectionsMailer', 'first_draft_created', 'deliver_now',
                                                { params: {
-                                                 collection_version: collection_version
+                                                 collection_version:
                                                }, args: [] }
                                              ))
           end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Work do
-  subject(:work) { build(:work, collection: collection, assign_doi: assign_doi) }
+  subject(:work) { build(:work, collection:, assign_doi:) }
 
   let(:assign_doi) { false }
 

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe WorkVersion do
 
   describe 'authors' do
     let(:work) { create(:work) }
-    let(:work_version) { create(:work_version, work: work) }
+    let(:work_version) { create(:work_version, work:) }
 
     before do
       allow(work_version.work).to receive(:broadcast_update)
@@ -83,7 +83,7 @@ RSpec.describe WorkVersion do
 
   describe '#attached_files' do
     before do
-      create(:attached_file, :with_file, work_version: work_version)
+      create(:attached_file, :with_file, work_version:)
     end
 
     it 'has attached files' do
@@ -98,9 +98,9 @@ RSpec.describe WorkVersion do
   describe '.awaiting_review_by' do
     subject { described_class.awaiting_review_by(user) }
 
-    let(:work1) { create(:work, collection: collection) }
+    let(:work1) { create(:work, collection:) }
     let!(:work_version1) { create(:work_version, :pending_approval, work: work1) }
-    let(:work2) { create(:work, collection: collection) }
+    let(:work2) { create(:work, collection:) }
 
     before do
       # We should not see this draft work in the query results
@@ -347,9 +347,9 @@ RSpec.describe WorkVersion do
 
     describe 'an update_metadata event' do
       let(:collection) { create(:collection, :with_managers) }
-      let(:collection_version) { create(:collection_version_with_collection, collection: collection) }
-      let(:work_version) { create(:work_version, state: state, work: work) }
-      let(:work) { create(:work, collection: collection, depositor: collection.managed_by.first) }
+      let(:collection_version) { create(:collection_version_with_collection, collection:) }
+      let(:work_version) { create(:work_version, state:, work:) }
+      let(:work) { create(:work, collection:, depositor: collection.managed_by.first) }
 
       context 'when the state was new' do
         let(:state) { 'new' }
@@ -364,7 +364,7 @@ RSpec.describe WorkVersion do
                                              { params: {
                                                user: collection.managed_by.last,
                                                owner: work.owner,
-                                               collection_version: collection_version
+                                               collection_version:
                                              }, args: [] }
                                            ))
         end
@@ -381,8 +381,8 @@ RSpec.describe WorkVersion do
     end
 
     describe 'a deposit_complete event' do
-      let(:work_version) { build(:work_version, :depositing, work: work) }
-      let(:work) { create(:work, collection: collection, druid: 'druid:foo') }
+      let(:work_version) { build(:work_version, :depositing, work:) }
+      let(:work) { create(:work, collection:, druid: 'druid:foo') }
 
       context 'when an initial deposit into a non-reviewed collection' do
         let(:collection) { create(:collection) }
@@ -393,14 +393,14 @@ RSpec.describe WorkVersion do
             .to('deposited')
             .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                    'WorksMailer', 'deposited_email', 'deliver_now',
-                   { params: { user: work.owner, work_version: work_version }, args: [] }
+                   { params: { user: work.owner, work_version: }, args: [] }
                  ))
             .and change(Event, :count).by(1)
         end
       end
 
       context 'when a deposit with globus' do
-        let(:work_version) { build(:work_version, :depositing, work: work, globus: true) }
+        let(:work_version) { build(:work_version, :depositing, work:, globus: true) }
         let(:collection) { create(:collection) }
 
         before do
@@ -413,11 +413,11 @@ RSpec.describe WorkVersion do
             .to('deposited')
             .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                    'WorksMailer', 'deposited_email', 'deliver_now',
-                   { params: { user: work.owner, work_version: work_version }, args: [] }
+                   { params: { user: work.owner, work_version: }, args: [] }
                  ))
             .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                    'WorksMailer', 'globus_deposited_email', 'deliver_now',
-                   { params: { user: work.owner, work_version: work_version }, args: [] }
+                   { params: { user: work.owner, work_version: }, args: [] }
                  ))
             .and change(Event, :count).by(1)
         end
@@ -425,8 +425,8 @@ RSpec.describe WorkVersion do
 
       context 'when an subsequent version deposit into a non-reviewed collection' do
         let(:collection) { create(:collection) }
-        let(:work_version) { build(:work_version, :depositing, version: 2, work: work) }
-        let(:work) { create(:work, collection: collection, druid: 'druid:foo') }
+        let(:work_version) { build(:work_version, :depositing, version: 2, work:) }
+        let(:work) { create(:work, collection:, druid: 'druid:foo') }
 
         it 'transitions to deposited' do
           expect { work_version.deposit_complete! }
@@ -434,7 +434,7 @@ RSpec.describe WorkVersion do
             .to('deposited')
             .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                    'WorksMailer', 'new_version_deposited_email', 'deliver_now',
-                   { params: { user: work.owner, work_version: work_version }, args: [] }
+                   { params: { user: work.owner, work_version: }, args: [] }
                  ))
             .and change(Event, :count).by(1)
         end
@@ -449,7 +449,7 @@ RSpec.describe WorkVersion do
             .to('deposited')
             .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                    'WorksMailer', 'approved_email', 'deliver_now',
-                   { params: { user: work.owner, work_version: work_version }, args: [] }
+                   { params: { user: work.owner, work_version: }, args: [] }
                  ))
             .and change(Event, :count).by(1)
         end
@@ -463,8 +463,8 @@ RSpec.describe WorkVersion do
       let(:reviewer) { build(:user) }
 
       context 'when work is first_draft' do
-        let(:work_version) { create(:work_version, :first_draft, work: work) }
-        let(:work) { create(:work, collection: collection, depositor: depositor, owner: owner) }
+        let(:work_version) { create(:work_version, :first_draft, work:) }
+        let(:work) { create(:work, collection:, depositor:, owner:) }
 
         it 'transitions to pending_approval' do
           expect { work_version.submit_for_review! }
@@ -472,19 +472,19 @@ RSpec.describe WorkVersion do
             .to('pending_approval')
             .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                    'ReviewersMailer', 'submitted_email', 'deliver_now',
-                   { params: { user: reviewer, work_version: work_version }, args: [] }
+                   { params: { user: reviewer, work_version: }, args: [] }
                  ))
             .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                    'WorksMailer', 'submitted_email', 'deliver_now',
-                   { params: { user: owner, work_version: work_version }, args: [] }
+                   { params: { user: owner, work_version: }, args: [] }
                  ))
             .and change(Event, :count).by(1)
         end
       end
 
       context 'when work was rejected' do
-        let(:work_version) { create(:work_version, :rejected, work: work) }
-        let(:work) { create(:work, collection: collection, depositor: depositor, owner: owner) }
+        let(:work_version) { create(:work_version, :rejected, work:) }
+        let(:work) { create(:work, collection:, depositor:, owner:) }
 
         it 'transitions to pending_approval' do
           expect { work_version.submit_for_review! }
@@ -492,11 +492,11 @@ RSpec.describe WorkVersion do
             .to('pending_approval')
             .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                    'ReviewersMailer', 'submitted_email', 'deliver_now',
-                   { params: { user: reviewer, work_version: work_version }, args: [] }
+                   { params: { user: reviewer, work_version: }, args: [] }
                  ))
             .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                    'WorksMailer', 'submitted_email', 'deliver_now',
-                   { params: { user: owner, work_version: work_version }, args: [] }
+                   { params: { user: owner, work_version: }, args: [] }
                  ))
             .and change(Event, :count).by(1)
         end
@@ -504,7 +504,7 @@ RSpec.describe WorkVersion do
     end
 
     describe 'a reject event' do
-      let(:work_version) { create(:work_version, :pending_approval, work: work) }
+      let(:work_version) { create(:work_version, :pending_approval, work:) }
       let(:work) { create(:work) }
 
       it 'transitions to rejected' do
@@ -513,15 +513,15 @@ RSpec.describe WorkVersion do
           .to('rejected')
           .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                  'WorksMailer', 'reject_email', 'deliver_now',
-                 { params: { user: work.owner, work_version: work_version }, args: [] }
+                 { params: { user: work.owner, work_version: }, args: [] }
                ))
       end
     end
 
     describe 'a decommission event' do
       let(:collection) { create(:collection, :with_managers) }
-      let(:work) { create(:work, collection: collection) }
-      let(:work_version) { create(:work_version, work: work) }
+      let(:work) { create(:work, collection:) }
+      let(:work_version) { create(:work_version, work:) }
 
       it 'transitions to decommissioned' do
         expect { work_version.decommission! }
@@ -529,11 +529,11 @@ RSpec.describe WorkVersion do
           .to('decommissioned')
           .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                  'WorksMailer', 'decommission_owner_email', 'deliver_now',
-                 { params: { work_version: work_version }, args: [] }
+                 { params: { work_version: }, args: [] }
                ))
           .and(have_enqueued_job(ActionMailer::MailDeliveryJob).with(
                  'WorksMailer', 'decommission_manager_email', 'deliver_now',
-                 { params: { work_version: work_version, user: collection.managed_by.first }, args: [] }
+                 { params: { work_version:, user: collection.managed_by.first }, args: [] }
                ))
       end
     end

--- a/spec/policies/collection_policy_spec.rb
+++ b/spec/policies/collection_policy_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe CollectionPolicy do
   # `context` is the authorization context
   let(:context) do
     {
-      user: user,
-      user_with_groups: UserWithGroups.new(user: user, groups: groups)
+      user:,
+      user_with_groups: UserWithGroups.new(user:, groups:)
     }
   end
   let(:groups) { [] }

--- a/spec/policies/collection_version_policy_spec.rb
+++ b/spec/policies/collection_version_policy_spec.rb
@@ -5,14 +5,14 @@ require 'rails_helper'
 RSpec.describe CollectionVersionPolicy do
   let(:user) { build_stubbed :user }
   # # `record` must be defined - it is the authorization target
-  let(:record) { build_stubbed :collection_version, collection: collection }
+  let(:record) { build_stubbed :collection_version, collection: }
   let(:collection) { build_stubbed :collection }
 
   # `context` is the authorization context
   let(:context) do
     {
-      user: user,
-      user_with_groups: UserWithGroups.new(user: user, groups: groups)
+      user:,
+      user_with_groups: UserWithGroups.new(user:, groups:)
     }
   end
   let(:groups) { [] }
@@ -30,12 +30,12 @@ RSpec.describe CollectionVersionPolicy do
 
     failed 'when user is a collection manager and status is depositing' do
       let(:collection) { build_stubbed :collection, managed_by: [user] }
-      let(:record) { build_stubbed :collection_version, :depositing, collection: collection }
+      let(:record) { build_stubbed :collection_version, :depositing, collection: }
     end
 
     failed 'when the collection version is not the head version' do
       let(:collection) { build_stubbed :collection, managed_by: [user], head: build_stubbed(:collection_version) }
-      let(:record) { build_stubbed :collection_version, :deposited, collection: collection }
+      let(:record) { build_stubbed :collection_version, :deposited, collection: }
     end
 
     succeed 'when user is an admin' do

--- a/spec/policies/dashboard_policy_spec.rb
+++ b/spec/policies/dashboard_policy_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe DashboardPolicy do
   # `context` is the authorization context
   let(:context) do
     {
-      user: user,
-      user_with_groups: UserWithGroups.new(user: user, groups: groups)
+      user:,
+      user_with_groups: UserWithGroups.new(user:, groups:)
     }
   end
   let(:groups) { [] }

--- a/spec/policies/work_policy_spec.rb
+++ b/spec/policies/work_policy_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe WorkPolicy do
   let(:user) { build_stubbed :user }
   # `record` must be defined - it is the authorization target
-  let(:work_version) { build_stubbed :work_version, work: work }
-  let(:work) { build_stubbed :work, collection: collection }
+  let(:work_version) { build_stubbed :work_version, work: }
+  let(:work) { build_stubbed :work, collection: }
   let(:collection) { build_stubbed :collection, head: collection_version }
   let(:collection_version) { build_stubbed :collection_version, :deposited }
   let(:record) { work }
@@ -14,8 +14,8 @@ RSpec.describe WorkPolicy do
   # `context` is the authorization context
   let(:context) do
     {
-      user: user,
-      user_with_groups: UserWithGroups.new(user: user, groups: groups)
+      user:,
+      user_with_groups: UserWithGroups.new(user:, groups:)
     }
   end
 
@@ -69,7 +69,7 @@ RSpec.describe WorkPolicy do
     end
 
     context 'when not persisted' do
-      let(:work) { Work.new(attributes_for(:work).merge(collection: collection)) }
+      let(:work) { Work.new(attributes_for(:work).merge(collection:)) }
 
       failed 'when user is not the owner, reviewer or manager for the collection'
 

--- a/spec/policies/work_version_policy_spec.rb
+++ b/spec/policies/work_version_policy_spec.rb
@@ -5,16 +5,16 @@ require 'rails_helper'
 RSpec.describe WorkVersionPolicy do
   let(:user) { build_stubbed :user }
   # `record` must be defined - it is the authorization target
-  let(:record) { build_stubbed :work_version, work: work }
-  let(:work) { build_stubbed :work, collection: collection }
+  let(:record) { build_stubbed :work_version, work: }
+  let(:work) { build_stubbed :work, collection: }
   let(:collection) { build_stubbed :collection, head: collection_version }
   let(:collection_version) { build_stubbed :collection_version, :deposited }
 
   # `context` is the authorization context
   let(:context) do
     {
-      user: user,
-      user_with_groups: UserWithGroups.new(user: user, groups: groups)
+      user:,
+      user_with_groups: UserWithGroups.new(user:, groups:)
     }
   end
 
@@ -48,41 +48,41 @@ RSpec.describe WorkVersionPolicy do
     failed 'when user is not the owner'
 
     succeed 'when user is the owner and status is not pending_approval' do
-      let(:work) { build_stubbed :work, collection: collection, owner: user }
-      let(:record) { build_stubbed :work_version, work: work }
+      let(:work) { build_stubbed :work, collection:, owner: user }
+      let(:record) { build_stubbed :work_version, work: }
     end
 
     failed 'when user is the owner and status is pending_approval' do
-      let(:work) { build_stubbed :work, collection: collection, owner: user }
-      let(:record) { build_stubbed :work_version, :pending_approval, work: work }
+      let(:work) { build_stubbed :work, collection:, owner: user }
+      let(:record) { build_stubbed :work_version, :pending_approval, work: }
     end
 
     failed 'when user is the owner and status is depositing' do
-      let(:work) { build_stubbed :work, collection: collection, owner: user }
-      let(:record) { build_stubbed :work_version, :depositing, work: work }
+      let(:work) { build_stubbed :work, collection:, owner: user }
+      let(:record) { build_stubbed :work_version, :depositing, work: }
     end
 
     context 'when user is an admin' do
       let(:groups) { [Settings.authorization_workgroup_names.administrators] }
 
       failed 'when locked' do
-        let(:work) { build_stubbed :work, :locked, collection: collection }
+        let(:work) { build_stubbed :work, :locked, collection: }
       end
 
       failed 'when status is depositing' do
-        let(:work) { build_stubbed :work, collection: collection }
-        let(:record) { build_stubbed :work_version, :depositing, work: work }
+        let(:work) { build_stubbed :work, collection: }
+        let(:record) { build_stubbed :work_version, :depositing, work: }
       end
 
       failed 'when status is reserving_purl' do
-        let(:work) { build_stubbed :work, collection: collection }
-        let(:record) { build_stubbed :work_version, :reserving_purl, work: work }
+        let(:work) { build_stubbed :work, collection: }
+        let(:record) { build_stubbed :work_version, :reserving_purl, work: }
       end
 
       succeed 'when status is not pending_approval'
 
       succeed 'when status is pending_approval' do
-        let(:record) { build_stubbed :work_version, :pending_approval, work: work }
+        let(:record) { build_stubbed :work_version, :pending_approval, work: }
       end
     end
 
@@ -90,13 +90,13 @@ RSpec.describe WorkVersionPolicy do
       let(:collection) { build_stubbed :collection, managed_by: [user] }
 
       failed 'when locked' do
-        let(:work) { build_stubbed :work, :locked, collection: collection }
+        let(:work) { build_stubbed :work, :locked, collection: }
       end
 
       succeed 'when status is not pending_approval'
 
       succeed 'when status is pending_approval' do
-        let(:record) { build_stubbed :work_version, :pending_approval, work: work }
+        let(:record) { build_stubbed :work_version, :pending_approval, work: }
       end
     end
 
@@ -104,14 +104,14 @@ RSpec.describe WorkVersionPolicy do
       let(:collection) { build_stubbed :collection, reviewed_by: [user] }
 
       failed 'when locked' do
-        let(:work) { build_stubbed :work, :locked, collection: collection }
+        let(:work) { build_stubbed :work, :locked, collection: }
       end
 
       succeed 'when status is not pending_approval'
 
       succeed 'when status is pending_approval' do
         let(:collection) { build_stubbed :collection, reviewed_by: [user] }
-        let(:record) { build_stubbed :work_version, :pending_approval, work: work }
+        let(:record) { build_stubbed :work_version, :pending_approval, work: }
       end
     end
   end
@@ -121,7 +121,7 @@ RSpec.describe WorkVersionPolicy do
 
     succeed 'when user is the owner' do
       let(:work) { build_stubbed :work, owner: user }
-      let(:record) { build_stubbed :work_version, work: work }
+      let(:record) { build_stubbed :work_version, work: }
     end
 
     succeed 'when user is an admin' do
@@ -139,16 +139,16 @@ RSpec.describe WorkVersionPolicy do
 
   describe_rule :review? do
     failed 'when user is not a reviewer the collection' do
-      let(:record) { build_stubbed :work_version, :pending_approval, work: work }
+      let(:record) { build_stubbed :work_version, :pending_approval, work: }
     end
 
     succeed 'when user is an admin' do
       let(:groups) { [Settings.authorization_workgroup_names.administrators] }
-      let(:record) { build_stubbed :work_version, :pending_approval, work: work }
+      let(:record) { build_stubbed :work_version, :pending_approval, work: }
     end
 
     succeed 'when user is a reviewer and status is pending_approval' do
-      let(:record) { build_stubbed :work_version, :pending_approval, work: work }
+      let(:record) { build_stubbed :work_version, :pending_approval, work: }
       before { collection.reviewed_by = [user] }
     end
 
@@ -161,7 +161,7 @@ RSpec.describe WorkVersionPolicy do
     end
 
     succeed 'when user is a collection manager' do
-      let(:record) { build_stubbed :work_version, :pending_approval, work: work }
+      let(:record) { build_stubbed :work_version, :pending_approval, work: }
       let(:collection) { build_stubbed :collection, managed_by: [user] }
     end
   end
@@ -238,7 +238,7 @@ RSpec.describe WorkVersionPolicy do
     end
 
     context 'when not persisted' do
-      let(:record) { WorkVersion.new(attributes_for(:work_version).merge(work: work)) }
+      let(:record) { WorkVersion.new(attributes_for(:work_version).merge(work:)) }
 
       failed 'when user is not the owner, reviewer or manager for the collection'
 
@@ -265,8 +265,8 @@ RSpec.describe WorkVersionPolicy do
 
     let(:policy) { described_class.new(**context) }
     let(:collection) { create(:collection) }
-    let(:work) { create(:work, collection: collection) }
-    let(:work_version) { create(:work_version, work: work) }
+    let(:work) { create(:work, collection:) }
+    let(:work_version) { create(:work_version, work:) }
 
     before do
       work.update(head: work_version)
@@ -278,7 +278,7 @@ RSpec.describe WorkVersionPolicy do
 
     context 'when the user is the owner' do
       let(:user) { create(:user) }
-      let(:work) { create(:work, collection: collection, owner: user) }
+      let(:work) { create(:work, collection:, owner: user) }
 
       it { is_expected.to include(work) }
     end

--- a/spec/requests/admin/search_for_druid_spec.rb
+++ b/spec/requests/admin/search_for_druid_spec.rb
@@ -4,11 +4,11 @@ require 'rails_helper'
 
 RSpec.describe 'Search for a DRUID' do
   let(:user) { create(:user) }
-  let(:work) { create(:work, :with_druid, collection: collection) }
-  let(:work_version) { create(:work_version, work: work) }
+  let(:work) { create(:work, :with_druid, collection:) }
+  let(:work_version) { create(:work_version, work:) }
   let(:work_druid) { work.druid }
   let(:collection) { create(:collection, :with_collection_druid) }
-  let(:collection_version) { create(:collection_version, collection: collection) }
+  let(:collection_version) { create(:collection_version, collection:) }
 
   before do
     work.update(head: work_version)

--- a/spec/requests/admins_spec.rb
+++ b/spec/requests/admins_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe 'Admin dashboard' do
 
   context 'when user is an application admin' do
     let(:collection) { create(:collection, creator: user) }
-    let(:collection_version) { create(:collection_version_with_collection, collection: collection) }
-    let(:work1) { create(:work, :with_druid, owner: user, collection: collection) }
+    let(:collection_version) { create(:collection_version_with_collection, collection:) }
+    let(:work1) { create(:work, :with_druid, owner: user, collection:) }
     let(:work_version1) { create(:work_version, state: 'deposited', work: work1) }
-    let(:work2) { create(:work, owner: user, collection: collection) }
+    let(:work2) { create(:work, owner: user, collection:) }
     let(:work_version2) { create(:work_version, state: 'first_draft', work: work2) }
 
     before do

--- a/spec/requests/autocomplete_spec.rb
+++ b/spec/requests/autocomplete_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe 'Autocomplete Controller' do
 
     before do
       url = "#{Settings.autocomplete_lookup.url}?q=keywords:(tea)#{other_params}"
-      stub_request(:get, url).with(headers: headers).to_return(status: 200, body: lookup_resp_body, headers: {})
+      stub_request(:get, url).with(headers:).to_return(status: 200, body: lookup_resp_body, headers: {})
     end
 
     it 'returns status 200 and html with suggestions' do
@@ -276,9 +276,9 @@ RSpec.describe 'Autocomplete Controller' do
 
     before do
       url1 = "#{Settings.autocomplete_lookup.url}?q=keywords:(tesl)#{other_params}"
-      stub_request(:get, url1).with(headers: headers).to_return(status: 200, body: lookup_resp_body1, headers: {})
+      stub_request(:get, url1).with(headers:).to_return(status: 200, body: lookup_resp_body1, headers: {})
       url2 = "#{Settings.autocomplete_lookup.url}?q=keywords:(tesl*)#{other_params}"
-      stub_request(:get, url2).with(headers: headers).to_return(status: 200, body: lookup_resp_body2, headers: {})
+      stub_request(:get, url2).with(headers:).to_return(status: 200, body: lookup_resp_body2, headers: {})
     end
 
     it 'returns status 200 and html with suggestions' do
@@ -304,7 +304,7 @@ RSpec.describe 'Autocomplete Controller' do
     before do
       url = "#{Settings.autocomplete_lookup.url}?q=keywords:(tea)#{other_params}"
       stub_request(:get, url)
-        .with(headers: headers)
+        .with(headers:)
         .to_return(status: [404, 'some error message'], body: '', headers: {})
       allow(Rails.logger).to receive(:warn)
     end

--- a/spec/requests/change_work_owner_spec.rb
+++ b/spec/requests/change_work_owner_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Change owner of a work' do
   let(:manager) { create(:user) }
   let(:reviewer) { create(:user) }
 
-  let(:work_version) { create(:work_version, work: work) }
+  let(:work_version) { create(:work_version, work:) }
   let(:collection_version) do
     create(:collection_version_with_collection, managed_by: [manager], reviewed_by: [reviewer])
   end

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe 'Create a new work' do
                    access: 'stanford') # an access selection that will be overwritten
         end
 
-        before { create(:collection_version_with_collection, collection: collection) }
+        before { create(:collection_version_with_collection, collection:) }
 
         it 'displays the work' do
           post "/collections/#{collection.id}/works", params: { work: work_params,
@@ -299,7 +299,7 @@ RSpec.describe 'Create a new work' do
           }
         end
 
-        before { create(:collection_version_with_collection, collection: collection) }
+        before { create(:collection_version_with_collection, collection:) }
 
         it 'saves the draft' do
           post "/collections/#{collection.id}/works", params: params
@@ -365,7 +365,7 @@ RSpec.describe 'Create a new work' do
           }
         end
 
-        before { create(:collection_version_with_collection, collection: collection) }
+        before { create(:collection_version_with_collection, collection:) }
 
         it 'displays the work' do
           post "/collections/#{collection.id}/works", params: { work: work_params, commit: 'Deposit' }
@@ -510,7 +510,7 @@ RSpec.describe 'Create a new work' do
           }
         end
 
-        before { create(:collection_version_with_collection, collection: collection) }
+        before { create(:collection_version_with_collection, collection:) }
 
         it 'displays the work' do
           post "/collections/#{collection.id}/works", params: { work: work_params,
@@ -587,7 +587,7 @@ RSpec.describe 'Create a new work' do
           }
         end
 
-        before { create(:collection_version_with_collection, :with_contact_emails, collection: collection) }
+        before { create(:collection_version_with_collection, :with_contact_emails, collection:) }
 
         it 'releases it immediately' do
           post "/collections/#{collection.id}/works", params: { work: work_params,
@@ -654,7 +654,7 @@ RSpec.describe 'Create a new work' do
           }
         end
 
-        before { create(:collection_version_with_collection, :with_contact_emails, collection: collection) }
+        before { create(:collection_version_with_collection, :with_contact_emails, collection:) }
 
         it 'sets embargo to the date specified in the collection' do
           post "/collections/#{collection.id}/works", params: { work: work_params,
@@ -719,7 +719,7 @@ RSpec.describe 'Create a new work' do
           }
         end
 
-        before { create(:collection_version_with_collection, :with_contact_emails, collection: collection) }
+        before { create(:collection_version_with_collection, :with_contact_emails, collection:) }
 
         it 'sets the license indicated by the collection' do
           post "/collections/#{collection.id}/works", params: { work: work_params,
@@ -793,7 +793,7 @@ RSpec.describe 'Create a new work' do
           }
         end
 
-        before { create(:collection_version_with_collection, collection: collection) }
+        before { create(:collection_version_with_collection, collection:) }
 
         it 'displays the work' do
           post "/collections/#{collection.id}/works", params: { work: work_params, commit: 'Deposit' }

--- a/spec/requests/dashboard_collection_spec.rb
+++ b/spec/requests/dashboard_collection_spec.rb
@@ -8,27 +8,27 @@ RSpec.describe 'Dashboard collection requests' do
   context 'when user has in progress deposits in different states' do
     let(:user) { collection.depositors.first }
     let(:collection) { create(:collection, :with_depositors, depositor_count: 1) }
-    let(:work1) { create(:work, owner: user, collection: collection) }
+    let(:work1) { create(:work, owner: user, collection:) }
     let(:work_version1) { create(:work_version, state: 'first_draft', title: 'I am a first draft', work: work1) }
-    let(:work2) { create(:work, owner: user, collection: collection) }
+    let(:work2) { create(:work, owner: user, collection:) }
     let(:work_version2) { create(:work_version, state: 'version_draft', title: 'I am a version draft', work: work2) }
-    let(:work3) { create(:work, owner: user, collection: collection) }
+    let(:work3) { create(:work, owner: user, collection:) }
     let(:work_version3) { create(:work_version, state: 'rejected', title: 'I am rejected', work: work3) }
-    let(:work4) { create(:work, owner: user, collection: collection) }
+    let(:work4) { create(:work, owner: user, collection:) }
     let(:work_version4) { create(:work_version, state: 'deposited', title: 'I am deposited', work: work4) }
-    let(:work5) { create(:work, owner: user, collection: collection) }
+    let(:work5) { create(:work, owner: user, collection:) }
     let(:work_version5) { create(:work_version, state: 'depositing', title: 'I am depositing', work: work5) }
-    let(:work6) { create(:work, owner: user, collection: collection) }
+    let(:work6) { create(:work, owner: user, collection:) }
     let(:work_version6) do
       create(:work_version, state: 'pending_approval', title: 'I am a pending approval', work: work6)
     end
-    let(:work7) { create(:work, owner: user, collection: collection) }
+    let(:work7) { create(:work, owner: user, collection:) }
     let(:work_version7) do
       create(:work_version, state: 'decommissioned', title: 'I am decommissioned', work: work6)
     end
 
     before do
-      create(:collection_version_with_collection, collection: collection)
+      create(:collection_version_with_collection, collection:)
 
       work1.update(head: work_version1)
       work2.update(head: work_version2)

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe 'Dashboard requests' do
   context 'when user has deposits' do
     let(:user) { collection.depositors.first }
     let(:collection) { create(:collection, :with_depositors, depositor_count: 1) }
-    let(:work1) { create(:work, owner: user, collection: collection) }
+    let(:work1) { create(:work, owner: user, collection:) }
     let(:work_version1) { create(:work_version, title: 'Happy little title', work: work1) }
     let(:work_version2) { create(:work_version, title: 'Secret') }
 
     before do
-      create(:collection_version_with_collection, collection: collection)
+      create(:collection_version_with_collection, collection:)
       work1.update(head: work_version1)
       work_version2.work.update(head: work_version2)
       sign_in user
@@ -32,12 +32,12 @@ RSpec.describe 'Dashboard requests' do
   context 'when user has a draft deposit with no title' do
     let(:user) { collection.depositors.first }
     let(:collection) { create(:collection, :with_depositors, depositor_count: 1) }
-    let(:work1) { create(:work, owner: user, collection: collection) }
+    let(:work1) { create(:work, owner: user, collection:) }
     let(:work_version1) { create(:work_version, title: '', work: work1) }
     let(:work_version2) { create(:work_version, title: 'Secret') }
 
     before do
-      create(:collection_version_with_collection, collection: collection)
+      create(:collection_version_with_collection, collection:)
       work1.update(head: work_version1)
       work_version2.work.update(head: work_version2)
       sign_in user
@@ -53,10 +53,10 @@ RSpec.describe 'Dashboard requests' do
 
   context 'when user is a collection manager and there is a collection in progress' do
     let(:collection) { create(:collection, managed_by: [user]) }
-    let(:work) { create(:work, collection: collection) }
-    let(:work_version) { create(:work_version, work: work) }
+    let(:work) { create(:work, collection:) }
+    let(:work_version) { create(:work_version, work:) }
     let!(:collection_version) do
-      create(:collection_version_with_collection, :first_draft, name: 'Happy collection', collection: collection)
+      create(:collection_version_with_collection, :first_draft, name: 'Happy collection', collection:)
     end
 
     before do
@@ -75,25 +75,25 @@ RSpec.describe 'Dashboard requests' do
   context 'when user has in progress deposits in different states' do
     let(:user) { collection.depositors.first }
     let(:collection) { create(:collection, :with_depositors, depositor_count: 1) }
-    let(:work1) { create(:work, owner: user, collection: collection) }
+    let(:work1) { create(:work, owner: user, collection:) }
     let(:work_version1) { create(:work_version, state: 'first_draft', title: 'I am a first draft', work: work1) }
-    let(:work2) { create(:work, owner: user, collection: collection) }
+    let(:work2) { create(:work, owner: user, collection:) }
     let(:work_version2) { create(:work_version, state: 'version_draft', title: 'I am a version draft', work: work2) }
-    let(:work3) { create(:work, owner: user, collection: collection) }
+    let(:work3) { create(:work, owner: user, collection:) }
     let(:work_version3) { create(:work_version, state: 'rejected', title: 'I am rejected', work: work3) }
-    let(:work4) { create(:work, owner: user, collection: collection) }
+    let(:work4) { create(:work, owner: user, collection:) }
     let(:work_version4) { create(:work_version, state: 'deposited', title: 'I am deposited', work: work4) }
-    let(:work5) { create(:work, owner: user, collection: collection) }
+    let(:work5) { create(:work, owner: user, collection:) }
     let(:work_version5) { create(:work_version, state: 'depositing', title: 'I am depositing', work: work5) }
-    let(:work6) { create(:work, owner: user, collection: collection) }
+    let(:work6) { create(:work, owner: user, collection:) }
     let(:work_version6) do
       create(:work_version, state: 'pending_approval', title: 'I am a pending approval', work: work6)
     end
-    let(:work7) { create(:work, owner: user, collection: collection) }
+    let(:work7) { create(:work, owner: user, collection:) }
     let(:work_version7) { create(:work_version, state: 'purl_reserved', title: 'I am reserved purl', work: work6) }
 
     before do
-      create(:collection_version_with_collection, collection: collection)
+      create(:collection_version_with_collection, collection:)
 
       work1.update(head: work_version1)
       work2.update(head: work_version2)
@@ -146,11 +146,11 @@ RSpec.describe 'Dashboard requests' do
   context 'when user is a reviewer' do
     let(:collection) { create(:collection, :with_reviewers) }
     let(:user) { collection.reviewed_by.first }
-    let(:work) { create(:work, collection: collection) }
-    let(:work_version) { create(:work_version, :pending_approval, title: 'To Review', work: work) }
+    let(:work) { create(:work, collection:) }
+    let(:work_version) { create(:work_version, :pending_approval, title: 'To Review', work:) }
 
     before do
-      create(:collection_version_with_collection, collection: collection)
+      create(:collection_version_with_collection, collection:)
 
       work.update(head: work_version)
       sign_in user
@@ -169,9 +169,9 @@ RSpec.describe 'Dashboard requests' do
     let(:work) { create(:work, owner: user) }
 
     before do
-      create(:collection_version_with_collection, collection: collection)
+      create(:collection_version_with_collection, collection:)
 
-      create(:work_version, work: work) # Must have a deposit to visit the dashboard
+      create(:work_version, work:) # Must have a deposit to visit the dashboard
       sign_in user
     end
 
@@ -187,15 +187,15 @@ RSpec.describe 'Dashboard requests' do
     let(:collection) { create(:collection, :with_reviewers, :with_depositors) }
     let(:user) { collection.depositors.first }
 
-    let(:work1) { create(:work, owner: user, collection: collection) }
+    let(:work1) { create(:work, owner: user, collection:) }
     let(:work_version1) { create(:work_version, :pending_approval, title: 'To Review', work: work1) }
-    let(:work2) { create(:work, owner: user, collection: collection) }
+    let(:work2) { create(:work, owner: user, collection:) }
     let(:work_version2) { create(:work_version, :first_draft, title: 'No Review', work: work2) }
-    let(:work3) { create(:work, owner: user, collection: collection) }
+    let(:work3) { create(:work, owner: user, collection:) }
     let(:work_version3) { create(:work_version, :rejected, title: 'Rejected Upon Review', work: work3) }
 
     before do
-      create(:collection_version_with_collection, collection: collection)
+      create(:collection_version_with_collection, collection:)
       work1.update(head: work_version1)
       work2.update(head: work_version2)
       work3.update(head: work_version3)

--- a/spec/requests/delete_work_version_spec.rb
+++ b/spec/requests/delete_work_version_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Deleting a version' do
 
   context 'when a subsequent version' do
     let(:head_version) { 2 }
-    let!(:first_version) { create(:work_version, version: 1, work: work) }
+    let!(:first_version) { create(:work_version, version: 1, work:) }
 
     before do
       sign_in user, groups: ['dlss:hydrus-app-collection-creators']

--- a/spec/requests/edit_collection_link_spec.rb
+++ b/spec/requests/edit_collection_link_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Link to edit a collection' do
   before do
     sign_in user
-    create(:collection_version_with_collection, :version_draft, collection: collection)
+    create(:collection_version_with_collection, :version_draft, collection:)
   end
 
   let(:rendered) do

--- a/spec/requests/edit_collection_spec.rb
+++ b/spec/requests/edit_collection_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Updating an existing collection' do
 
     describe 'show the form for an existing object' do
       before do
-        create(:collection_version_with_collection, :version_draft, :with_contact_emails, collection: collection)
+        create(:collection_version_with_collection, :version_draft, :with_contact_emails, collection:)
       end
 
       it 'allows GETs to /collections/{id}/edit' do
@@ -59,7 +59,7 @@ RSpec.describe 'Updating an existing collection' do
 
         context 'when an existing collection is updated' do
           let(:collection_version) do
-            create(:collection_version_with_collection, :deposited, :with_contact_emails, collection: collection)
+            create(:collection_version_with_collection, :deposited, :with_contact_emails, collection:)
           end
 
           it 'updates the collection' do
@@ -85,12 +85,12 @@ RSpec.describe 'Updating an existing collection' do
               required_license: 'CC0-1.0',
               email_depositors_status_changed: true,
               review_enabled: 'false',
-              reviewed_by_attributes: reviewed_by_attributes
+              reviewed_by_attributes:
             }
           end
 
           before do
-            create(:collection_version_with_collection, :version_draft, :with_contact_emails, collection: collection)
+            create(:collection_version_with_collection, :version_draft, :with_contact_emails, collection:)
           end
 
           it 'removes the reviewers' do
@@ -115,7 +115,7 @@ RSpec.describe 'Updating an existing collection' do
           end
 
           before do
-            create(:collection_version_with_collection, :version_draft, :with_contact_emails, collection: collection)
+            create(:collection_version_with_collection, :version_draft, :with_contact_emails, collection:)
             allow(CollectionObserver).to receive(:settings_updated)
           end
 
@@ -157,7 +157,7 @@ RSpec.describe 'Updating an existing collection' do
           end
 
           before do
-            create(:collection_version_with_collection, :version_draft, collection: collection)
+            create(:collection_version_with_collection, :version_draft, collection:)
           end
 
           it 'logs the changes in the event description' do
@@ -183,7 +183,7 @@ RSpec.describe 'Updating an existing collection' do
 
         context 'when setting release option to immediate' do
           let(:collection) { create(:collection, managed_by: [user], release_option: 'delay') }
-          let(:work) { create(:work, collection: collection) }
+          let(:work) { create(:work, collection:) }
 
           let(:collection_params) do
             {
@@ -196,13 +196,13 @@ RSpec.describe 'Updating an existing collection' do
           end
 
           before do
-            create(:collection_version_with_collection, collection: collection)
-            create(:work_version_with_work, :embargoed, collection: collection, work: work)
+            create(:collection_version_with_collection, collection:)
+            create(:work_version_with_work, :embargoed, collection:, work:)
           end
 
           context 'when works with embargoes would be orphaned' do
             before do
-              create(:work_version_with_work, :embargoed, collection: collection, work: work)
+              create(:work_version_with_work, :embargoed, collection:, work:)
             end
 
             it 'does not allow the change' do
@@ -214,7 +214,7 @@ RSpec.describe 'Updating an existing collection' do
 
           context 'when works with embargoes would not be orphaned' do
             before do
-              create(:work_version_with_work, :expired_embargo, collection: collection, work: work)
+              create(:work_version_with_work, :expired_embargo, collection:, work:)
             end
 
             it 'allows the change' do
@@ -234,7 +234,7 @@ RSpec.describe 'Updating an existing collection' do
         end
 
         before do
-          create(:collection_version_with_collection, :version_draft, collection: collection)
+          create(:collection_version_with_collection, :version_draft, collection:)
         end
 
         it 'renders the page again' do

--- a/spec/requests/edit_collection_version_link_spec.rb
+++ b/spec/requests/edit_collection_version_link_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Link to edit a collection version' do
   end
 
   let(:collection_version) do
-    create(:collection_version_with_collection, :version_draft, collection: collection)
+    create(:collection_version_with_collection, :version_draft, collection:)
   end
 
   let(:rendered) do

--- a/spec/requests/edit_collection_version_spec.rb
+++ b/spec/requests/edit_collection_version_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Updating an existing collection version' do
     describe 'show the form for an existing object in first draft' do
       let(:collection_version) do
         create(:collection_version_with_collection, :version_draft, :with_contact_emails, :with_version_description,
-               collection: collection)
+               collection:)
       end
 
       it 'allows GETs to /collection_versions/{id}/edit and shows saved version description' do
@@ -34,7 +34,7 @@ RSpec.describe 'Updating an existing collection version' do
     describe 'show the form for an existing already deposited object' do
       let(:collection_version) do
         create(:collection_version_with_collection, :with_contact_emails, :with_version_description,
-               collection: collection)
+               collection:)
       end
 
       it 'allows GETs to /collection_versions/{id}/edit and shows blank version description' do
@@ -61,7 +61,7 @@ RSpec.describe 'Updating an existing collection version' do
 
         context 'when deposit button is pressed for a previously deposited version' do
           let(:collection_version) do
-            create(:collection_version_with_collection, :deposited, :with_contact_emails, collection: collection)
+            create(:collection_version_with_collection, :deposited, :with_contact_emails, collection:)
           end
 
           it 'updates the collection via deposit button' do
@@ -76,7 +76,7 @@ RSpec.describe 'Updating an existing collection version' do
 
         context 'when save draft button is pressed' do
           let(:collection_version) do
-            create(:collection_version_with_collection, :version_draft, :with_contact_emails, collection: collection)
+            create(:collection_version_with_collection, :version_draft, :with_contact_emails, collection:)
           end
 
           it 'updates the collection' do
@@ -98,7 +98,7 @@ RSpec.describe 'Updating an existing collection version' do
         end
 
         let(:collection_version) do
-          create(:collection_version_with_collection, :version_draft, collection: collection)
+          create(:collection_version_with_collection, :version_draft, collection:)
         end
 
         it 'renders the page again' do

--- a/spec/requests/edit_work_spec.rb
+++ b/spec/requests/edit_work_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe 'Updating an existing work' do
 
     describe 'display the form' do
       let(:collection) { create(:collection_version_with_collection).collection }
-      let(:work) { create(:work, collection: collection) }
-      let(:work_version) { create(:work_version, :published, :with_creation_date_range, work: work) }
+      let(:work) { create(:work, collection:) }
+      let(:work_version) { create(:work_version, :published, :with_creation_date_range, work:) }
 
       it 'shows the form' do
         get "/works/#{work.id}/edit"
@@ -32,8 +32,8 @@ RSpec.describe 'Updating an existing work' do
     describe 'submit the form' do
       context 'when the previous version was deposited' do
         let(:collection) { create(:collection_version_with_collection).collection }
-        let(:work) { create(:work, collection: collection) }
-        let(:work_version) { create(:work_version, :deposited, :with_required_associations, work: work) }
+        let(:work) { create(:work, collection:) }
+        let(:work_version) { create(:work_version, :deposited, :with_required_associations, work:) }
         let(:work_params) do
           {
             title: 'New title',
@@ -69,7 +69,7 @@ RSpec.describe 'Updating an existing work' do
         end
 
         before do
-          create(:attached_file, :with_file, work_version: work_version)
+          create(:attached_file, :with_file, work_version:)
           allow(CollectionObserver).to receive(:version_draft_created)
         end
 
@@ -77,7 +77,7 @@ RSpec.describe 'Updating an existing work' do
           it 'redirects to the work page' do
             patch "/works/#{work.id}", params: { work: work_params }
             expect(CollectionObserver).to have_received(:version_draft_created)
-            expect(WorkVersion.where(work: work).count).to eq 2
+            expect(WorkVersion.where(work:).count).to eq 2
             expect(work.reload.head).to be_version_draft
             expect(work.head.subtype).to eq []
             # Only changed fields are recorded in event.
@@ -89,7 +89,7 @@ RSpec.describe 'Updating an existing work' do
         end
 
         context "when a doi is requested (but wasn't present before)" do
-          let(:work) { create(:work, :with_druid, collection: collection) }
+          let(:work) { create(:work, :with_druid, collection:) }
 
           before do
             work_params[:assign_doi] = 'true'
@@ -99,7 +99,7 @@ RSpec.describe 'Updating an existing work' do
           it 'sets the doi' do
             patch "/works/#{work.id}", params: { work: work_params, commit: 'Deposit' }
             expect(CollectionObserver).to have_received(:version_draft_created)
-            expect(WorkVersion.where(work: work).count).to eq 2
+            expect(WorkVersion.where(work:).count).to eq 2
             expect(work.reload.head).to be_depositing
             expect(work.doi).to eq '10.80343/bc123df4567'
             expect(response).to redirect_to(next_step_work_path(work))
@@ -107,7 +107,7 @@ RSpec.describe 'Updating an existing work' do
         end
 
         context "when a doi is not requested (and wasn't present before)" do
-          let(:work) { create(:work, :with_druid, collection: collection) }
+          let(:work) { create(:work, :with_druid, collection:) }
 
           before do
             work_params[:assign_doi] = 'false'
@@ -117,7 +117,7 @@ RSpec.describe 'Updating an existing work' do
           it 'sets the doi' do
             patch "/works/#{work.id}", params: { work: work_params, commit: 'Deposit' }
             expect(CollectionObserver).to have_received(:version_draft_created)
-            expect(WorkVersion.where(work: work).count).to eq 2
+            expect(WorkVersion.where(work:).count).to eq 2
             expect(work.reload.head).to be_depositing
             expect(work.doi).to be_nil
             expect(response).to redirect_to(next_step_work_path(work))
@@ -125,7 +125,7 @@ RSpec.describe 'Updating an existing work' do
         end
 
         context 'when a doi is not permitted' do
-          let(:work) { create(:work, :with_druid, collection: collection) }
+          let(:work) { create(:work, :with_druid, collection:) }
 
           before do
             collection.update!(doi_option: 'no')
@@ -134,7 +134,7 @@ RSpec.describe 'Updating an existing work' do
           it 'sets assign_doi to false' do
             patch "/works/#{work.id}", params: { work: work_params, commit: 'Deposit' }
             expect(CollectionObserver).to have_received(:version_draft_created)
-            expect(WorkVersion.where(work: work).count).to eq 2
+            expect(WorkVersion.where(work:).count).to eq 2
             expect(work.reload.head).to be_depositing
             expect(work.assign_doi).to be false
             expect(response).to redirect_to(next_step_work_path(work))
@@ -148,7 +148,7 @@ RSpec.describe 'Updating an existing work' do
             it 'removes any attached files' do
               expect(work.head.attached_files.count).to eq 1
               patch "/works/#{work.id}", params: { work: work_params, commit: 'Deposit' }
-              expect(WorkVersion.where(work: work).count).to eq 2
+              expect(WorkVersion.where(work:).count).to eq 2
               work.reload
               expect(work.head.state).to eq 'depositing'
               expect(work.head.attached_files.count).to eq 0
@@ -159,7 +159,7 @@ RSpec.describe 'Updating an existing work' do
             it 'removes any attached files' do
               expect(work.head.attached_files.count).to eq 1
               patch "/works/#{work.id}", params: { work: work_params, commit: 'Save as draft' }
-              expect(WorkVersion.where(work: work).count).to eq 2
+              expect(WorkVersion.where(work:).count).to eq 2
               work.reload
               expect(work.head.state).to eq 'version_draft'
               expect(work.head.attached_files.count).to eq 0
@@ -170,8 +170,8 @@ RSpec.describe 'Updating an existing work' do
 
       context 'with a validation problem' do
         let(:collection) { create(:collection_version_with_collection).collection }
-        let(:work) { create(:work, collection: collection) }
-        let(:work_version) { create(:work_version, work: work) }
+        let(:work) { create(:work, collection:) }
+        let(:work_version) { create(:work_version, work:) }
 
         context 'when missing title' do
           let(:work_params) do

--- a/spec/requests/first_draft_collection_spec.rb
+++ b/spec/requests/first_draft_collection_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Updating a first draft (non-deposited) collection' do
 
     describe 'redirects and renders the full collection form with settings and details' do
       before do
-        create(:collection_version_with_collection, :first_draft, :with_contact_emails, collection: collection)
+        create(:collection_version_with_collection, :first_draft, :with_contact_emails, collection:)
       end
 
       it 'redirects GETs to /collections/{id}/edit to /first_draft_collections/{id}/edit' do
@@ -47,7 +47,7 @@ RSpec.describe 'Updating a first draft (non-deposited) collection' do
     describe 'submit the form' do
       context 'when a first draft collection is saved' do
         let(:collection_version) do
-          create(:collection_version_with_collection, :first_draft, :with_contact_emails, collection: collection)
+          create(:collection_version_with_collection, :first_draft, :with_contact_emails, collection:)
         end
 
         let(:collection_params) do

--- a/spec/requests/purl_reservation_spec.rb
+++ b/spec/requests/purl_reservation_spec.rb
@@ -47,13 +47,13 @@ RSpec.describe 'Reserve a PURL and flesh it out into a work (version)' do
     end
 
     describe 'choose a type for the reserved PURL' do
-      let(:work) { create(:work, owner: user, collection: collection) }
+      let(:work) { create(:work, owner: user, collection:) }
 
       # have to set this here (?), artifact of the circular relationship between works and work_versions
       before { work.update(head: work_version) }
 
       context 'when the work version still has no type info specified' do
-        let!(:work_version) { create(:work_version, :purl_reserved, work: work) }
+        let!(:work_version) { create(:work_version, :purl_reserved, work:) }
 
         it 'sets the type and subtype, then redirects to the work edit page' do
           patch "/reservations/#{work.id}", params: { work_type: 'text', subtype: ['Other spoken word'] }
@@ -67,7 +67,7 @@ RSpec.describe 'Reserve a PURL and flesh it out into a work (version)' do
       end
 
       context 'when the work version has no type and is then given an invalid type' do
-        let(:work_version) { create(:work_version, :purl_reserved, work: work) }
+        let(:work_version) { create(:work_version, :purl_reserved, work:) }
 
         it 'returns the user to the dashboard with an explanatory error message' do
           patch "/reservations/#{work.id}", params: { work_type: 'other', subtype: [] }
@@ -80,7 +80,7 @@ RSpec.describe 'Reserve a PURL and flesh it out into a work (version)' do
       end
 
       context 'when the work version has already had a type chosen' do
-        let(:work_version) { create(:work_version, work: work) }
+        let(:work_version) { create(:work_version, work:) }
 
         it 'redirects the user to the homepage with an explanatory error message' do
           patch "/reservations/#{work.id}", params: { work_type: 'text', subtype: ['Other spoken word'] }

--- a/spec/requests/reviews_spec.rb
+++ b/spec/requests/reviews_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe 'Works requests' do
   context 'with an authenticated user' do
     let(:user) { collection.reviewed_by.first }
     let(:collection) { create(:collection, :with_reviewers) }
-    let(:work) { create(:work, collection: collection) }
-    let(:work_version) { create(:work_version, :pending_approval, work: work) }
+    let(:work) { create(:work, collection:) }
+    let(:work_version) { create(:work_version, :pending_approval, work:) }
 
     before do
       work.update(head: work_version)
-      create(:collection_version_with_collection, collection: collection)
+      create(:collection_version_with_collection, collection:)
 
       sign_in user
       allow(DepositJob).to receive(:perform_later)

--- a/spec/requests/show_collection_settings_spec.rb
+++ b/spec/requests/show_collection_settings_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Show the collection settings page' do
     let(:managers) { collection.managed_by.map(&:sunetid).join(', ') }
 
     before do
-      create(:collection_version_with_collection, collection: collection)
+      create(:collection_version_with_collection, collection:)
       sign_in user, groups: [Settings.authorization_workgroup_names.administrators]
     end
 

--- a/spec/requests/show_work_spec.rb
+++ b/spec/requests/show_work_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 RSpec.describe 'Show a work detail' do
   let(:collection) { create(:collection_version_with_collection).collection }
-  let(:work) { create(:work, collection: collection) }
-  let(:work_version) { create(:work_version, work: work) }
+  let(:work) { create(:work, collection:) }
+  let(:work_version) { create(:work_version, work:) }
 
   before do
     work.update(head: work_version)
@@ -56,7 +56,7 @@ RSpec.describe 'Show a work detail' do
     end
 
     context 'when the work has a blank title' do
-      let(:work_version) { create(:work_version, title: '', work: work) }
+      let(:work_version) { create(:work_version, title: '', work:) }
 
       it 'displays a default title for a work when it is blank' do
         expect(response).to have_http_status(:ok)
@@ -67,7 +67,7 @@ RSpec.describe 'Show a work detail' do
     context 'when work opener is same as depositor' do
       let(:user) { create(:user) }
 
-      let(:work) { create(:work, collection: collection, owner: user, depositor: user) }
+      let(:work) { create(:work, collection:, owner: user, depositor: user) }
 
       it 'does not display the owner' do
         expect(response).to have_http_status(:ok)

--- a/spec/requests/show_works_in_collection_spec.rb
+++ b/spec/requests/show_works_in_collection_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe 'Show the collection work list page' do
   let(:collection) { collection_version.collection }
   let(:collection_version) { create(:collection_version_with_collection) }
   let(:user) { create(:user) }
-  let!(:work_version1) { create(:work_version_with_work, collection: collection) }
-  let!(:work_version2) { create(:work_version_with_work, collection: collection, state: 'decommissioned') }
+  let!(:work_version1) { create(:work_version_with_work, collection:) }
+  let!(:work_version2) { create(:work_version_with_work, collection:, state: 'decommissioned') }
   # let(:work7) { create(:work, owner: user, collection: collection) }
   # let(:work_version7) do
   #   create(:work_version, state: 'decommissioned', title: 'I am decommissioned', work: work6)
   # end
 
-  before { create(:work_version_with_work, collection: collection) }
+  before { create(:work_version_with_work, collection:) }
 
   context 'with an admin user' do
     let(:attached_file) { build(:attached_file, :with_file) }

--- a/spec/requests/work_edit_button_spec.rb
+++ b/spec/requests/work_edit_button_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Link to edit a work' do
   let(:user) { create(:user) }
 
   context 'with a user who may edit the object' do
-    let(:work) { create(:work_version_with_work, :version_draft, collection: collection, owner: user).work }
+    let(:work) { create(:work_version_with_work, :version_draft, collection:, owner: user).work }
 
     it 'draws a link' do
       get "/works/#{work.id}/edit_button"
@@ -49,7 +49,7 @@ RSpec.describe 'Link to edit a work' do
   end
 
   context 'with a user who may not edit the object' do
-    let(:work) { create(:work_version_with_work, :version_draft, collection: collection).work }
+    let(:work) { create(:work_version_with_work, :version_draft, collection:).work }
 
     it 'only draws the turbo-frame' do
       get "/works/#{work.id}/edit_button"

--- a/spec/requests/zips_request_spec.rb
+++ b/spec/requests/zips_request_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Download a zip file of all attached files', type: :request do
-  let(:rendered) { render_inline(described_class.new(work_version: work_version)) }
-  let(:work_version) { create(:work_version, work: work) }
+  let(:rendered) { render_inline(described_class.new(work_version:)) }
+  let(:work_version) { create(:work_version, work:) }
   let(:user) { create(:user) }
   let(:work) { create(:work, owner: user) }
   let(:work_id) { work.id }
@@ -24,7 +24,7 @@ RSpec.describe 'Download a zip file of all attached files', type: :request do
     before do
       sign_in user
       work.update(head: work_version)
-      create(:attached_file, :with_file, work_version: work_version)
+      create(:attached_file, :with_file, work_version:)
     end
 
     it 'shows a download link' do

--- a/spec/services/account_service_spec.rb
+++ b/spec/services/account_service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe AccountService do
 
       before do
         stub_request(:get, 'https://accountws-uat.stanford.edu/accounts/jcoyne85')
-          .to_return(status: 200, body: body, headers: { 'Content-Type' => 'application/json' })
+          .to_return(status: 200, body:, headers: { 'Content-Type' => 'application/json' })
       end
 
       it 'returns data' do

--- a/spec/services/admin/collections_csv_generator_spec.rb
+++ b/spec/services/admin/collections_csv_generator_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Admin::CollectionsCsvGenerator do
       state: 'deposited',
       version: 1,
       updated_at: Time.zone.parse('2019-01-01'),
-      collection: collection
+      collection:
     )
   end
 

--- a/spec/services/admin/work_csv_generator_spec.rb
+++ b/spec/services/admin/work_csv_generator_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Admin::WorkCsvGenerator do
   end
 
   let(:work) do
-    build(:work, id: 1, collection: collection,
+    build(:work, id: 1, collection:,
                  druid: 'druid:cn748wq9511',
                  doi: '10.25740/bc123df4567',
                  depositor: user1, owner: user2)
   end
 
   let(:version) do
-    build(:work_version, work: work,
+    build(:work_version, work:,
                          title: 'Test title 1',
                          state: 'deposited', updated_at: Time.zone.parse('2019-01-01'))
   end

--- a/spec/services/admin/work_report_query_spec.rb
+++ b/spec/services/admin/work_report_query_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Admin::WorkReportQuery do
   let!(:user1) { create(:user) }
   let!(:user2) { create(:user) }
   let(:user3) { create(:user, email: 'aaaa@stanford.edu') }
-  let!(:work1) { create(:work_version_with_work, state: 'deposited', collection: collection, owner: user1).work }
-  let!(:work2) { create(:work_version_with_work, state: 'first_draft', collection: collection, owner: user2).work }
+  let!(:work1) { create(:work_version_with_work, state: 'deposited', collection:, owner: user1).work }
+  let!(:work2) { create(:work_version_with_work, state: 'first_draft', collection:, owner: user2).work }
   let!(:work3) do
     work = create(:work_version_with_work, state: 'version_draft',
-                                           collection: collection,
+                                           collection:,
                                            owner: user3,
                                            updated_at: Time.zone.parse('2018-06-01')).work
     work.created_at = Time.zone.parse('2005-01-01')

--- a/spec/services/cocina_generator/access_generator_spec.rb
+++ b/spec/services/cocina_generator/access_generator_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CocinaGenerator::AccessGenerator do
-  let(:model) { described_class.generate(work_version: work_version) }
+  let(:model) { described_class.generate(work_version:) }
   let(:license_uri) { License.find('CC0-1.0').uri }
 
   context 'when license is none' do

--- a/spec/services/cocina_generator/collection_generator_spec.rb
+++ b/spec/services/cocina_generator/collection_generator_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CocinaGenerator::CollectionGenerator do
-  let(:model) { described_class.generate_model(collection_version: collection_version) }
+  let(:model) { described_class.generate_model(collection_version:) }
   let(:project_tag) { Settings.h2.project_tag }
   let(:description) do
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit, ' \
@@ -15,8 +15,8 @@ RSpec.describe CocinaGenerator::CollectionGenerator do
     let(:collection_version) do
       build(:collection_version, :with_related_links, :with_contact_emails,
             name: 'Test title',
-            description: description,
-            collection: collection)
+            description:,
+            collection:)
     end
     let(:expected_model) do
       Cocina::Models::RequestCollection.new(
@@ -78,8 +78,8 @@ RSpec.describe CocinaGenerator::CollectionGenerator do
     let(:collection_version) do
       build(:collection_version, :with_contact_emails,
             name: 'Test title',
-            description: description,
-            collection: collection)
+            description:,
+            collection:)
     end
 
     let(:expected_model) do

--- a/spec/services/cocina_generator/description/contributors_generator_spec.rb
+++ b/spec/services/cocina_generator/description/contributors_generator_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CocinaGenerator::Description::ContributorsGenerator do
-  subject(:cocina_model) { described_class.generate(work_version: work_version) }
+  subject(:cocina_model) { described_class.generate(work_version:) }
 
   let(:cocina_props) { cocina_model.map(&:to_h) }
 
@@ -48,7 +48,7 @@ RSpec.describe CocinaGenerator::Description::ContributorsGenerator do
       context 'with no publisher' do
         let(:contributor) { build(:person_contributor) }
         let(:work_version) { build(:work_version, contributors: [contributor]) }
-        let(:cocina_model) { described_class.events_from_publisher_contributors(work_version: work_version) }
+        let(:cocina_model) { described_class.events_from_publisher_contributors(work_version:) }
 
         it 'returns empty Array' do
           expect(cocina_model).to eq []
@@ -59,7 +59,7 @@ RSpec.describe CocinaGenerator::Description::ContributorsGenerator do
         let(:org_contrib1) { build(:org_contributor, role: 'Publisher') }
         let(:org_contrib2) { build(:org_contributor, role: 'Publisher') }
         let(:work_version) { build(:work_version, contributors: [org_contrib1, org_contrib2]) }
-        let(:cocina_model) { described_class.events_from_publisher_contributors(work_version: work_version) }
+        let(:cocina_model) { described_class.events_from_publisher_contributors(work_version:) }
 
         it 'returns Array of populated cocina model events, one for each publisher' do
           expect(cocina_props).to eq(
@@ -111,7 +111,7 @@ RSpec.describe CocinaGenerator::Description::ContributorsGenerator do
         let(:contributor) { build(:person_contributor) }
         let(:work_version) { build(:work_version, contributors: [contributor]) }
         let(:cocina_model) do
-          described_class.events_from_publisher_contributors(work_version: work_version, pub_date: pub_date)
+          described_class.events_from_publisher_contributors(work_version:, pub_date:)
         end
 
         it 'returns empty Array' do
@@ -124,7 +124,7 @@ RSpec.describe CocinaGenerator::Description::ContributorsGenerator do
         let(:org_contrib2) { build(:org_contributor, role: 'Publisher') }
         let(:work_version) { build(:work_version, contributors: [org_contrib1, org_contrib2]) }
         let(:cocina_model) do
-          described_class.events_from_publisher_contributors(work_version: work_version, pub_date: pub_date)
+          described_class.events_from_publisher_contributors(work_version:, pub_date:)
         end
 
         it 'returns Array of populated cocina model events, one for each publisher' do
@@ -220,8 +220,8 @@ RSpec.describe CocinaGenerator::Description::ContributorsGenerator do
     let(:cocina_props) do
       {
         contributor: cocina_model.map(&:to_h),
-        event: described_class.events_from_publisher_contributors(work_version: work_version,
-                                                                  pub_date: pub_date).map(&:to_h)
+        event: described_class.events_from_publisher_contributors(work_version:,
+                                                                  pub_date:).map(&:to_h)
       }.compact_blank
     end
 

--- a/spec/services/cocina_generator/description/events_generator_spec.rb
+++ b/spec/services/cocina_generator/description/events_generator_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CocinaGenerator::Description::EventsGenerator do
-  subject(:events) { normalize_events(described_class.generate(work_version: work_version)) }
+  subject(:events) { normalize_events(described_class.generate(work_version:)) }
 
   let(:publisher_roles) do
     [
@@ -48,13 +48,13 @@ RSpec.describe CocinaGenerator::Description::EventsGenerator do
       build(:work)
     end
     let(:work_version2) do
-      build(:valid_deposited_work_version, published_at: Time.zone.parse('2017-01-01'), work: work)
+      build(:valid_deposited_work_version, published_at: Time.zone.parse('2017-01-01'), work:)
     end
     let!(:work_version3) do
-      build(:valid_deposited_work_version, published_at: Time.zone.parse('2018-01-01'), work: work)
+      build(:valid_deposited_work_version, published_at: Time.zone.parse('2018-01-01'), work:)
     end
     let(:work_version) do
-      build(:valid_deposited_work_version, work: work)
+      build(:valid_deposited_work_version, work:)
     end
 
     before do

--- a/spec/services/cocina_generator/description/generator_spec.rb
+++ b/spec/services/cocina_generator/description/generator_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CocinaGenerator::Description::Generator do
-  subject(:model) { described_class.generate(work_version: work_version).to_h }
+  subject(:model) { described_class.generate(work_version:).to_h }
 
   let(:contributor) { build(:org_contributor) }
   let(:work_version) do

--- a/spec/services/cocina_generator/description/types_generator_spec.rb
+++ b/spec/services/cocina_generator/description/types_generator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CocinaGenerator::Description::TypesGenerator do
   let(:work_version) { build(:work_version) }
 
   describe '.generate' do
-    subject(:generated) { described_class.generate(work_version: work_version) }
+    subject(:generated) { described_class.generate(work_version:) }
 
     context 'with a work containing multiple subtypes' do
       it 'generates a flat array of structured values for the work type and subtypes' do
@@ -202,7 +202,7 @@ RSpec.describe CocinaGenerator::Description::TypesGenerator do
   describe 'cocina mapping' do
     work_types = WorkType.all
 
-    let(:generator) { described_class.new(work_version: work_version) }
+    let(:generator) { described_class.new(work_version:) }
     let(:types_to_genres) { generator.send(:types_to_genres) }
     let(:types_to_resource_types) { generator.send(:types_to_resource_types) }
 
@@ -260,9 +260,9 @@ RSpec.describe CocinaGenerator::Description::TypesGenerator do
   # from https://github.com/sul-dlss/dor-services-app/blob/main/spec/services/cocina/mapping/descriptive/h2/form_h2_spec.rb
   # The contexts below match the spec names from above. The expected cocina props are copied directly.
   describe 'h2 mapping specification examples' do
-    subject(:cocina_props) { { form: described_class.generate(work_version: work_version).map(&:to_h) } }
+    subject(:cocina_props) { { form: described_class.generate(work_version:).map(&:to_h) } }
 
-    let(:work_version) { build(:work_version, work_type: work_type, subtype: work_subtypes) }
+    let(:work_version) { build(:work_version, work_type:, subtype: work_subtypes) }
 
     context 'with type only, resource type with URI' do
       let(:work_type) { 'data' }

--- a/spec/services/cocina_generator/dro_generator_spec.rb
+++ b/spec/services/cocina_generator/dro_generator_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe CocinaGenerator::DROGenerator do
   let(:collection) { build(:collection, druid: 'druid:bc123df4567') }
-  let(:model) { described_class.generate_model(work_version: work_version) }
+  let(:model) { described_class.generate_model(work_version:) }
   let(:project_tag) { Settings.h2.project_tag }
   let(:types_form) do
     [
@@ -90,9 +90,9 @@ RSpec.describe CocinaGenerator::DROGenerator do
   context 'when files are not present' do
     context 'without a druid' do
       let(:work_version) do
-        build(:work_version, work_type: 'text', work: work, title: 'Test title')
+        build(:work_version, work_type: 'text', work:, title: 'Test title')
       end
-      let(:work) { build(:work, id: 7, collection: collection) }
+      let(:work) { build(:work, id: 7, collection:) }
       let(:expected_model) do
         Cocina::Models::RequestDRO.new(
           {
@@ -147,9 +147,9 @@ RSpec.describe CocinaGenerator::DROGenerator do
 
   context 'with a druid, assign_doi is false' do
     let(:work_version) do
-      build(:work_version, work_type: 'text', title: 'Test title', work: work)
+      build(:work_version, work_type: 'text', title: 'Test title', work:)
     end
-    let(:work) { build(:work, id: 7, druid: 'druid:bk123gh4567', collection: collection) }
+    let(:work) { build(:work, id: 7, druid: 'druid:bk123gh4567', collection:) }
     let(:expected_model) do
       Cocina::Models::DRO.new(
         {
@@ -208,9 +208,9 @@ RSpec.describe CocinaGenerator::DROGenerator do
 
   context 'with a doi' do
     let(:work_version) do
-      build(:work_version, work_type: 'text', title: 'Test title', work: work)
+      build(:work_version, work_type: 'text', title: 'Test title', work:)
     end
-    let(:work) { build(:work, id: 7, druid: 'druid:bk123gh4567', doi: '10.80343/bk123gh4567', collection: collection) }
+    let(:work) { build(:work, id: 7, druid: 'druid:bk123gh4567', doi: '10.80343/bk123gh4567', collection:) }
     let(:expected_model) do
       Cocina::Models::DRO.new(
         {
@@ -266,9 +266,9 @@ RSpec.describe CocinaGenerator::DROGenerator do
 
   context 'when a doi is requested and there is no druid' do
     let(:work_version) do
-      build(:work_version, :version_draft, work_type: 'text', title: 'Test title', work: work)
+      build(:work_version, :version_draft, work_type: 'text', title: 'Test title', work:)
     end
-    let(:work) { build(:work, id: 7, druid: nil, collection: collection) }
+    let(:work) { build(:work, id: 7, druid: nil, collection:) }
     let(:expected_model) do
       Cocina::Models::RequestDRO.new(
         {
@@ -343,9 +343,9 @@ RSpec.describe CocinaGenerator::DROGenerator do
 
     context 'without a druid' do
       let(:work_version) do
-        build(:work_version, version: 1, attached_files: [attached_file], title: 'Test title', work: work)
+        build(:work_version, version: 1, attached_files: [attached_file], title: 'Test title', work:)
       end
-      let(:work) { build(:work, id: 7, collection: collection) }
+      let(:work) { build(:work, id: 7, collection:) }
 
       let(:expected_model) do
         Cocina::Models::RequestDRO.new(
@@ -422,9 +422,9 @@ RSpec.describe CocinaGenerator::DROGenerator do
 
     context 'with a druid' do
       let(:work_version) do
-        build(:work_version, version: 1, attached_files: [attached_file], title: 'Test title', work: work)
+        build(:work_version, version: 1, attached_files: [attached_file], title: 'Test title', work:)
       end
-      let(:work) { build(:work, id: 7, druid: 'druid:bk123gh4567', collection: collection) }
+      let(:work) { build(:work, id: 7, druid: 'druid:bk123gh4567', collection:) }
 
       let(:expected_model) do
         Cocina::Models::DRO.new(

--- a/spec/services/cocina_generator/structural/file_generator_spec.rb
+++ b/spec/services/cocina_generator/structural/file_generator_spec.rb
@@ -3,13 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe CocinaGenerator::Structural::FileGenerator do
-  let(:model) { described_class.generate(work_version: work_version, attached_file: attached_file) }
+  let(:model) { described_class.generate(work_version:, attached_file:) }
 
   describe '#access' do
     subject { model.access }
 
     context 'when file is visible' do
-      let(:attached_file) { create(:attached_file, :with_file, work_version: work_version) }
+      let(:attached_file) { create(:attached_file, :with_file, work_version:) }
 
       context 'when work is public' do
         let(:work_version) { build(:work_version) }
@@ -26,14 +26,14 @@ RSpec.describe CocinaGenerator::Structural::FileGenerator do
 
     context 'when file is hidden' do
       let(:work_version) { build(:work_version) }
-      let(:attached_file) { create(:attached_file, :with_file, work_version: work_version, hide: true) }
+      let(:attached_file) { create(:attached_file, :with_file, work_version:, hide: true) }
 
       it { is_expected.to eq Cocina::Models::FileAccess.new(view: 'world', download: 'world') }
     end
 
     context 'when object is embargoed' do
       let(:work_version) { build(:work_version, :embargoed) }
-      let(:attached_file) { create(:attached_file, :with_file, work_version: work_version, hide: true) }
+      let(:attached_file) { create(:attached_file, :with_file, work_version:, hide: true) }
 
       it { is_expected.to eq Cocina::Models::FileAccess.new(view: 'dark', download: 'none') }
     end

--- a/spec/services/collection_event_description_builder_spec.rb
+++ b/spec/services/collection_event_description_builder_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe CollectionEventDescriptionBuilder do
-  subject(:result) { described_class.build(form: form, change_set: change_set) }
+  subject(:result) { described_class.build(form:, change_set:) }
 
   let(:collection) { create(:collection) }
   let(:form) { CollectionSettingsForm.new(collection) }
   let(:change_set) do
     instance_double(CollectionChangeSet,
                     participants_changed?: participants_changed,
-                    participant_change_description: participant_change_description,
+                    participant_change_description:,
                     email_when_participants_changed_changed?: email_when_participants_changed_changed,
                     email_depositors_status_changed_changed?: email_depositors_status_changed_changed,
                     review_enabled_changed?: review_enabled_changed,

--- a/spec/services/collection_observer_spec.rb
+++ b/spec/services/collection_observer_spec.rb
@@ -4,12 +4,12 @@ require 'rails_helper'
 
 RSpec.describe CollectionObserver do
   let(:collection) { create(:collection) }
-  let(:collection_version) { create(:collection_version_with_collection, collection: collection) }
-  let(:form) { DraftCollectionForm.new(collection_version: collection_version, collection: collection) }
+  let(:collection_version) { create(:collection_version_with_collection, collection:) }
+  let(:form) { DraftCollectionForm.new(collection_version:, collection:) }
 
   describe '.settings_updated' do
     subject(:action) do
-      described_class.settings_updated(collection, user: collection.creator, change_set: change_set, form: form)
+      described_class.settings_updated(collection, user: collection.creator, change_set:, form:)
     end
 
     let(:change_set) { CollectionChangeSet::PointInTime.new(collection).diff(collection_after) }
@@ -25,7 +25,7 @@ RSpec.describe CollectionObserver do
         it 'sends emails to those removed' do
           expect { action }.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
             'CollectionsMailer', 'deposit_access_removed_email', 'deliver_now',
-            { params: { user: collection.depositors.last, collection_version: collection_version }, args: [] }
+            { params: { user: collection.depositors.last, collection_version: }, args: [] }
           )
         end
       end
@@ -43,17 +43,17 @@ RSpec.describe CollectionObserver do
         it 'sends emails to the managers about the participants change' do
           expect { action }.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
             'CollectionsMailer', 'participants_changed_email', 'deliver_now',
-            { params: { user: manager, collection_version: collection_version }, args: [] }
+            { params: { user: manager, collection_version: }, args: [] }
           )
         end
 
         it 'sends emails to the reviewers about the participants change' do
           expect { action }.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
             'CollectionsMailer', 'participants_changed_email', 'deliver_now',
-            { params: { user: reviewer, collection_version: collection_version }, args: [] }
+            { params: { user: reviewer, collection_version: }, args: [] }
           ).and have_enqueued_job(ActionMailer::MailDeliveryJob).with(
             'CollectionsMailer', 'participants_changed_email', 'deliver_now',
-            { params: { user: reviewer2, collection_version: collection_version }, args: [] }
+            { params: { user: reviewer2, collection_version: }, args: [] }
           )
         end
       end
@@ -91,7 +91,7 @@ RSpec.describe CollectionObserver do
       it 'sends emails to those added' do
         expect { action }.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
           'CollectionsMailer', 'manage_access_granted_email', 'deliver_now',
-          { params: { user: manager, collection_version: collection_version }, args: [] }
+          { params: { user: manager, collection_version: }, args: [] }
         )
       end
     end
@@ -105,7 +105,7 @@ RSpec.describe CollectionObserver do
       it 'sends emails to those removed' do
         expect { action }.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
           'CollectionsMailer', 'manage_access_removed_email', 'deliver_now',
-          { params: { user: collection.managed_by.last, collection_version: collection_version }, args: [] }
+          { params: { user: collection.managed_by.last, collection_version: }, args: [] }
         )
       end
     end
@@ -118,7 +118,7 @@ RSpec.describe CollectionObserver do
       it 'sends emails to those added' do
         expect { action }.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
           'CollectionsMailer', 'review_access_granted_email', 'deliver_now',
-          { params: { user: reviewer, collection_version: collection_version }, args: [] }
+          { params: { user: reviewer, collection_version: }, args: [] }
         )
       end
     end
@@ -136,7 +136,7 @@ RSpec.describe CollectionObserver do
       it 'sends access granted email but not participant change notification to manager' do
         expect { action }.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
           'CollectionsMailer', 'review_access_granted_email', 'deliver_now',
-          { params: { user: manager, collection_version: collection_version }, args: [] }
+          { params: { user: manager, collection_version: }, args: [] }
         ).and not_to_have_enqueued_job(ActionMailer::MailDeliveryJob).with(
           'CollectionsMailer', 'participants_changed_email', anything, anything
         )
@@ -152,16 +152,16 @@ RSpec.describe CollectionObserver do
       it 'sends emails to those removed' do
         expect { action }.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
           'CollectionsMailer', 'review_access_removed_email', 'deliver_now',
-          { params: { user: collection.reviewed_by.last, collection_version: collection_version }, args: [] }
+          { params: { user: collection.reviewed_by.last, collection_version: }, args: [] }
         )
       end
     end
 
     context 'when review not enabled' do
       let(:collection) { create(:collection) }
-      let!(:work_version1) { create(:work_version_with_work, collection: collection, state: 'pending_approval') }
-      let!(:work_version2) { create(:work_version_with_work, collection: collection, state: 'rejected') }
-      let!(:work_version3) { create(:work_version_with_work, collection: collection, state: 'deposited') }
+      let!(:work_version1) { create(:work_version_with_work, collection:, state: 'pending_approval') }
+      let!(:work_version2) { create(:work_version_with_work, collection:, state: 'rejected') }
+      let!(:work_version3) { create(:work_version_with_work, collection:, state: 'deposited') }
       let(:collection_after) { collection }
 
       before do
@@ -178,8 +178,8 @@ RSpec.describe CollectionObserver do
 
     context 'when review is enabled' do
       let(:collection) { create(:collection) }
-      let!(:work_version1) { create(:work_version_with_work, collection: collection, state: 'pending_approval') }
-      let!(:work_version2) { create(:work_version_with_work, collection: collection, state: 'rejected') }
+      let!(:work_version1) { create(:work_version_with_work, collection:, state: 'pending_approval') }
+      let!(:work_version2) { create(:work_version_with_work, collection:, state: 'rejected') }
       let(:collection_after) { collection }
 
       before do

--- a/spec/services/collection_reminder_generator_spec.rb
+++ b/spec/services/collection_reminder_generator_spec.rb
@@ -11,24 +11,24 @@ RSpec.describe CollectionReminderGenerator do
 
     context 'when there are collections that need a notification sent' do
       let(:version_draft4) do
-        create(:collection_version, :version_draft, created_at: 14.days.ago, collection: collection)
+        create(:collection_version, :version_draft, created_at: 14.days.ago, collection:)
       end
       let(:version_draft6) do
-        create(:collection_version, :version_draft, created_at: 42.days.ago, collection: collection)
+        create(:collection_version, :version_draft, created_at: 42.days.ago, collection:)
       end
       # every 28 days from there
       let(:version_draft8) do
-        create(:collection_version, :version_draft, created_at: 70.days.ago, collection: collection)
+        create(:collection_version, :version_draft, created_at: 70.days.ago, collection:)
       end
       let(:first_draft4) do
-        create(:collection_version, :first_draft, created_at: 14.days.ago, collection: collection)
+        create(:collection_version, :first_draft, created_at: 14.days.ago, collection:)
       end
       let(:first_draft6) do
-        create(:collection_version, :first_draft, created_at: 42.days.ago, collection: collection)
+        create(:collection_version, :first_draft, created_at: 42.days.ago, collection:)
       end
       # every 28 days from there
       let(:first_draft8) do
-        create(:collection_version, :first_draft, created_at: 70.days.ago, collection: collection)
+        create(:collection_version, :first_draft, created_at: 70.days.ago, collection:)
       end
 
       it 'queues an email for each draft collection that needs a notification sent' do
@@ -36,42 +36,42 @@ RSpec.describe CollectionReminderGenerator do
           .to have_enqueued_job(ActionMailer::MailDeliveryJob)
           .with(
             'CollectionsMailer', 'first_draft_reminder_email', 'deliver_now',
-            { params: { collection_version: first_draft4, user: user }, args: [] }
+            { params: { collection_version: first_draft4, user: }, args: [] }
           )
           .and(have_enqueued_job(ActionMailer::MailDeliveryJob)
               .with(
                 'CollectionsMailer', 'first_draft_reminder_email', 'deliver_now',
-                { params: { collection_version: first_draft6, user: user }, args: [] }
+                { params: { collection_version: first_draft6, user: }, args: [] }
               ))
           .and(have_enqueued_job(ActionMailer::MailDeliveryJob)
               .with(
                 'CollectionsMailer', 'first_draft_reminder_email', 'deliver_now',
-                { params: { collection_version: first_draft8, user: user }, args: [] }
+                { params: { collection_version: first_draft8, user: }, args: [] }
               ))
           .and(have_enqueued_job(ActionMailer::MailDeliveryJob)
               .with(
                 'CollectionsMailer', 'new_version_reminder_email', 'deliver_now',
-                { params: { collection_version: version_draft4, user: user }, args: [] }
+                { params: { collection_version: version_draft4, user: }, args: [] }
               ))
           .and(have_enqueued_job(ActionMailer::MailDeliveryJob)
               .with(
                 'CollectionsMailer', 'new_version_reminder_email', 'deliver_now',
-                { params: { collection_version: version_draft6, user: user }, args: [] }
+                { params: { collection_version: version_draft6, user: }, args: [] }
               ))
           .and(have_enqueued_job(ActionMailer::MailDeliveryJob)
               .with(
                 'CollectionsMailer', 'new_version_reminder_email', 'deliver_now',
-                { params: { collection_version: version_draft8, user: user }, args: [] }
+                { params: { collection_version: version_draft8, user: }, args: [] }
               ))
       end
     end
 
     context 'with collections in the wrong state, but at the right interval' do
       let(:collection_depositing) do
-        create(:collection_version, :depositing, created_at: 14.days.ago, collection: collection)
+        create(:collection_version, :depositing, created_at: 14.days.ago, collection:)
       end
       let(:collection_deposited) do
-        create(:collection_version, :deposited, created_at: 14.days.ago, collection: collection)
+        create(:collection_version, :deposited, created_at: 14.days.ago, collection:)
       end
 
       it 'does not queue notifications' do
@@ -79,49 +79,49 @@ RSpec.describe CollectionReminderGenerator do
           .to not_have_enqueued_job(ActionMailer::MailDeliveryJob)
           .with(
             'CollectionsMailer', 'first_draft_reminder_email', anything,
-            { params: { collection_version: collection_depositing, user: user }, args: anything }
+            { params: { collection_version: collection_depositing, user: }, args: anything }
           )
           .and(not_have_enqueued_job(ActionMailer::MailDeliveryJob)
               .with(
                 'CollectionsMailer', 'first_draft_reminder_email', anything,
-                { params: { collection_version: collection_deposited, user: user }, args: anything }
+                { params: { collection_version: collection_deposited, user: }, args: anything }
               ))
           .and(not_have_enqueued_job(ActionMailer::MailDeliveryJob)
             .with(
               'CollectionsMailer', 'new_version_reminder_email', anything,
-              { params: { collection_version: collection_deposited, user: user }, args: anything }
+              { params: { collection_version: collection_deposited, user: }, args: anything }
             ))
           .and(not_have_enqueued_job(ActionMailer::MailDeliveryJob)
             .with(
               'CollectionsMailer', 'new_version_reminder_email', anything,
-              { params: { collection_version: collection_deposited, user: user }, args: anything }
+              { params: { collection_version: collection_deposited, user: }, args: anything }
             ))
       end
     end
 
     context "when drafts that aren't on a reminder interval day relative to creation" do
-      let(:version_draft1) { create(:collection_version, :version_draft, collection: collection) }
+      let(:version_draft1) { create(:collection_version, :version_draft, collection:) }
       let(:version_draft2) do
-        create(:collection_version, :version_draft, created_at: 3.days.ago, collection: collection)
+        create(:collection_version, :version_draft, created_at: 3.days.ago, collection:)
       end
       let(:version_draft3) do
-        create(:collection_version, :version_draft, created_at: 7.days.ago, collection: collection)
+        create(:collection_version, :version_draft, created_at: 7.days.ago, collection:)
       end
       let(:version_draft5) do
-        create(:collection_version, :version_draft, created_at: 28.days.ago, collection: collection)
+        create(:collection_version, :version_draft, created_at: 28.days.ago, collection:)
       end
       let(:version_draft7) do
-        create(:collection_version, :version_draft, created_at: 47.days.ago, collection: collection)
+        create(:collection_version, :version_draft, created_at: 47.days.ago, collection:)
       end
 
-      let(:first_draft1) { create(:collection_version, :first_draft, collection: collection) }
-      let(:first_draft2) { create(:collection_version, :first_draft, created_at: 3.days.ago, collection: collection) }
-      let(:first_draft3) { create(:collection_version, :first_draft, created_at: 7.days.ago, collection: collection) }
+      let(:first_draft1) { create(:collection_version, :first_draft, collection:) }
+      let(:first_draft2) { create(:collection_version, :first_draft, created_at: 3.days.ago, collection:) }
+      let(:first_draft3) { create(:collection_version, :first_draft, created_at: 7.days.ago, collection:) }
       let(:first_draft5) do
-        create(:collection_version, :first_draft, created_at: 28.days.ago, collection: collection)
+        create(:collection_version, :first_draft, created_at: 28.days.ago, collection:)
       end
       let(:first_draft7) do
-        create(:collection_version, :first_draft, created_at: 47.days.ago, collection: collection)
+        create(:collection_version, :first_draft, created_at: 47.days.ago, collection:)
       end
 
       it 'does not queue notifications' do
@@ -129,52 +129,52 @@ RSpec.describe CollectionReminderGenerator do
           .to not_have_enqueued_job(ActionMailer::MailDeliveryJob)
           .with(
             'CollectionsMailer', 'first_draft_reminder_email', anything,
-            { params: { collection_version: first_draft1, user: user }, args: anything }
+            { params: { collection_version: first_draft1, user: }, args: anything }
           )
           .and(not_have_enqueued_job(ActionMailer::MailDeliveryJob)
       .with(
         'CollectionsMailer', 'first_draft_reminder_email', anything,
-        { params: { collection_version: first_draft2, user: user }, args: anything }
+        { params: { collection_version: first_draft2, user: }, args: anything }
       ))
           .and(not_have_enqueued_job(ActionMailer::MailDeliveryJob)
       .with(
         'CollectionsMailer', 'first_draft_reminder_email', anything,
-        { params: { collection_version: first_draft3, user: user }, args: anything }
+        { params: { collection_version: first_draft3, user: }, args: anything }
       ))
           .and(not_have_enqueued_job(ActionMailer::MailDeliveryJob)
       .with(
         'CollectionsMailer', 'first_draft_reminder_email', anything,
-        { params: { collection_version: first_draft5, user: user }, args: anything }
+        { params: { collection_version: first_draft5, user: }, args: anything }
       ))
           .and(not_have_enqueued_job(ActionMailer::MailDeliveryJob)
       .with(
         'CollectionsMailer', 'first_draft_reminder_email', anything,
-        { params: { collection_version: first_draft7, user: user }, args: anything }
+        { params: { collection_version: first_draft7, user: }, args: anything }
       ))
           .and(not_have_enqueued_job(ActionMailer::MailDeliveryJob)
       .with(
         'CollectionsMailer', 'new_version_reminder_email', anything,
-        { params: { collection_version: version_draft1, user: user }, args: anything }
+        { params: { collection_version: version_draft1, user: }, args: anything }
       ))
           .and(not_have_enqueued_job(ActionMailer::MailDeliveryJob)
       .with(
         'CollectionsMailer', 'new_version_reminder_email', anything,
-        { params: { collection_version: version_draft2, user: user }, args: anything }
+        { params: { collection_version: version_draft2, user: }, args: anything }
       ))
           .and(not_have_enqueued_job(ActionMailer::MailDeliveryJob)
       .with(
         'CollectionsMailer', 'new_version_reminder_email', anything,
-        { params: { collection_version: version_draft3, user: user }, args: anything }
+        { params: { collection_version: version_draft3, user: }, args: anything }
       ))
           .and(not_have_enqueued_job(ActionMailer::MailDeliveryJob)
       .with(
         'CollectionsMailer', 'new_version_reminder_email', anything,
-        { params: { collection_version: version_draft5, user: user }, args: anything }
+        { params: { collection_version: version_draft5, user: }, args: anything }
       ))
           .and(not_have_enqueued_job(ActionMailer::MailDeliveryJob)
       .with(
         'CollectionsMailer', 'new_version_reminder_email', anything,
-        { params: { collection_version: version_draft7, user: user }, args: anything }
+        { params: { collection_version: version_draft7, user: }, args: anything }
       ))
       end
     end

--- a/spec/services/collection_version_event_description_builder_spec.rb
+++ b/spec/services/collection_version_event_description_builder_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe CollectionVersionEventDescriptionBuilder do
   subject(:result) { described_class.build(form) }
 
   let(:collection) { create(:collection) }
-  let(:collection_version) { create(:collection_version_with_collection, collection: collection) }
-  let(:form) { DraftCollectionForm.new(collection_version: collection_version, collection: collection) }
+  let(:collection_version) { create(:collection_version_with_collection, collection:) }
+  let(:form) { DraftCollectionForm.new(collection_version:, collection:) }
 
   context 'when nothing has changed' do
     before do

--- a/spec/services/deposit_completer_spec.rb
+++ b/spec/services/deposit_completer_spec.rb
@@ -3,17 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe DepositCompleter do
-  subject(:deposit_completer) { described_class.new(object_version: object_version) }
+  subject(:deposit_completer) { described_class.new(object_version:) }
 
   let(:work) { create(:work, :with_druid) }
   let(:object_version) do
-    build(:work_version, state, work: work, version_description: version_description)
+    build(:work_version, state, work:, version_description:)
   end
   let(:state) { :depositing }
   let(:version_description) { 'Fixing the title' }
 
   describe '.complete' do
-    let(:instance) { described_class.new(object_version: object_version) }
+    let(:instance) { described_class.new(object_version:) }
 
     before do
       allow(described_class).to receive(:new).and_return(instance)
@@ -21,7 +21,7 @@ RSpec.describe DepositCompleter do
     end
 
     it 'invokes #complete on a new instance' do
-      described_class.complete(object_version: object_version)
+      described_class.complete(object_version:)
       expect(instance).to have_received(:complete).once
     end
   end
@@ -41,7 +41,7 @@ RSpec.describe DepositCompleter do
 
     context 'with a collection version' do
       let(:object_version) do
-        build(:collection_version, state, version_description: version_description)
+        build(:collection_version, state, version_description:)
       end
 
       it 'returns a collection' do

--- a/spec/services/orcid_service_spec.rb
+++ b/spec/services/orcid_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe OrcidService do
   include Dry::Monads[:result]
 
-  let(:response) { described_class.lookup(orcid: orcid) }
+  let(:response) { described_class.lookup(orcid:) }
 
   # rubocop:disable Layout/LineLength
   let(:body) { '{"last-modified-date":{"value":1460763728406},"name":{"created-date":{"value":1460763728406},"last-modified-date":{"value":1460763728406},"given-names":{"value":"Justin"},"family-name":{"value":"Littman"},"credit-name":null,"source":null,"visibility":"public","path":"0000-0003-1527-0030"},"other-names":{"last-modified-date":null,"other-name":[],"path":"/0000-0003-1527-0030/other-names"},"biography":null,"path":"/0000-0003-1527-0030/personal-details"}' }
@@ -30,7 +30,7 @@ RSpec.describe OrcidService do
             'User-Agent' => 'Stanford Self-Deposit (Happy Heron)'
           }
         )
-        .to_return(status: 200, body: body, headers: {})
+        .to_return(status: 200, body:, headers: {})
     end
 
     it 'returns success with first and last name' do
@@ -43,7 +43,7 @@ RSpec.describe OrcidService do
 
     before do
       stub_request(:get, 'https://pub.orcid.org/v3.0/0000-0003-1527-003X/personal-details')
-        .to_return(status: 200, body: body, headers: {})
+        .to_return(status: 200, body:, headers: {})
     end
 
     it 'returns success with first and last name' do

--- a/spec/services/work_version_event_description_builder_spec.rb
+++ b/spec/services/work_version_event_description_builder_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
   subject(:result) { described_class.build(form) }
 
   let(:collection) { build(:collection, :depositor_selects_access, :depositor_selects_release_date) }
-  let(:work_version) { create(:work_version_with_work, :with_no_subtype, collection: collection) }
+  let(:work_version) { create(:work_version_with_work, :with_no_subtype, collection:) }
   let(:work) { work_version.work }
-  let(:form) { DraftWorkForm.new(work_version: work_version, work: work) }
+  let(:form) { DraftWorkForm.new(work_version:, work:) }
 
   context 'when nothing has changed' do
     let(:params) do
@@ -32,7 +32,7 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
   context 'when embargoed, then edited with no changes to embargo' do
     let(:embargo_date) { 11.months.from_now }
     let(:work_version) do
-      create(:work_version_with_work, :with_no_subtype, embargo_date: embargo_date, collection: collection)
+      create(:work_version_with_work, :with_no_subtype, embargo_date:, collection:)
     end
     let(:params) do
       ActionController::Parameters.new(
@@ -57,7 +57,7 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
     let(:embargo_date) { 10.months.from_now }
     let(:new_embargo_date) { 11.months.from_now }
     let(:work_version) do
-      create(:work_version_with_work, :with_no_subtype, embargo_date: embargo_date, collection: collection)
+      create(:work_version_with_work, :with_no_subtype, embargo_date:, collection:)
     end
     let(:params) do
       ActionController::Parameters.new(
@@ -80,7 +80,7 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
 
   context 'when not embargoed, then embargo set' do
     let(:new_embargo_date) { 11.months.from_now }
-    let(:work_version) { create(:work_version_with_work, :with_no_subtype, collection: collection) }
+    let(:work_version) { create(:work_version_with_work, :with_no_subtype, collection:) }
     let(:params) do
       ActionController::Parameters.new(
         title: 'new title',
@@ -103,7 +103,7 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
   context 'when embargoed, then embargo removed' do
     let(:embargo_date) { 10.months.from_now }
     let(:work_version) do
-      create(:work_version_with_work, :with_no_subtype, embargo_date: embargo_date, collection: collection)
+      create(:work_version_with_work, :with_no_subtype, embargo_date:, collection:)
     end
     let(:params) do
       ActionController::Parameters.new(
@@ -218,8 +218,8 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
   context 'when a new work version and nothing has changed' do
     let(:user) { build(:user) }
     let(:collection) { build(:collection, required_license: 'CC0-1.0', release_option: 'immediate', access: 'world') }
-    let(:work) { Work.new(collection: collection, depositor: user, owner: user) }
-    let(:work_version) { WorkVersion.new(work: work) }
+    let(:work) { Work.new(collection:, depositor: user, owner: user) }
+    let(:work_version) { WorkVersion.new(work:) }
 
     context 'when nothing has changed' do
       before do

--- a/spec/support/capybara_actions.rb
+++ b/spec/support/capybara_actions.rb
@@ -6,8 +6,8 @@ module CapybaraActions
     field.native.send_keys :tab
   end
 
-  def within_section(title, &block)
-    within :xpath, "//section[contains(header/text(),'#{title}')]", &block
+  def within_section(title, &)
+    within(:xpath, "//section[contains(header/text(),'#{title}')]", &)
   end
 end
 

--- a/spec/validators/created_in_past_validator_spec.rb
+++ b/spec/validators/created_in_past_validator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CreatedInPastValidator do
   let(:validator) { described_class.new(options) }
   let(:work) { work_version.work }
   let(:work_version) { build(:work_version) }
-  let(:record) { WorkForm.new(work_version: work_version, work: work) }
+  let(:record) { WorkForm.new(work_version:, work:) }
 
   before do
     validator.validate_each(record, attribute, value)
@@ -48,7 +48,7 @@ RSpec.describe CreatedInPastValidator do
         let(:year) { next_month.year }
         let(:month) { next_month.month }
 
-        let(:value) { EDTF.parse(format('%<year>d-%<month>02d', year: year, month: month)) }
+        let(:value) { EDTF.parse(format('%<year>d-%<month>02d', year:, month:)) }
 
         it 'has errors' do
           expect(record.errors.full_messages).to eq ['Created edtf must be in the past']
@@ -61,7 +61,7 @@ RSpec.describe CreatedInPastValidator do
         let(:month) { tomorrow.month }
         let(:day) { tomorrow.day }
 
-        let(:value) { EDTF.parse(format('%<year>d-%<month>02d-%<day>02d', year: year, month: month, day: day)) }
+        let(:value) { EDTF.parse(format('%<year>d-%<month>02d-%<day>02d', year:, month:, day:)) }
 
         it 'has errors' do
           expect(record.errors.full_messages).to eq ['Created edtf must be in the past']

--- a/spec/validators/embargo_date_parts_spec.rb
+++ b/spec/validators/embargo_date_parts_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe EmbargoDateParts do
   let(:validator) { described_class.new }
   let(:work) { work_version.work }
   let(:work_version) { build(:work_version) }
-  let(:record) { WorkForm.new(work_version: work_version, work: work) }
+  let(:record) { WorkForm.new(work_version:, work:) }
 
   context 'when a valid date is provided' do
     before do

--- a/spec/validators/embargo_date_validator_spec.rb
+++ b/spec/validators/embargo_date_validator_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe EmbargoDateValidator do
   let(:options) { { attributes: ['hi'] } }
   let(:validator) { described_class.new(options) }
   let(:collection) { create(:collection, release_option: 'depositor-selects', release_duration: '3 years') }
-  let(:work) { create(:work, collection: collection) }
+  let(:work) { create(:work, collection:) }
   let(:current_date) { Time.now.in_time_zone('Pacific Time (US & Canada)').to_date }
-  let(:work_version) { create(:work_version, work: work) }
-  let(:record) { WorkForm.new(work_version: work_version, work: work) }
+  let(:work_version) { create(:work_version, work:) }
+  let(:record) { WorkForm.new(work_version:, work:) }
 
   before do
     validator.validate_each(record, attribute, value)

--- a/spec/validators/work_subtype_validator_spec.rb
+++ b/spec/validators/work_subtype_validator_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe WorkSubtypeValidator do
   let(:error_message) { "Subtype is not a valid subtype for work type #{work_type_id}" }
-  let(:record) { WorkForm.new(work: build(:work), work_version: work_version) }
+  let(:record) { WorkForm.new(work: build(:work), work_version:) }
   let(:validator) { described_class.new({ attributes: ['stub'] }) }
   let(:work_version) { build(:work_version, work_type: work_type_id) }
 

--- a/spec/validators/work_type_validator_spec.rb
+++ b/spec/validators/work_type_validator_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe WorkTypeValidator do
   let(:work) { Work.new(owner: build_stubbed(:user)) }
-  let(:record) { WorkForm.new(work: work, work_version: WorkVersion.new(work: work)) }
+  let(:record) { WorkForm.new(work:, work_version: WorkVersion.new(work:)) }
   let(:validator) { described_class.new({ attributes: ['stub'] }) }
 
   before do


### PR DESCRIPTION
## Why was this change made? 🤔
We use rubocop 3.1 everwhere.


## How was this change tested? 🤨
ci