### PR TITLE
Wrap the EditButtonComponent with clearfix

### DIFF
--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -14,7 +14,7 @@
     </div>
   <% end %>
 
-  <header class="title">
+  <header class="title clearfix"><%# clearfix here prevents the EditButtonCompnent from spilling outside the container if the title is long %>
     <span class="header-text"><%= title %></span>
     <%= helpers.turbo_frame_tag dom_id(work, :edit), src: edit_button_work_path(work), target: '_top' %>
     <span class="state"><%= render Works::StateDisplayComponent.new(work_version: work_version) %></span>

--- a/app/components/works/edit_button_component.rb
+++ b/app/components/works/edit_button_component.rb
@@ -2,6 +2,7 @@
 
 module Works
   # Renders a button that links to the work edit page
+  # This should be within a container styled with .clearfix
   class EditButtonComponent < ApplicationComponent
     def initialize(work_version:)
       @work_version = work_version


### PR DESCRIPTION


## Why was this change made? 🤔

This ensures it doesn't go outside the container if the title is long. Fixes #2602

## How was this change tested? 🤨
locally
