### PR TITLE
Require subtypes for music and mixed materials.

### DIFF
--- a/app/components/works/work_type_modal_component.html.erb
+++ b/app/components/works/work_type_modal_component.html.erb
@@ -65,7 +65,10 @@
 
           <div class="mb-4 subtype-container" data-work-type-target="moreTypes" hidden></div>
 
-          <button type="submit" class="btn btn-primary mx-auto d-block" data-work-type-target="continueButton">Continue</button>
+          <button type="submit" 
+            class="btn btn-primary mx-auto d-block" 
+            data-action="work-type#checkSubtypes"
+            data-work-type-target="continueButton">Continue</button>
         </form>
       </div>
     </div>

--- a/app/javascript/controllers/work_type_controller.js
+++ b/app/javascript/controllers/work_type_controller.js
@@ -11,6 +11,10 @@ export default class extends Controller {
     "musicTemplateSubheader", "mixedMaterialTemplateSubheader"
   ]
 
+  connect() {
+    this.requiredSubtypeCount = 0
+  }
+
   // Sets the form in the popup to use the action in the data-destination attribute
   setCollection(event) {
     event.preventDefault()
@@ -37,6 +41,18 @@ export default class extends Controller {
 
     // Display the work type choices
     this.areaTarget.hidden = false
+
+    // Set the number of required subtypes
+    switch(type) {
+      case 'music':
+        this.requiredSubtypeCount = 1
+        break
+      case 'mixed material':
+        this.requiredSubtypeCount = 2
+        break
+      default:
+        this.requiredSubtypeCount = 0
+    }
   }
 
   toggleMoreTypes(event) {
@@ -109,5 +125,17 @@ export default class extends Controller {
         const id = moreType.replace(/\s/g, '_')
         return this.templateTarget.innerHTML.replace(/SUBTYPE_LABEL/g, moreType).replace(/SUBTYPE_ID/g, id)
       })
+  }
+
+  checkSubtypes() {    
+    const checked = this.formTarget.querySelectorAll('div.subtype-container input[type="checkbox"]:checked')
+    const firstInput = this.formTarget.querySelector('div.subtype-container input[type="checkbox"]:not(:checked)')
+    const inputs = this.formTarget.querySelectorAll('div.subtype-container input[type="checkbox"]')
+    inputs.forEach((input) => {      
+      input.setCustomValidity('')
+    })
+    if (checked.length < this.requiredSubtypeCount) {
+      firstInput.setCustomValidity(`Please select ${this.requiredSubtypeCount} or more subtype options.`)
+    }
   }
 }

--- a/cypress/spec/work_type_modal.cy.js
+++ b/cypress/spec/work_type_modal.cy.js
@@ -1,0 +1,69 @@
+describe('Clear dates', () => {
+  // const now = new Date()
+  let collection_id
+
+  beforeEach(() => {
+    const results = cy.appFactories([
+      ['create', 'collection_version_with_collection', {} ]
+    ]).then((results) => {
+      console.log(results)
+      collection_id = results[0].collection_id
+
+      // This stubs out edit link calls.
+      cy.intercept('GET', '**edit_link**', '').as('editLink')
+
+      cy.visit(`/collections/${collection_id}`)
+      // This wait for the async turbo call to finish.
+      cy.wait('@editLink')
+      cy.get(`button[data-destination="/collections/${collection_id}/works/new"]`).click()
+      // This wait for the async turbo call to finish.
+      cy.wait('@editLink')  
+    })
+  })
+
+  it('requires 1 subtype for music', () => {
+    cy.get('#workTypeModal').within(() => {
+      cy.get('#music').click()
+      cy.get('button[type="submit"]').click()
+      cy.get('div.subtype-item input').first().then(($input) => {
+        cy.wrap($input).invoke('prop', 'validity')
+        .should('deep.include', {
+          valid: false,
+          customError: true
+        })
+        cy.wrap($input).invoke('prop', 'validationMessage').should('equal', 'Please select 1 or more subtype options.')
+      })
+      cy.get('div.subtype-container[data-work-type-target="subtype"] div.subtype-item input').last().click()
+      cy.get('button[type="submit"]').click()      
+    })
+    cy.url().should('include', `/collections/${collection_id}/works/new?work_type=music&subtype%5B%5D=Video`)
+  })
+
+  it('requires 2 subtypes for mixed materials', () => {
+    cy.get('#workTypeModal').within(() => {
+      cy.get('input[value="mixed material"]').click()
+      cy.get('button[type="submit"]').click()
+      cy.get('div.subtype-item input').first().then(($input) => {
+        cy.wrap($input).invoke('prop', 'validity')
+        .should('deep.include', {
+          valid: false,
+          customError: true
+        })
+        cy.wrap($input).invoke('prop', 'validationMessage').should('equal', 'Please select 2 or more subtype options.')
+      })
+      cy.get('div.subtype-container[data-work-type-target="subtype"] div.subtype-item input').first().click()
+      cy.get('div.subtype-container[data-work-type-target="subtype"] div.subtype-item input').last().click()
+      cy.get('button[type="submit"]').click()      
+    })
+    cy.url().should('include', `/collections/${collection_id}/works/new?work_type=mixed+material&subtype%5B%5D=Data&subtype%5B%5D=Video`)
+  })
+
+  it('requires 0 subtypes for other types', () => {
+    cy.get('#workTypeModal').within(() => {
+      cy.get('#text').click()
+      cy.get('button[type="submit"]').click()
+    })
+    cy.url().should('include', `/collections/${collection_id}/works/new?work_type=text`)
+  })
+
+})


### PR DESCRIPTION
closes #2687

## Why was this change made? 🤔
Per user feedback for errors.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit, cypress
