### PR TITLE
Add doi to auto-generated citation

### DIFF
--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -150,7 +150,7 @@
     </tr>
     <tr>
       <th scope="row">Preferred citation</th>
-      <td data-work-updates-target="citation">
+      <td>
         <%= citation %>
       </td>
     </tr>

--- a/app/components/works/form_component.html.erb
+++ b/app/components/works/form_component.html.erb
@@ -3,7 +3,8 @@
     data: {
       controller: 'auto-citation unsaved-changes',
       action: 'change->unsaved-changes#changed beforeunload@window->unsaved-changes#leavingPage turbo:before-visit@window->unsaved-changes#leavingPage',
-      auto_citation_purl: purl
+      auto_citation_purl: purl,
+      auto_citation_doi: doi_field
     },
     html: { class: "needs-validation work-editor", novalidate: true, multipart: true } do |f| %>
   <% if work_form.errors.present? %>

--- a/app/components/works/form_component.rb
+++ b/app/components/works/form_component.rb
@@ -21,6 +21,9 @@ module Works
 
     delegate :persisted?, to: :work_form
     delegate :purl, to: :work
+    delegate :druid, to: :work
+    delegate :doi, to: :work
+    delegate :will_assign_doi?, to: :work_form
 
     def work
       work_form.model.fetch(:work)
@@ -28,6 +31,17 @@ module Works
 
     def work_version
       work_form.model.fetch(:work_version)
+    end
+
+    def doi_field
+      return "https://doi.org/#{doi}." if doi
+
+      # create DOI URL or placeholder for works in collections that allow DOI assignment
+      return unless will_assign_doi?
+
+      return "https://doi.org/#{Doi.for(druid)}." if druid
+
+      WorkVersion::DOI_TEXT
     end
   end
 end

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -171,4 +171,8 @@ class DraftWorkForm < Reform::Form
   def model_name
     Work.model_name
   end
+
+  def will_assign_doi?
+    (collection.doi_option == 'depositor-selects' && assign_doi) || collection.doi_option == 'yes'
+  end
 end

--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -63,8 +63,7 @@ class WorkForm < DraftWorkForm
   def assign_doi?
     return false unless work.druid
 
-    (collection.doi_option == 'depositor-selects' && assign_doi) ||
-      collection.doi_option == 'yes'
+    will_assign_doi?
   end
 
   def availability_component_present?

