### PR TITLE
Allow collections to be decommissioned

### DIFF
--- a/app/assets/stylesheets/collection.scss
+++ b/app/assets/stylesheets/collection.scss
@@ -30,7 +30,7 @@
       font-size: large;
     }
   }
-  
+
   // The pencil icon
   .edit {
     margin-left: 10px;
@@ -49,6 +49,14 @@
         color: $primary;
         font-weight: bold;
       }
+    }
+  }
+
+  .admin-section {
+    background-color: $silver-sand;
+
+    label.admin-functions {
+      @extend h5;
     }
   }
 }

--- a/app/components/collections/admin_component.html.erb
+++ b/app/components/collections/admin_component.html.erb
@@ -1,0 +1,15 @@
+<section class="admin-section p-3 mb-5">
+  <div class="row">
+    <div class="col">
+      <label for="adminFunctionsSelect" class="form-label admin-functions">Admin functions</label>
+    </div>
+    <div class="col">
+      <select id="adminFunctionsSelect" class="form-select" onchange="this.value !== 'select' ? document.querySelector('#collectionAdminSection').src = this.value : document.querySelector('#collectionAdminSection').innerHTML = ''">
+        <%= options %>
+      </select>
+    </div>
+  </div>
+  <div class="row pt-3">
+    <turbo-frame id="collectionAdminSection"></turbo-frame>
+  </div>
+</section>

--- a/app/components/collections/admin_component.rb
+++ b/app/components/collections/admin_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Collections
+  # Renders the admin functions for a collection
+  class AdminComponent < ApplicationComponent
+    def initialize(collection:)
+      @collection = collection
+    end
+
+    attr_reader :collection
+
+    def render?
+      helpers.user_with_groups.administrator?
+    end
+
+    def options
+      opts = [
+        ['Select...', 'select']
+      ]
+      opts << ['Decommission collection', edit_collection_decommission_path(collection)] unless collection.head.decommissioned? # rubocop:disable Layout/LineLength
+      options_for_select(opts, 'select')
+    end
+  end
+end

--- a/app/components/collections/detail_component.html.erb
+++ b/app/components/collections/detail_component.html.erb
@@ -1,8 +1,11 @@
 <table class="table table-sm mb-5 caption-header">
   <caption>Details
-    <%= link_to edit_collection_version_path(collection_version), aria: { label: 'Edit details' } do %>
-      <span class="fa-solid fa-pencil-alt edit" aria-hidden="true"></span>
-    <% end %>
+    <%= helpers.turbo_frame_tag dom_id(collection_version, :edit),
+                                src: edit_link_collection_version_path(
+                                  collection_version,
+                                  label: 'Edit details'
+                                ),
+                                target: '_top' %>
   </caption>
 
   <tbody>

--- a/app/components/collections/links_component.html.erb
+++ b/app/components/collections/links_component.html.erb
@@ -1,8 +1,13 @@
 <table class="table table-sm mb-5 caption-header">
   <caption>Links to related information
-    <%= link_to edit_collection_version_path(collection_version, anchor: 'links'), aria: { label: 'Edit links to related information' } do %>
-      <span class="fa-solid fa-pencil-alt edit" aria-hidden="true"></span>
-    <% end %>
+    <%= helpers.turbo_frame_tag dom_id(collection_version, :edit_links),
+                                src: edit_link_collection_version_path(
+                                  collection_version,
+                                  ref: 'links',
+                                  label: 'Edit links to related information'
+                                ),
+                                target: '_top' %>
+
   </caption>
   <tbody>
     <tr>

--- a/app/components/works/admin_component.rb
+++ b/app/components/works/admin_component.rb
@@ -19,7 +19,7 @@ module Works
         ['Change owner', edit_owners_path(work)],
         ['Lock/Unlock', edit_locks_path(work)]
       ]
-      opts << ['Decommission', edit_decommission_path(work)] unless work.head.decommissioned?
+      opts << ['Decommission', edit_work_decommission_path(work)] unless work.head.decommissioned?
       options_for_select(opts, 'select')
     end
   end

