### PR TITLE
redirect to dashboard when deleting works from there

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -95,7 +95,7 @@ class WorksController < ObjectsController
       work.destroy
     end
 
-    redirect_to collection_works_path(collection)
+    request.referer.include?('dashboard') ? redirect_to(dashboard_path) : redirect_to(collection_works_path(collection))
   end
 
   def next_step


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2695 - redirect to the dashboard if we are deleting a work from there, else go back to the collection deposits page (unchanged)


## How was this change tested? 🤨

Localhost