### PR TITLE
correctly show license modified on new works

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -26,7 +26,7 @@ class WorksController < ObjectsController
 
     @form = work_form(work_version)
     if @form.validate(work_params) && @form.save
-      after_save(form: @form, event_context: { user: current_user, description: 'Created' })
+      after_save(form: @form, event_context: build_create_event_context(@form))
     else
       @form.prepopulate!
       render :new, status: :unprocessable_entity
@@ -59,7 +59,7 @@ class WorksController < ObjectsController
 
     @form = work_form(work_version)
     # `changed?(field)` on a reform form object needs to be asked before persistence on existing records
-    event_context = build_event_context(context_form(orig_work_version, orig_clean_params))
+    event_context = build_update_event_context(context_form(orig_work_version, orig_clean_params))
     if @form.validate(clean_params) && @form.save
       after_save(form: @form, event_context:)
     else
@@ -169,7 +169,24 @@ class WorksController < ObjectsController
     end
   end
 
-  def build_event_context(form)
+  # used to build event context from creating a new work
+  def build_create_event_context(form)
+    # For create events, all we need to record is if the user changed the license from the default;
+    #  if not...we just record the work as being created (same as we do for a new collection)
+    description = if form.license == form.collection.default_license
+                    'Created'
+                  else
+                    'license modified'
+                  end
+
+    {
+      user: current_user,
+      description:
+    }
+  end
+
+  # used to build event context from updating an existing work
+  def build_update_event_context(form)
     {
       user: current_user,
       description: WorkVersionEventDescriptionBuilder.build(form)

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -26,7 +26,7 @@ class WorksController < ObjectsController
 
     @form = work_form(work_version)
     if @form.validate(work_params) && @form.save
-      after_save(form: @form, event_context: build_event_context(form: @form, event_type: :create))
+      after_save(form: @form, event_context: build_event_context(@form))
     else
       @form.prepopulate!
       render :new, status: :unprocessable_entity
@@ -59,7 +59,7 @@ class WorksController < ObjectsController
 
     @form = work_form(work_version)
     # `changed?(field)` on a reform form object needs to be asked before persistence on existing records
-    event_context = build_event_context(form: context_form(orig_work_version, orig_clean_params), event_type: :update)
+    event_context = build_event_context(context_form(orig_work_version, orig_clean_params))
     if @form.validate(clean_params) && @form.save
       after_save(form: @form, event_context:)
     else
@@ -170,10 +170,10 @@ class WorksController < ObjectsController
   end
 
   # used to build event context from creating or updating an existing work
-  def build_event_context(form:, event_type:)
+  def build_event_context(form)
     {
       user: current_user,
-      description: WorkVersionEventDescriptionBuilder.build(form:, event_type:)
+      description: WorkVersionEventDescriptionBuilder.build(form)
     }
   end
 

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe 'Create a new work in a deposited collection', js: true do
   let(:user) { create(:user) }
   let(:collection_version) { create(:collection_version, :deposited, collection:) }
-  let(:collection) { create(:collection, :depositor_selects_access, depositors: [user]) }
+  let(:default_license) { 'CC0-1.0' }
+  let(:collection) { create(:collection, :depositor_selects_access, depositors: [user], default_license:) }
   let(:second_email) { 'second@example.com' }
 
   before do

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -163,8 +163,11 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
           expect(page).to have_content 'CC0-1.0'
 
           within '#events' do
-            # New work gets a description of "Created"
-            expect(page).to have_content 'Created', count: 1
+            # New work gets a description of what's changed (except subtypes)
+            changed = ['title of deposit modified', 'abstract modified', 'contact email modified', 'authors modified',
+                       'publication date modified', 'creation date modified', 'keywords modified', 'citation modified',
+                       'files added/removed']
+            expect(page).to have_content changed.join(', '), count: 1
           end
         end
       end
@@ -383,8 +386,11 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
           expect(page).to have_content 'CC0-1.0'
 
           within '#events' do
-            # New work gets a description of "Created"
-            expect(page).to have_content 'Created', count: 1
+            # New work gets a description of what's changed (except subtypes)
+            changed = ['title of deposit modified', 'abstract modified', 'contact email modified', 'authors modified',
+                       'publication date modified', 'creation date modified', 'keywords modified', 'citation modified',
+                       'files added/removed']
+            expect(page).to have_content changed.join(', '), count: 1
           end
         end
       end

--- a/spec/services/work_version_event_description_builder_spec.rb
+++ b/spec/services/work_version_event_description_builder_spec.rb
@@ -3,13 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe WorkVersionEventDescriptionBuilder do
-  subject(:result) { described_class.build(form) }
+  subject(:result) { described_class.build(form:, event_type:) }
 
   let(:collection) { build(:collection, :depositor_selects_access, :depositor_selects_release_date) }
   let(:work_version) { create(:work_version_with_work, :with_no_subtype, collection:, attached_files:) }
   let(:work) { work_version.work }
   let(:form) { DraftWorkForm.new(work_version:, work:) }
   let(:attached_files) { [] }
+  let(:event_type) { 'update' }
 
   context 'when nothing has changed' do
     let(:params) do

--- a/spec/services/work_version_event_description_builder_spec.rb
+++ b/spec/services/work_version_event_description_builder_spec.rb
@@ -10,38 +10,146 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
   let(:work) { work_version.work }
   let(:form) { DraftWorkForm.new(work_version:, work:) }
   let(:attached_files) { [] }
-  let(:event_type) { 'update' }
 
-  context 'when nothing has changed' do
-    let(:params) do
-      ActionController::Parameters.new(
-        # TODO: to make realistic, add ALL the params that get passed in from the form
-        work_type: work_version.work_type,
-        title: work_version.title,
-        abstract: work_version.abstract,
-        citation: work_version.citation,
-        subtype: work_version.subtype
-      )
+  context 'when work is created' do
+    let(:event_type) { :create }
+
+    before { form.validate(params) }
+
+    context 'when nothing changed' do
+      let(:params) do
+        ActionController::Parameters.new(
+          work_type: work_version.work_type,
+          subtype: work_version.subtype
+        )
+      end
+
+      it { is_expected.to eq 'Created' }
     end
 
-    before do
-      form.validate(params)
+    context 'when different license is select' do
+      let(:params) do
+        ActionController::Parameters.new(
+          work_type: work_version.work_type,
+          subtype: work_version.subtype,
+          license: 'Apache-2.0'
+        )
+      end
+
+      it { is_expected.to eq 'license modified' }
     end
 
-    it { is_expected.to be_blank }
+    context 'when multiple fields are added' do
+      let(:params) do
+        ActionController::Parameters.new(
+          work_type: work_version.work_type,
+          subtype: work_version.subtype,
+          title: 'A great work',
+          abstract: 'This is really fundamental work.'
+        )
+      end
+
+      it { is_expected.to eq 'title of deposit modified, abstract modified' }
+    end
   end
 
-  # NOTE: there are other associations on the work_version that should behave identically to this
-  # and use the same code to detect changes, but are not being tested right now.
-  # These are: authors, contributors, related_links, related_works, contact_emails, subtype
-  context 'when keywords changed' do
-    let(:params) { ActionController::Parameters.new(keywords: keyword_params) }
+  context 'when work is updated' do
+    let(:event_type) { 'update' }
 
-    before do
-      form.validate(params)
+    context 'when nothing has changed' do
+      let(:params) do
+        ActionController::Parameters.new(
+          # TODO: to make realistic, add ALL the params that get passed in from the form
+          work_type: work_version.work_type,
+          title: work_version.title,
+          abstract: work_version.abstract,
+          citation: work_version.citation,
+          subtype: work_version.subtype
+        )
+      end
+
+      before do
+        form.validate(params)
+      end
+
+      it { is_expected.to be_blank }
     end
 
-    context 'when keyword added' do
+    # NOTE: there are other associations on the work_version that should behave identically to this
+    # and use the same code to detect changes, but are not being tested right now.
+    # These are: authors, contributors, related_links, related_works, contact_emails, subtype
+    context 'when keywords changed' do
+      let(:params) { ActionController::Parameters.new(keywords: keyword_params) }
+
+      before do
+        form.validate(params)
+      end
+
+      context 'when keyword added' do
+        let(:keyword_params) do
+          [
+            { '_destroy' => '', 'id' => form.keywords[0].id, 'label' => form.keywords[0].label, 'uri' => 'http://example.org/uri',
+              'cocina_type' => 'place' },
+            { '_destroy' => '', 'id' => form.keywords[1].id, 'label' => form.keywords[1].label, 'uri' => 'http://example.org/uri',
+              'cocina_type' => 'place' },
+            { '_destroy' => '', 'id' => form.keywords[2].id, 'label' => form.keywords[2].label, 'uri' => 'http://example.org/uri',
+              'cocina_type' => 'place' },
+            { '_destroy' => '', 'label' => 'This one added', 'uri' => 'http://example.org/uri', 'cocina_type' => 'test' }
+          ]
+        end
+
+        it { is_expected.to eq 'keywords modified' }
+      end
+
+      context 'when one keyword changed' do
+        let(:keyword_params) do
+          [
+            { '_destroy' => '', 'label' => 'This one changed', 'uri' => 'http://example.org/uri',
+              'cocina_type' => 'place' },
+            { '_destroy' => '', 'id' => form.keywords[1].id, 'label' => form.keywords[1].label, 'uri' => 'http://example.org/uri',
+              'cocina_type' => 'place' },
+            { '_destroy' => '', 'id' => form.keywords[2].id, 'label' => form.keywords[2].label, 'uri' => 'http://example.org/uri',
+              'cocina_type' => 'place' }
+          ]
+        end
+
+        it { is_expected.to eq 'keywords modified' }
+      end
+
+      context 'when one keyword removed and one keyword added' do
+        let(:keyword_params) do
+          [
+            { '_destroy' => '1', 'id' => form.keywords[0].id, 'label' => form.keywords[0].label, 'uri' => 'http://example.org/uri',
+              'cocina_type' => 'place' },
+            { '_destroy' => '', 'id' => form.keywords[1].id, 'label' => form.keywords[1].label, 'uri' => 'http://example.org/uri',
+              'cocina_type' => 'place' },
+            { '_destroy' => '', 'id' => form.keywords[2].id, 'label' => form.keywords[2].label, 'uri' => 'http://example.org/uri',
+              'cocina_type' => 'place' },
+            { '_destroy' => '', 'label' => 'This one added', 'uri' => 'http://example.org/uri',
+              'cocina_type' => 'place' }
+          ]
+        end
+
+        it { is_expected.to eq 'keywords modified' }
+      end
+
+      context 'when keyword removed' do
+        let(:keyword_params) do
+          [
+            { '_destroy' => '1', 'id' => form.keywords[0].id, 'label' => form.keywords[0].label, 'uri' => 'http://example.org/uri',
+              'cocina_type' => 'place' },
+            { '_destroy' => '', 'id' => form.keywords[1].id, 'label' =>  form.keywords[1].label, 'uri' => 'http://example.org/uri',
+              'cocina_type' => 'place' },
+            { '_destroy' => '', 'id' => form.keywords[2].id, 'label' =>  form.keywords[2].label, 'uri' => 'http://example.org/uri',
+              'cocina_type' => 'place' }
+          ]
+        end
+
+        it { is_expected.to eq 'keywords modified' }
+      end
+    end
+
+    context 'when keywords are the same' do
       let(:keyword_params) do
         [
           { '_destroy' => '', 'id' => form.keywords[0].id, 'label' => form.keywords[0].label, 'uri' => 'http://example.org/uri',
@@ -49,377 +157,314 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
           { '_destroy' => '', 'id' => form.keywords[1].id, 'label' => form.keywords[1].label, 'uri' => 'http://example.org/uri',
             'cocina_type' => 'place' },
           { '_destroy' => '', 'id' => form.keywords[2].id, 'label' => form.keywords[2].label, 'uri' => 'http://example.org/uri',
-            'cocina_type' => 'place' },
-          { '_destroy' => '', 'label' => 'This one added', 'uri' => 'http://example.org/uri', 'cocina_type' => 'test' }
-        ]
-      end
-
-      it { is_expected.to eq 'keywords modified' }
-    end
-
-    context 'when one keyword changed' do
-      let(:keyword_params) do
-        [
-          { '_destroy' => '', 'label' => 'This one changed', 'uri' => 'http://example.org/uri',
-            'cocina_type' => 'place' },
-          { '_destroy' => '', 'id' => form.keywords[1].id, 'label' => form.keywords[1].label, 'uri' => 'http://example.org/uri',
-            'cocina_type' => 'place' },
-          { '_destroy' => '', 'id' => form.keywords[2].id, 'label' => form.keywords[2].label, 'uri' => 'http://example.org/uri',
             'cocina_type' => 'place' }
         ]
       end
+      let(:params) { ActionController::Parameters.new(keywords: keyword_params) }
 
-      it { is_expected.to eq 'keywords modified' }
-    end
-
-    context 'when one keyword removed and one keyword added' do
-      let(:keyword_params) do
-        [
-          { '_destroy' => '1', 'id' => form.keywords[0].id, 'label' => form.keywords[0].label, 'uri' => 'http://example.org/uri',
-            'cocina_type' => 'place' },
-          { '_destroy' => '', 'id' => form.keywords[1].id, 'label' => form.keywords[1].label, 'uri' => 'http://example.org/uri',
-            'cocina_type' => 'place' },
-          { '_destroy' => '', 'id' => form.keywords[2].id, 'label' => form.keywords[2].label, 'uri' => 'http://example.org/uri',
-            'cocina_type' => 'place' },
-          { '_destroy' => '', 'label' => 'This one added', 'uri' => 'http://example.org/uri',
-            'cocina_type' => 'place' }
-        ]
-      end
-
-      it { is_expected.to eq 'keywords modified' }
-    end
-
-    context 'when keyword removed' do
-      let(:keyword_params) do
-        [
-          { '_destroy' => '1', 'id' => form.keywords[0].id, 'label' => form.keywords[0].label, 'uri' => 'http://example.org/uri',
-            'cocina_type' => 'place' },
-          { '_destroy' => '', 'id' => form.keywords[1].id, 'label' =>  form.keywords[1].label, 'uri' => 'http://example.org/uri',
-            'cocina_type' => 'place' },
-          { '_destroy' => '', 'id' => form.keywords[2].id, 'label' =>  form.keywords[2].label, 'uri' => 'http://example.org/uri',
-            'cocina_type' => 'place' }
-        ]
-      end
-
-      it { is_expected.to eq 'keywords modified' }
-    end
-  end
-
-  context 'when keywords are the same' do
-    let(:keyword_params) do
-      [
-        { '_destroy' => '', 'id' => form.keywords[0].id, 'label' => form.keywords[0].label, 'uri' => 'http://example.org/uri',
-          'cocina_type' => 'place' },
-        { '_destroy' => '', 'id' => form.keywords[1].id, 'label' => form.keywords[1].label, 'uri' => 'http://example.org/uri',
-          'cocina_type' => 'place' },
-        { '_destroy' => '', 'id' => form.keywords[2].id, 'label' => form.keywords[2].label, 'uri' => 'http://example.org/uri',
-          'cocina_type' => 'place' }
-      ]
-    end
-    let(:params) { ActionController::Parameters.new(keywords: keyword_params) }
-
-    before do
-      form.validate(params)
-    end
-
-    it { is_expected.to be_blank }
-  end
-
-  context 'when embargoed, then edited with no changes to embargo' do
-    let(:embargo_date) { 11.months.from_now }
-    let(:work_version) do
-      create(:work_version_with_work, :with_no_subtype, embargo_date:, collection:)
-    end
-    let(:params) do
-      ActionController::Parameters.new(
-        title: 'new title',
-        release: 'embargo',
-        'embargo_date(1i)' => embargo_date.year,
-        'embargo_date(2i)' => embargo_date.month,
-        'embargo_date(3i)' => embargo_date.day
-      )
-    end
-
-    before do
-      form.validate(params)
-    end
-
-    it 'description does not show embargo modified' do
-      expect(result).to eq 'title of deposit modified'
-    end
-  end
-
-  context 'when embargoed, then changes to embargo date' do
-    let(:embargo_date) { 10.months.from_now }
-    let(:new_embargo_date) { 11.months.from_now }
-    let(:work_version) do
-      create(:work_version_with_work, :with_no_subtype, embargo_date:, collection:)
-    end
-    let(:params) do
-      ActionController::Parameters.new(
-        title: 'new title',
-        release: 'embargo',
-        'embargo_date(1i)' => new_embargo_date.year,
-        'embargo_date(2i)' => new_embargo_date.month,
-        'embargo_date(3i)' => new_embargo_date.day
-      )
-    end
-
-    before do
-      form.validate(params)
-    end
-
-    it 'description does show embargo modified' do
-      expect(result).to eq 'title of deposit modified, embargo modified'
-    end
-  end
-
-  context 'when not embargoed, then embargo set' do
-    let(:new_embargo_date) { 11.months.from_now }
-    let(:work_version) { create(:work_version_with_work, :with_no_subtype, collection:) }
-    let(:params) do
-      ActionController::Parameters.new(
-        title: 'new title',
-        release: 'embargo',
-        'embargo_date(1i)' => new_embargo_date.year,
-        'embargo_date(2i)' => new_embargo_date.month,
-        'embargo_date(3i)' => new_embargo_date.day
-      )
-    end
-
-    before do
-      form.validate(params)
-    end
-
-    it 'description does show embargo modified' do
-      expect(result).to eq 'title of deposit modified, embargo modified'
-    end
-  end
-
-  context 'when embargoed, then embargo removed' do
-    let(:embargo_date) { 10.months.from_now }
-    let(:work_version) do
-      create(:work_version_with_work, :with_no_subtype, embargo_date:, collection:)
-    end
-    let(:params) do
-      ActionController::Parameters.new(
-        title: 'new title',
-        release: 'immediate'
-      )
-    end
-
-    before do
-      form.validate(params)
-    end
-
-    it 'description does show embargo modified' do
-      expect(result).to eq 'title of deposit modified, embargo modified'
-    end
-  end
-
-  context 'when file visibility has changed' do
-    before do
-      allow(AttachedFile).to receive(:new).and_return(AttachedFile.new)
-
-      form.validate(
-        attached_files: [
-          { 'label' => 'xml.svg', 'hide' => true, 'file' => '123782312abcdef' }
-        ]
-      )
-    end
-
-    it { is_expected.to include 'file visibility changed' }
-  end
-
-  context 'when new file label is not blank' do
-    before do
-      allow(AttachedFile).to receive(:new).and_return(AttachedFile.new)
-
-      form.validate(
-        attached_files: [
-          { 'label' => 'a new label!', 'hide' => false, 'file' => '123782312abcdef' }
-        ]
-      )
-    end
-
-    it { is_expected.to include 'file description changed' }
-  end
-
-  context 'when new file label is blank' do
-    before do
-      allow(AttachedFile).to receive(:new).and_return(AttachedFile.new)
-
-      form.validate(
-        attached_files: [
-          { 'label' => '', 'hide' => false, 'file' => '123782312abcdef' }
-        ]
-      )
-    end
-
-    it { is_expected.not_to include 'file description changed' }
-  end
-
-  context 'when existing file label remains blank' do
-    let(:attached_files) { [AttachedFile.new] }
-
-    before do
-      allow(AttachedFile).to receive(:new).and_return(AttachedFile.new(label: ''))
-
-      form.validate(
-        attached_files: [
-          { 'label' => '', 'hide' => false, 'file' => '123782312abcdef' }
-        ]
-      )
-    end
-
-    it { is_expected.not_to include 'file description changed' }
-  end
-
-  context 'when existing file label is removed' do
-    let(:attached_files) { [AttachedFile.new] }
-
-    before do
-      allow(AttachedFile).to receive(:new).and_return(AttachedFile.new(label: 'something', hide: false))
-      form.validate(
-        attached_files: [
-          { 'label' => '', 'hide' => false, 'file' => '123782312abcdef' }
-        ]
-      )
-    end
-
-    it { is_expected.to include 'file description changed' }
-  end
-
-  context 'when title has changed' do
-    before do
-      form.validate(title: 'new title')
-    end
-
-    it { is_expected.to eq 'title of deposit modified' }
-  end
-
-  context 'when many fields have changed' do
-    let(:params) do
-      ActionController::Parameters.new(
-        title: 'new title',
-        abstract: 'foo',
-        contact_emails: [{ 'email' => 'foo@bar.io' }],
-        authors: [{ 'role_term' => 'person|Author', 'first_name' => 'Megan' }],
-        contributors: [{ 'role_term' => 'person|Author', 'first_name' => 'Sara' }],
-        related_links: [{ 'link_title' => 'Hey', 'url' => 'http://io.io' }],
-        related_works: [{ 'citation' => 'Hey' }],
-        'published(1i)' => '2020',
-        'created(1i)' => '2020',
-        keywords: [{ 'label' => 'Brown coal' }],
-        release: 'embargo',
-        'embargo_date(1i)' => '2021', 'embargo_date(2i)' => '3', 'embargo_date(3i)' => '3',
-        license: 'ODbL-1.0',
-        access: 'stanford',
-        citation: 'Lorem ipsum',
-        subtype: %w[foo bar],
-        assign_doi: 'false',
-        attached_files_attributes: { '0' =>
-                      { 'label' => 'a label', '_destroy' => 'false', 'hide' => '0',
-                        'file' => 'eyJfcmFpbHMiOnsibWVzc2FnZS...' } }
-      )
-    end
-
-    before do
-      allow(AttachedFile).to receive(:new).and_return(AttachedFile.new)
-
-      form.validate(params)
-    end
-
-    it 'has a complete description' do
-      expect(result).to eq 'title of deposit modified, abstract modified, ' \
-                           'contact email modified, authors modified, contributors modified, ' \
-                           'related links modified, related works modified, ' \
-                           'publication date modified, creation date modified, ' \
-                           'keywords modified, work subtypes modified, ' \
-                           'citation modified, embargo modified, ' \
-                           'visibility modified, license modified, ' \
-                           'files added/removed, file description changed, assign DOI modified'
-    end
-  end
-
-  context 'when a new work version and nothing has changed' do
-    let(:user) { build(:user) }
-    let(:collection) { build(:collection, required_license: 'CC0-1.0', release_option: 'immediate', access: 'world') }
-    let(:work) { Work.new(collection:, depositor: user, owner: user) }
-    let(:work_version) { WorkVersion.new(work:) }
-
-    context 'when nothing has changed' do
       before do
-        form.validate(
-          {
-            'title' => '',
-            'work_type' => 'text',
-            'published(1i)' => '',
-            'published(2i)' => '',
-            'published(3i)' => '',
-            'created_type' => 'single',
-            'created(1i)' => '',
-            'created(2i)' => '',
-            'created(3i)' => '',
-            'abstract' => '',
-            'citation_auto' => ', . (2022). . Stanford Digital Repository. Available at :link will be ' \
-                               'inserted here automatically when available:',
-            'citation' => '',
-            'default_citation' => 'true',
-            'agree_to_terms' => '0',
-            'globus' => 'false',
-            'authors_attributes' => {
-              '0' => {
-                '_destroy' => '',
-                'full_name' => '',
-                'first_name' => '',
-                'last_name' => '',
-                'role_term' => 'person|Author',
-                'weight' => '0',
-                'orcid' => ''
-              }
-            },
-            'contributors_attributes' => {
-              '0' => {
-                '_destroy' => '',
-                'full_name' => '',
-                'first_name' => '',
-                'last_name' => '',
-                'role_term' => 'person|Author', 'orcid' => ''
-              }
-            },
-            'contact_emails_attributes' => {
-              '0' => {
-                '_destroy' => '',
-                'email' => ''
-              }
-            },
-            'keywords_attributes' => {
-              '0' => {
-                '_destroy' => '',
-                'label' => '',
-                'uri' => '',
-                'cocina_type' => ''
-              }
-            },
-            'related_works_attributes' => {
-              '0' => {
-                '_destroy' => '',
-                'citation' => ''
-              }
-            },
-            'related_links_attributes' => {
-              '0' => {
-                '_destroy' => '',
-                'link_title' => '',
-                'url' => ''
-              }
-            }
-          }
-        )
+        form.validate(params)
       end
 
       it { is_expected.to be_blank }
+    end
+
+    context 'when embargoed, then edited with no changes to embargo' do
+      let(:embargo_date) { 11.months.from_now }
+      let(:work_version) do
+        create(:work_version_with_work, :with_no_subtype, embargo_date:, collection:)
+      end
+      let(:params) do
+        ActionController::Parameters.new(
+          title: 'new title',
+          release: 'embargo',
+          'embargo_date(1i)' => embargo_date.year,
+          'embargo_date(2i)' => embargo_date.month,
+          'embargo_date(3i)' => embargo_date.day
+        )
+      end
+
+      before do
+        form.validate(params)
+      end
+
+      it 'description does not show embargo modified' do
+        expect(result).to eq 'title of deposit modified'
+      end
+    end
+
+    context 'when embargoed, then changes to embargo date' do
+      let(:embargo_date) { 10.months.from_now }
+      let(:new_embargo_date) { 11.months.from_now }
+      let(:work_version) do
+        create(:work_version_with_work, :with_no_subtype, embargo_date:, collection:)
+      end
+      let(:params) do
+        ActionController::Parameters.new(
+          title: 'new title',
+          release: 'embargo',
+          'embargo_date(1i)' => new_embargo_date.year,
+          'embargo_date(2i)' => new_embargo_date.month,
+          'embargo_date(3i)' => new_embargo_date.day
+        )
+      end
+
+      before do
+        form.validate(params)
+      end
+
+      it 'description does show embargo modified' do
+        expect(result).to eq 'title of deposit modified, embargo modified'
+      end
+    end
+
+    context 'when not embargoed, then embargo set' do
+      let(:new_embargo_date) { 11.months.from_now }
+      let(:work_version) { create(:work_version_with_work, :with_no_subtype, collection:) }
+      let(:params) do
+        ActionController::Parameters.new(
+          title: 'new title',
+          release: 'embargo',
+          'embargo_date(1i)' => new_embargo_date.year,
+          'embargo_date(2i)' => new_embargo_date.month,
+          'embargo_date(3i)' => new_embargo_date.day
+        )
+      end
+
+      before do
+        form.validate(params)
+      end
+
+      it 'description does show embargo modified' do
+        expect(result).to eq 'title of deposit modified, embargo modified'
+      end
+    end
+
+    context 'when embargoed, then embargo removed' do
+      let(:embargo_date) { 10.months.from_now }
+      let(:work_version) do
+        create(:work_version_with_work, :with_no_subtype, embargo_date:, collection:)
+      end
+      let(:params) do
+        ActionController::Parameters.new(
+          title: 'new title',
+          release: 'immediate'
+        )
+      end
+
+      before do
+        form.validate(params)
+      end
+
+      it 'description does show embargo modified' do
+        expect(result).to eq 'title of deposit modified, embargo modified'
+      end
+    end
+
+    context 'when file visibility has changed' do
+      before do
+        allow(AttachedFile).to receive(:new).and_return(AttachedFile.new)
+
+        form.validate(
+          attached_files: [
+            { 'label' => 'xml.svg', 'hide' => true, 'file' => '123782312abcdef' }
+          ]
+        )
+      end
+
+      it { is_expected.to include 'file visibility changed' }
+    end
+
+    context 'when new file label is not blank' do
+      before do
+        allow(AttachedFile).to receive(:new).and_return(AttachedFile.new)
+
+        form.validate(
+          attached_files: [
+            { 'label' => 'a new label!', 'hide' => false, 'file' => '123782312abcdef' }
+          ]
+        )
+      end
+
+      it { is_expected.to include 'file description changed' }
+    end
+
+    context 'when new file label is blank' do
+      before do
+        allow(AttachedFile).to receive(:new).and_return(AttachedFile.new)
+
+        form.validate(
+          attached_files: [
+            { 'label' => '', 'hide' => false, 'file' => '123782312abcdef' }
+          ]
+        )
+      end
+
+      it { is_expected.not_to include 'file description changed' }
+    end
+
+    context 'when existing file label remains blank' do
+      let(:attached_files) { [AttachedFile.new] }
+
+      before do
+        allow(AttachedFile).to receive(:new).and_return(AttachedFile.new(label: ''))
+
+        form.validate(
+          attached_files: [
+            { 'label' => '', 'hide' => false, 'file' => '123782312abcdef' }
+          ]
+        )
+      end
+
+      it { is_expected.not_to include 'file description changed' }
+    end
+
+    context 'when existing file label is removed' do
+      let(:attached_files) { [AttachedFile.new] }
+
+      before do
+        allow(AttachedFile).to receive(:new).and_return(AttachedFile.new(label: 'something', hide: false))
+        form.validate(
+          attached_files: [
+            { 'label' => '', 'hide' => false, 'file' => '123782312abcdef' }
+          ]
+        )
+      end
+
+      it { is_expected.to include 'file description changed' }
+    end
+
+    context 'when title has changed' do
+      before do
+        form.validate(title: 'new title')
+      end
+
+      it { is_expected.to eq 'title of deposit modified' }
+    end
+
+    context 'when many fields have changed' do
+      let(:params) do
+        ActionController::Parameters.new(
+          title: 'new title',
+          abstract: 'foo',
+          contact_emails: [{ 'email' => 'foo@bar.io' }],
+          authors: [{ 'role_term' => 'person|Author', 'first_name' => 'Megan' }],
+          contributors: [{ 'role_term' => 'person|Author', 'first_name' => 'Sara' }],
+          related_links: [{ 'link_title' => 'Hey', 'url' => 'http://io.io' }],
+          related_works: [{ 'citation' => 'Hey' }],
+          'published(1i)' => '2020',
+          'created(1i)' => '2020',
+          keywords: [{ 'label' => 'Brown coal' }],
+          release: 'embargo',
+          'embargo_date(1i)' => '2021', 'embargo_date(2i)' => '3', 'embargo_date(3i)' => '3',
+          license: 'ODbL-1.0',
+          access: 'stanford',
+          citation: 'Lorem ipsum',
+          subtype: %w[foo bar],
+          assign_doi: 'false',
+          attached_files_attributes: { '0' =>
+                        { 'label' => 'a label', '_destroy' => 'false', 'hide' => '0',
+                          'file' => 'eyJfcmFpbHMiOnsibWVzc2FnZS...' } }
+        )
+      end
+
+      before do
+        allow(AttachedFile).to receive(:new).and_return(AttachedFile.new)
+
+        form.validate(params)
+      end
+
+      it 'has a complete description' do
+        expect(result).to eq 'title of deposit modified, abstract modified, ' \
+                             'contact email modified, authors modified, contributors modified, ' \
+                             'related links modified, related works modified, ' \
+                             'publication date modified, creation date modified, ' \
+                             'keywords modified, work subtypes modified, ' \
+                             'citation modified, embargo modified, ' \
+                             'visibility modified, license modified, ' \
+                             'files added/removed, file description changed, assign DOI modified'
+      end
+    end
+
+    context 'when a new work version and nothing has changed' do
+      let(:user) { build(:user) }
+      let(:collection) { build(:collection, required_license: 'CC0-1.0', release_option: 'immediate', access: 'world') }
+      let(:work) { Work.new(collection:, depositor: user, owner: user) }
+      let(:work_version) { WorkVersion.new(work:) }
+
+      context 'when nothing has changed' do
+        before do
+          form.validate(
+            {
+              'title' => '',
+              'work_type' => 'text',
+              'published(1i)' => '',
+              'published(2i)' => '',
+              'published(3i)' => '',
+              'created_type' => 'single',
+              'created(1i)' => '',
+              'created(2i)' => '',
+              'created(3i)' => '',
+              'abstract' => '',
+              'citation_auto' => ', . (2022). . Stanford Digital Repository. Available at :link will be ' \
+                                 'inserted here automatically when available:',
+              'citation' => '',
+              'default_citation' => 'true',
+              'agree_to_terms' => '0',
+              'globus' => 'false',
+              'authors_attributes' => {
+                '0' => {
+                  '_destroy' => '',
+                  'full_name' => '',
+                  'first_name' => '',
+                  'last_name' => '',
+                  'role_term' => 'person|Author',
+                  'weight' => '0',
+                  'orcid' => ''
+                }
+              },
+              'contributors_attributes' => {
+                '0' => {
+                  '_destroy' => '',
+                  'full_name' => '',
+                  'first_name' => '',
+                  'last_name' => '',
+                  'role_term' => 'person|Author', 'orcid' => ''
+                }
+              },
+              'contact_emails_attributes' => {
+                '0' => {
+                  '_destroy' => '',
+                  'email' => ''
+                }
+              },
+              'keywords_attributes' => {
+                '0' => {
+                  '_destroy' => '',
+                  'label' => '',
+                  'uri' => '',
+                  'cocina_type' => ''
+                }
+              },
+              'related_works_attributes' => {
+                '0' => {
+                  '_destroy' => '',
+                  'citation' => ''
+                }
+              },
+              'related_links_attributes' => {
+                '0' => {
+                  '_destroy' => '',
+                  'link_title' => '',
+                  'url' => ''
+                }
+              }
+            }
+          )
+        end
+
+        it { is_expected.to be_blank }
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2686 - indicate if a license was changed from the default for a brand new work; if not, keep the current message ("Created")

Todo: 
- [x] add a test
- [x] update functionality for how events work (see ticket comments)

## How was this change tested? 🤨

Localhost and added a request test