--- a/app/controllers/collection_decommission_controller.rb
+++ b/app/controllers/collection_decommission_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# a controller for decommissioning a collection.
+class CollectionDecommissionController < ApplicationController
+  before_action :authenticate_user!
+  verify_authorized
+
+  def edit
+    authorize! :collection_decommission
+  end
+
+  def update
+    authorize! :collection_decommission
+
+    collection = Collection.find(params[:id])
+    # Check that collection contains only NO items or ONLY DECOMMISSIONED items
+    if collection.works_without_decommissioned.any?
+      flash[:error] = I18n.t('collection.flash.decommission_failed')
+    else
+      decommission!(collection)
+      flash[:success] = I18n.t('collection.flash.decommissioned')
+    end
+    redirect_to collection_path(collection)
+  end
+
+  private
+
+  def decommission!(collection)
+    Collection.transaction do
+      # NOTE: You might think the `head.collection` bit here is not needed...
+      #       but it is. Why? Because when the event is created in the
+      #       CollectionVersion class, we access the collection **via** the
+      #       collection version. And that in-memory collection instance is a
+      #       different in-memory collection instance than the collection here.
+      collection.head.collection.event_context = {
+        user: current_user,
+        description: I18n.t('collection.flash.decommissioned')
+      }
+      collection.head.decommission!
+      collection.update!(
+        managed_by: [],
+        depositors: [],
+        reviewed_by: []
+      )
+    end
+  end
+end

--- a/app/controllers/collection_versions_controller.rb
+++ b/app/controllers/collection_versions_controller.rb
@@ -66,11 +66,15 @@ class CollectionVersionsController < ObjectsController
 
   # We render this link lazily because it requires doing a query to see if the user has access.
   # The access can vary depending on the user and the state of the collection.
+  # NOTE, the "ref" parameter is used to create the anchor as well as the dom_id for the turbo-frame
+  # so when you link to this method ensure the dom_id or the containing frame matches the target anchor.
   def edit_link
     collection_version = CollectionVersion.find(params[:id])
+    label = params.fetch(:label) { "Edit #{collection_version.name}" }
     render partial: 'edit_link', locals: {
       collection_version:,
-      name: collection_version.name
+      label:,
+      anchor: params[:ref]
     }
   end
 

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -85,6 +85,11 @@ class CollectionsController < ObjectsController
     }
   end
 
+  def admin
+    @collection = Collection.find(params[:id])
+    authorize! @collection
+  end
+
   private
 
   def update_params

--- a/app/models/collection_version.rb
+++ b/app/models/collection_version.rb
@@ -65,6 +65,10 @@ class CollectionVersion < ApplicationRecord
       transition new: :first_draft
       transition %i[first_draft version_draft] => same
     end
+
+    event :decommission do
+      transition all => :decommissioned
+    end
   end
 
   def updatable?

--- a/app/policies/collection_decommission_policy.rb
+++ b/app/policies/collection_decommission_policy.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Authorization policy for Collection decommission operations
+class CollectionDecommissionPolicy < ApplicationPolicy
+  alias_rule :edit?, to: :update?
+
+  def update?
+    administrator?
+  end
+end

--- a/app/policies/collection_version_policy.rb
+++ b/app/policies/collection_version_policy.rb
@@ -5,6 +5,17 @@ class CollectionVersionPolicy < ApplicationPolicy
   alias_rule :edit?, to: :update?
   alias_rule :delete?, to: :destroy?
 
+  # Return the relation defining the collections you can view and removing decommissioned works unless administrator.
+  scope_for :relation do |relation|
+    return relation if administrator?
+
+    relation.where.not(state: 'decommissioned').and(
+      relation.where(
+        collection_id: user.deposits_into_ids + user.manages_collection_ids + user.reviews_collection_ids
+      )
+    )
+  end
+
   def update?
     return false unless record.updatable?
 
@@ -17,6 +28,10 @@ class CollectionVersionPolicy < ApplicationPolicy
 
   def destroy?
     (administrator? || manages_collection?(record.collection)) && record.persisted? && record.version_draft?
+  end
+
+  def deposit?
+    record.updatable? && show?
   end
 
   delegate :administrator?, :collection_creator?, to: :user_with_groups

--- a/app/policies/work_policy.rb
+++ b/app/policies/work_policy.rb
@@ -4,7 +4,7 @@
 class WorkPolicy < ApplicationPolicy
   alias_rule :delete?, to: :destroy?
 