--- a/app/javascript/controllers/auto_citation_controller.js
+++ b/app/javascript/controllers/auto_citation_controller.js
@@ -7,6 +7,7 @@ export default class extends Controller {
 
   connect() {
     this.purl = this.data.get("purl") || ":link will be inserted here automatically when available:" // Use a real purl on a persisted item or a placeholder
+    this.doi = this.data.get("doi") || ""
 
     this.updateDisplay()
 
@@ -22,7 +23,7 @@ export default class extends Controller {
   }
 
   get citation() {
-    return `${this.authorAsSentence} (${this.date}). ${this.title}. Stanford Digital Repository. Available at ${this.purl}`
+    return `${this.authorAsSentence} (${this.date}). ${this.title}. Stanford Digital Repository. Available at ${this.purl}. ${this.doi}`
   }
 
   get authorAsSentence() {

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -42,6 +42,7 @@ class WorkVersion < ApplicationRecord
   }
 
   LINK_TEXT = ':link will be inserted here automatically when available:'
+  DOI_TEXT = ':DOI will be inserted here automatically when available:'
 
   after_update_commit -> { work.broadcast_update }
 
@@ -140,6 +141,12 @@ class WorkVersion < ApplicationRecord
     return unless citation
 
     update!(citation: citation.gsub(LINK_TEXT, work.purl))
+  end
+
+  def add_doi_to_citation
+    return unless citation
+
+    update!(citation: citation.gsub(DOI_TEXT, "https://doi.org/#{work.doi}."))
   end
 
   # the terms agreement checkbox value is not persisted in the database with the work and the value is instead:

--- a/app/services/cocina_generator/description/generator.rb
+++ b/app/services/cocina_generator/description/generator.rb
@@ -72,9 +72,10 @@ module CocinaGenerator
       def citation
         return if work_version.citation.blank?
 
-        # :link: is a special placeholder in dor-services-app.
+        # :link: and :doi: are special placeholders in dor-services-app.
         # See https://github.com/sul-dlss/dor-services-app/pull/1566/files#diff-30396654f0ad00ad1daa7292fd8327759d7ff7f3b92f98f40a2e25b6839807e2R13
-        exportable_citation = work_version.citation.gsub(WorkVersion::LINK_TEXT, ':link:')
+        exportable_citation = work_version.citation.gsub(WorkVersion::LINK_TEXT, ':link:').gsub(WorkVersion::DOI_TEXT,
+                                                                                                ':doi:')
 
         Cocina::Models::DescriptiveValue.new(
           value: exportable_citation,

--- a/app/services/work_observer.rb
+++ b/app/services/work_observer.rb
@@ -24,6 +24,7 @@ class WorkObserver
     work = work_version.work
     work.update(doi: Doi.for(work.druid)) if transition.to_name == :purl_reserved && work.assign_doi?
     work_version.add_purl_to_citation
+    work_version.add_doi_to_citation if work.doi
   end
 
   def self.after_begin_deposit(work_version, _transition)

--- a/spec/features/auto_citation_spec.rb
+++ b/spec/features/auto_citation_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Automatically generate a citation', js: true do
       expect(page).to have_content 'Deposit your content'
 
       within_section 'Authors to include in citation' do
-        fill_in 'First name', with: 'Diana'
+        fill_in 'First name', with: 'Dana'
         fill_in 'Last name', with: 'Scully'
         blur_from 'Last name'
       end

--- a/spec/features/create_new_draft_work_spec.rb
+++ b/spec/features/create_new_draft_work_spec.rb
@@ -31,5 +31,32 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
 
     expect(page).to have_content 'My Draft'
     expect(page).to have_content 'Draft - Not deposited'
+    expect(page).to have_content WorkVersion::LINK_TEXT.to_s
+    expect(page).to have_content WorkVersion::DOI_TEXT.to_s
+  end
+
+  context 'when collection does not allow DOI assignment' do
+    let(:collection) { create(:collection, doi_option: 'no', depositors: [user]) }
+
+    it 'does not show DOI placeholder text' do
+      visit dashboard_path
+
+      click_button '+ Deposit to this collection'
+
+      expect(page).to have_content 'What type of content will you deposit?'
+
+      find('label', text: 'Sound').click
+
+      click_button 'Continue'
+
+      fill_in 'Title of deposit', with: 'My Draft'
+
+      click_button 'Save as draft'
+
+      expect(page).to have_content 'My Draft'
+      expect(page).to have_content 'Draft - Not deposited'
+      expect(page).to have_content WorkVersion::LINK_TEXT
+      expect(page).not_to have_content WorkVersion::DOI_TEXT
+    end
   end
 end

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -218,7 +218,8 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
           click_link 'My Title'
 
           expect(page).to have_content "Keller, M. (#{Time.zone.today.year}). My Title. " \
-                                       "Stanford Digital Repository. Available at #{WorkVersion::LINK_TEXT}"
+                                       "Stanford Digital Repository. Available at #{WorkVersion::LINK_TEXT}. " \
+                                       "#{WorkVersion::DOI_TEXT}"
         end
       end
     end

--- a/spec/requests/edit_work_spec.rb
+++ b/spec/requests/edit_work_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe 'Updating an existing work' do
             collection.update!(doi_option: 'depositor-selects')
           end
 
-          it 'sets the doi' do
+          it 'does not set the doi' do
             patch "/works/#{work.id}", params: { work: work_params, commit: 'Deposit' }
             expect(CollectionObserver).to have_received(:version_draft_created)
             expect(WorkVersion.where(work:).count).to eq 2

--- a/spec/services/cocina_generator/description/generator_spec.rb
+++ b/spec/services/cocina_generator/description/generator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CocinaGenerator::Description::Generator do
           :with_some_untitled_related_links, :with_related_works,
           :with_contact_emails,
           contributors: [contributor],
-          citation: "Test citation #{WorkVersion::LINK_TEXT}",
+          citation: "Test citation #{WorkVersion::LINK_TEXT}. #{WorkVersion::DOI_TEXT}",
           title: 'Test title')
   end
 
@@ -136,7 +136,7 @@ RSpec.describe CocinaGenerator::Description::Generator do
         ],
         note: [
           { type: 'abstract', value: 'test abstract' },
-          { type: 'preferred citation', value: 'Test citation :link:' }
+          { type: 'preferred citation', value: 'Test citation :link:. :doi:' }
         ],
         title: [{ value: 'Test title' }],
         contributor: [


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #2628. Adds DOI or placeholder to the auto-generated citation. Goes with https://github.com/sul-dlss/dor-services-app/pull/4234. 

## How was this change tested? 🤨
Unit, integration tests on QA. 


⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