-  # Return the relation defining the collections you can view and removing decommissioned works unless administrator.
+  # Return the relation defining the works you can view and removing decommissioned works unless administrator.
   scope_for :relation do |relation|
     new_relation = relation.where(collection_id: user.manages_collection_ids + user.reviews_collection_ids).or(
       relation.where(owner: user)

--- a/app/views/collection_decommission/edit.html.erb
+++ b/app/views/collection_decommission/edit.html.erb
@@ -1,14 +1,14 @@
-<turbo-frame id='workAdminSection'>
-  <%= form_with url: work_decommission_path(params[:id]), method: :put, data: {turbo: false} do |form| %>
+<turbo-frame id='collectionAdminSection'>
+  <%= form_with url: collection_decommission_path(params[:id]), method: :put, data: { turbo: false } do |form| %>
     <div data-controller="decommission">
       <div class="form-check mt-3">
         <input class="form-check-input" type="checkbox" value="" id="confirmCheckbox" data-decommission-target="confirm" data-action="decommission#change">
         <label class="form-check-label" for="confirmCheckbox">
-          I confirm this item has been decommissioned in Argo and <span class="text-danger">understand this cannot be undone</span>.
+          I confirm this collection has been decommissioned in Argo and <span class="text-danger">understand this cannot be undone</span>.
         </label>
       </div>
       <fieldset data-decommission-target="submit">
-        <%= form.submit "Decommission from H2", class: 'btn btn-primary mt-3' %>
+        <%= form.submit "Decommission collection from H2", class: 'btn btn-primary mt-3' %>
       </fieldset>
     </div>
   <% end %>

--- a/app/views/collection_versions/_edit_link.html.erb
+++ b/app/views/collection_versions/_edit_link.html.erb
@@ -1,6 +1,6 @@
-<%= turbo_frame_tag dom_id(collection_version, :edit) do %>
+<%= turbo_frame_tag dom_id(collection_version, ['edit', anchor].compact.join('_')) do %>
   <% if allowed_to?(:update?, collection_version) %>
-    <%= link_to edit_collection_version_path(collection_version), aria: { label: "Edit #{name}" } do %>
+    <%= link_to edit_collection_version_path(collection_version, anchor: anchor), aria: { label: } do %>
       <%= tag.span class: 'fa-solid fa-pencil-alt edit' %>
     <% end %>
   <% end %>

--- a/app/views/collections/_collection.html.erb
+++ b/app/views/collections/_collection.html.erb
@@ -2,6 +2,8 @@
 <section id="<%= dom_id(collection) %>" data-controller="work-type">
   <%= render Collections::Show::SettingsHeaderComponent.new(collection_version: collection.head) %>
   <%= render Works::WorkTypeModalComponent.new %>
+  <turbo-frame id="collectionAdminFrame" src="<%= admin_collection_path(collection) %>">
+  </turbo-frame>
   <%= render Collections::ReleaseComponent.new(collection: collection) %>
   <%= render Collections::TermsOfUseComponent.new(collection: collection) %>
   <%= render Collections::ParticipantsComponent.new(collection: collection) %>

--- a/app/views/collections/_deposit_button.html.erb
+++ b/app/views/collections/_deposit_button.html.erb
@@ -1,5 +1,8 @@
 <%= turbo_frame_tag dom_id(collection, :deposit) do %>
-  <% if allowed_to?(:create?, WorkVersion.new(work: Work.new(collection: collection))) %>
+  <%
+    if allowed_to?(:create?, WorkVersion.new(work: Work.new(collection: collection))) &&
+       allowed_to?(:deposit?, collection.head)
+  %>
     <%= button_tag '+ Deposit to this collection',
           data: {
             destination: new_collection_work_path(collection),

--- a/app/views/collections/admin.html.erb
+++ b/app/views/collections/admin.html.erb
@@ -1,0 +1,3 @@
+<turbo-frame id="collectionAdminFrame">
+  <%= render Collections::AdminComponent.new(collection: @collection) %>
+</turbo-frame>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,9 @@ en:
     access:
       world: anyone
       stanford: Stanford community members only
+    flash:
+      decommission_failed: "You must decommission the items in this collection before you can decommission the collection."
+      decommissioned: "Decommissioned"
   tooltip:
     what_type: Choose the one content type that best describes the overall or primary nature of the work. Click on each content type to view and select terms you may use to further describe the work you are depositing.
     further_types: You have the option to further describe the work you are depositing. If you have chosen "Mixed Materials", you must choose at least two of the additional terms. If you have chosen "Music", you must select at least one term from the shorter list of terms below, but you may enter others from the full list as well (choose "See more options"). If you have chosen "Other", you must enter a word or short phrase to describe the overall nature of the work you are depositing.
@@ -140,43 +143,43 @@ en:
       faculty_student_staff_publications:
         label: Faculty, Student, and Staff Publications
         description: >
-          An open collection for assembling publications by Stanford faculty, graduate students, 
+          An open collection for assembling publications by Stanford faculty, graduate students,
           post-docs, and staff from the full range of disciplines.
       stanford_research_data:
         label: Stanford Research Data
         description: >
-          This collection includes research data from Stanford-associated researchers and scientists on the 
-          wide variety of topics and fields under investigation at Stanford University, including biology, 
-          chemistry, engineering, environmental sciences, geosciences, history, languages, mathematics, 
-          medicine, music, physics, public policy, social sciences, and statistics. Data sets in this 
-          collection are in many different formats, and each is presented with descriptive information that 
-          identifies the people and organizations responsible for its creation, related publications, and 
-          other relevant information. The collection was created to support the preservation of the research 
+          This collection includes research data from Stanford-associated researchers and scientists on the
+          wide variety of topics and fields under investigation at Stanford University, including biology,
+          chemistry, engineering, environmental sciences, geosciences, history, languages, mathematics,
+          medicine, music, physics, public policy, social sciences, and statistics. Data sets in this
+          collection are in many different formats, and each is presented with descriptive information that
+          identifies the people and organizations responsible for its creation, related publications, and
+          other relevant information. The collection was created to support the preservation of the research
           output of the University and to enable data sharing and re-use.
       stanford_theses_dissertations:
         label: Stanford Theses and Dissertations
         description: >
-          This collection includes theses and dissertations authored by Stanford graduate and undergraduate 
-          students from a variety of schools and representing a broad range of scholarly disciplines. Established 
-          in 2014, the collection supports the preservation, sharing, and re-use of the research output of the 
-          University, particularly for those programs for which there is no formal or mandatory requirement for 
+          This collection includes theses and dissertations authored by Stanford graduate and undergraduate
+          students from a variety of schools and representing a broad range of scholarly disciplines. Established
+          in 2014, the collection supports the preservation, sharing, and re-use of the research output of the
+          University, particularly for those programs for which there is no formal or mandatory requirement for
           thesis deposit.
       sul_staff_publications_research:
         label: Stanford University Libraries staff publications and research
         description: >
-          Publications and research produced and contributed by staff of Stanford University Libraries on a 
+          Publications and research produced and contributed by staff of Stanford University Libraries on a
           broad range of topics relevant to academic and research libraries.
       stanford_open_access_articles:
         label: Stanford University Open Access Articles
         description: >
-          A collection of open access articles published by faculty, students, and other researchers at Stanford 
+          A collection of open access articles published by faculty, students, and other researchers at Stanford
           University.
       marc:
         label: I am a library employee, and I need a MARC record.
       no_collection:
         label: I do not see an appropriate collection.
   mail_preference:
-    participant_changed: A depositor, manager, or reviewer is added or removed. 
+    participant_changed: A depositor, manager, or reviewer is added or removed.
     new_item: A depositor creates a new item, deposits an item, or creates a new draft of an item
     submit_for_review: A depositor submits an item for review
     version_started_but_not_finished: A new version of this collection is started and not finished

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
       get :delete_button
       get :edit_link
       get :dashboard
+      get :admin
+      resource :decommission, only: %i[edit update], controller: 'collection_decommission', as: :collection_decommission
     end
 
     resources :works, shallow: true do
@@ -32,7 +34,7 @@ Rails.application.routes.draw do
         get :details
         resource :owners, only: %i[edit update], controller: 'work_owners'
         resource :locks, only: %i[edit update], controller: 'work_locks'
-        resource :decommission, only: %i[edit update], controller: 'work_decommission'
+        resource :decommission, only: %i[edit update], controller: 'work_decommission', as: :work_decommission
       end
 
       resource :review, only: :create

--- a/spec/components/collections/admin_component_spec.rb
+++ b/spec/components/collections/admin_component_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Collections::AdminComponent, type: :component do
+  let(:collection_version) { build_stubbed(:collection_version_with_collection, state:) }
+  let(:instance) { described_class.new(collection: collection_version.collection) }
+  let(:groups) { [] }
+  let(:rendered) { render_inline(instance) }
+  let(:state) { 'deposited' }
+  let(:user) { build(:user, name: 'Pyotr Kropotkin', email: 'kropot00@stanford.edu') }
+  let(:user_with_groups) { UserWithGroups.new(user:, groups:) }
+
+  before do
+    allow(controller).to receive_messages(
+      current_user: user,
+      user_with_groups:
+    )
+    allow(collection_version.collection).to receive(:head).and_return(collection_version)
+  end
+
+  context 'with a non-admin user' do
+    it 'does not render' do
+      expect(rendered.to_html).to be_empty
+    end
+  end
+
+  context 'with an admin user' do
+    let(:groups) { [Settings.authorization_workgroup_names.administrators] }
+
+    context 'with head in a state other than decommissioned' do
+      it 'includes an option to decommission' do
+        expect(rendered.to_html).to include('Decommission collection')
+      end
+    end
+
+    context 'with head in a decommissioned state' do
+      let(:state) { 'decommissioned' }
+
+      it 'does not include an option to decommission' do
+        expect(rendered.to_html).not_to include('Decommission collection')
+      end
+    end
+  end
+end

--- a/spec/factories/collection_versions.rb
+++ b/spec/factories/collection_versions.rb
@@ -17,13 +17,17 @@ FactoryBot.define do
         reviewed_by { [] }
         managed_by { [] }
         review_enabled { false }
+        access { 'world' }
+        doi_option { 'no' }
       end
       state { 'deposited' }
       collection do
         association(:collection, depositors:,
                                  managed_by:,
                                  reviewed_by:,
-                                 review_enabled:)
+                                 review_enabled:,
+                                 doi_option:,
+                                 access:)
       end
 
       after(:create) do |collection_version, _evaluator|

--- a/spec/features/decommission_collection_spec.rb
+++ b/spec/features/decommission_collection_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Decommission a collection', js: true do
+  let(:user) { create(:user) }
+  let(:collection_version) { create(:collection_version_with_collection) }
+
+  before do
+    sign_in user, groups: ['dlss:hydrus-app-administrators']
+  end
+
+  it 'allows collection to be decommissioned' do
+    visit collection_path(collection_version.collection)
+
+    select 'Decommission collection', from: 'Admin functions'
+    expect(page).to have_content 'I confirm this collection has been decommissioned in Argo'
+    check 'confirmCheckbox'
+    click_button 'Decommission collection from H2'
+
+    # Flash message
+    within '.alert' do
+      expect(page).to have_content 'Decommissioned'
+    end
+
+    # Event added
+    within '#events' do
+      expect(page).to have_content 'Decommissioned'
+    end
+  end
+end

--- a/spec/features/purl_reservation_spec.rb
+++ b/spec/features/purl_reservation_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 
 RSpec.describe 'Reserve a PURL for a work in a deposited collection', js: true do
   let(:user) { create(:user) }
-  let!(:collection) do
-    create(:collection, :depositor_selects_access, managed_by: [user], head: collection_version, doi_option:)
+  let(:collection_version) do
+    create(:collection_version_with_collection, access: 'depositor-selects', managed_by: [user], doi_option:)
   end
-  let(:collection_version) { create(:collection_version, :deposited) }
+  let!(:collection) { collection_version.collection }
   let(:druid) { 'druid:bc123df4567' }
   let(:title) { 'my PURL reservation test' }
   let(:doi_option) { 'depositor-selects' }

--- a/spec/models/collection_version_spec.rb
+++ b/spec/models/collection_version_spec.rb
@@ -146,5 +146,13 @@ RSpec.describe CollectionVersion do
           .and change(Event, :count).by(1)
       end
     end
+
+    describe 'a decommission event' do
+      it 'transitions to decommissioned' do
+        expect { collection_version.decommission! }
+          .to change(collection_version, :state)
+          .to('decommissioned')
+      end
+    end
   end
 end

--- a/spec/policies/collection_decommission_policy_spec.rb
+++ b/spec/policies/collection_decommission_policy_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CollectionDecommissionPolicy do
+  let(:user) { build_stubbed :user }
+  # `record` must be defined - it is the authorization target
+  let(:record) { build_stubbed :collection }
+  # `context` is the authorization context
+  let(:context) do
+    {
+      user:,
+      user_with_groups: UserWithGroups.new(user:, groups:)
+    }
+  end
+  let(:groups) { [] }
+
+  describe_rule :update? do
+    failed 'when user is not an adminstrator'
+
+    succeed 'when user is an admin' do
+      let(:groups) { [Settings.authorization_workgroup_names.administrators] }
+    end
+  end
+end

--- a/spec/policies/collection_policy_spec.rb
+++ b/spec/policies/collection_policy_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe CollectionPolicy do
   let(:user) { build_stubbed :user }
   # `record` must be defined - it is the authorization target
   let(:record) { build_stubbed :collection }
-
   # `context` is the authorization context
   let(:context) do
     {
@@ -32,7 +31,12 @@ RSpec.describe CollectionPolicy do
     subject(:scope) { policy.apply_scope(Collection, type: :active_record_relation, name: :deposit) }
 
     let(:policy) { described_class.new(**context) }
-    let!(:collection) { create(:collection) }
+    let(:collection) { create(:collection) }
+    let(:collection_version) { create(:collection_version, collection:) }
+
+    before do
+      collection.update(head: collection_version)
+    end
 
     context 'when the user is not affiliated' do
       it { is_expected.not_to include(collection) }

--- a/spec/requests/decommission_collection_spec.rb
+++ b/spec/requests/decommission_collection_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Decommission a collection' do
+  let(:collection_version) { create(:collection_version_with_collection) }
+  let(:collection) { collection_version.collection }
+  let(:groups) { [] }
+  let(:user) { create(:user) }
+
+  before do
+    collection.update(head: collection_version)
+    sign_in user, groups:
+  end
+
+  describe 'GET /collections/:id/decommission/edit' do
+    context 'with an authorized user' do
+      let(:groups) { [Settings.authorization_workgroup_names.administrators] }
+
+      it 'renders the form' do
+        get edit_collection_decommission_path(collection)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('I confirm this collection has been decommissioned in Argo')
+      end
+    end
+
+    context 'with an unauthorized user' do
+      it 'redirects and renders an error message' do
+        get edit_collection_decommission_path(collection)
+
+        follow_redirect!
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('You are not authorized to perform the requested action')
+      end
+    end
+  end
+
+  describe 'PUT /collections/:id/decommission' do
+    context 'with an authorized user' do
+      let(:groups) { [Settings.authorization_workgroup_names.administrators] }
+
+      context 'when collection has zero non-decommissioned works' do
+        it 'redirects to the collection page and confirms it was decommissioned' do
+          put collection_decommission_path(collection)
+
+          follow_redirect!
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include('Decommissioned')
+        end
+      end
+
+      context 'when collection has non-decommissioned works' do
+        let!(:work) { create(:work_version_with_work, collection:) } # rubocop:disable RSpec/LetSetup
+
+        it 'redirects to the collection page and confirms it was decommissioned' do
+          put collection_decommission_path(collection)
+
+          follow_redirect!
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include(
+            'You must decommission the items in this collection before you can decommission the collection'
+          )
+        end
+      end
+    end
+
+    context 'with an unauthorized user' do
+      it 'redirects and renders an error message' do
+        put collection_decommission_path(collection)
+
+        follow_redirect!
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('You are not authorized to perform the requested action')
+      end
+    end
+  end
+end


### PR DESCRIPTION

## Why was this change made? 🤔

Fixes #2629

This commit adds the ability to decommission collections if and only if all of their works have previously been decommissioned (or if they have no works). The approach taken in this commit mirrors that used for decommissioning works, with deviations where necessary due to design differences between collections and works.


## How was this change tested? 🤨

CI, and tested with Amy in a deployed env
