### PR TITLE
Replace uncertain with approximate for EDTF dates.

### DIFF
--- a/app/components/works/dates_component.rb
+++ b/app/components/works/dates_component.rb
@@ -56,7 +56,7 @@ module Works
     def created_approximate?
       return false unless created_edtf
 
-      created_edtf.uncertain?
+      created_edtf.approximate?
     end
 
     delegate :published_edtf, to: :reform
@@ -79,7 +79,7 @@ module Works
     def created_range_start_approximate?
       return false unless created_range_start
 
-      created_range_start.uncertain?
+      created_range_start.approximate?
     end
 
     def created_range_end_year
@@ -97,7 +97,7 @@ module Works
     def created_range_end_approximate?
       return false unless created_range_end
 
-      created_range_end.uncertain?
+      created_range_end.approximate?
     end
 
     def created_range_start

--- a/app/forms/edtf_params_filter.rb
+++ b/app/forms/edtf_params_filter.rb
@@ -22,9 +22,9 @@ class EdtfParamsFilter
     year = params["#{date_attribute}(#{1 + offset}i)"]
     month = params["#{date_attribute}(#{2 + offset}i)"]
     day = params["#{date_attribute}(#{3 + offset}i)"]
-    uncertain = params["#{date_attribute}(approx#{offset})"]
+    approximate = params["#{date_attribute}(approx#{offset})"]
 
-    deserialize_edtf_date(year, month, day, uncertain)
+    deserialize_edtf_date(year, month, day, approximate)
   end
 
   def deserialize_edtf_range(params, name)
@@ -37,7 +37,7 @@ class EdtfParamsFilter
     [start, finish].join('/')
   end
 
-  def deserialize_edtf_date(year, month, day, uncertain)
+  def deserialize_edtf_date(year, month, day, approximate)
     return if year.blank?
 
     date = year.dup
@@ -45,7 +45,7 @@ class EdtfParamsFilter
       date += "-#{format('%<month>02d', month:)}"
       date += "-#{format('%<day>02d', day:)}" if day.present?
     end
-    date += '?' if uncertain
+    date += '~' if approximate
     date
   end
 end

--- a/app/services/cocina_generator/description/date_generator.rb
+++ b/app/services/cocina_generator/description/date_generator.rb
@@ -45,7 +45,7 @@ module CocinaGenerator
         {
           structuredValue: interval_structured_values(interval_date)
         }.tap do |props|
-          if interval_date.from&.uncertain? || interval_date.to&.uncertain?
+          if interval_date.from&.approximate? || interval_date.to&.approximate?
             props[:qualifier] = 'approximate'
             props[:structuredValue].each { |struct_date_val| struct_date_val.delete(:qualifier) }
           end
@@ -61,8 +61,8 @@ module CocinaGenerator
 
       def edtf_date_props(edtf_date, type: nil)
         {
-          qualifier: edtf_date.uncertain? ? 'approximate' : nil,
-          value: edtf_date.edtf.chomp('?'),
+          qualifier: edtf_date.approximate? ? 'approximate' : nil,
+          value: edtf_date.edtf.chomp('~'),
           type:
         }.compact
       end

--- a/spec/components/works/dates_component_spec.rb
+++ b/spec/components/works/dates_component_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Works::DatesComponent do
   end
 
   context 'with a populated form with an approximate date range' do
-    let(:approx_date_range) { EDTF.parse('2019-05?/2020-07?') }
+    let(:approx_date_range) { EDTF.parse('2019-05~/2020-07~') }
     let(:work_version) { build(:work_version, created_edtf: approx_date_range) }
 
     it 'renders the component with both start and end approximate checkbox selected' do
@@ -53,7 +53,7 @@ RSpec.describe Works::DatesComponent do
 
   context 'with a populated form with an approximate backwards date range' do
     # Testing this due to how EDTF handles to < from
-    let(:approx_date_range) { EDTF.parse('2020-07?/2019-05?') }
+    let(:approx_date_range) { EDTF.parse('2020-07~/2019-05~') }
     let(:work_version) { build(:work_version, created_edtf: approx_date_range) }
 
     it 'renders the component with both start and end approximate checkbox selected' do
@@ -101,7 +101,7 @@ RSpec.describe Works::DatesComponent do
   end
 
   context 'with a populated form containing an approximate date' do
-    let(:creation_date) { EDTF.parse('2020-05-09?') }
+    let(:creation_date) { EDTF.parse('2020-05-09~') }
     let(:work_version) { build(:work_version, created_edtf: creation_date) }
 
     it 'renders the component with the approximate check-box selected' do

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -84,7 +84,7 @@ FactoryBot.define do
   end
 
   trait :with_approximate_creation_date_range do
-    created_edtf { EDTF.parse('2020-03-04?/2020-10-31?') }
+    created_edtf { EDTF.parse('2020-03-04~/2020-10-31~') }
   end
 
   trait :with_creation_date do
@@ -100,15 +100,15 @@ FactoryBot.define do
   end
 
   trait :with_approximate_creation_date do
-    created_edtf { EDTF.parse('2020-03-08?') }
+    created_edtf { EDTF.parse('2020-03-08~') }
   end
 
   trait :with_approximate_creation_date_year_only do
-    created_edtf { EDTF.parse('2020?') }
+    created_edtf { EDTF.parse('2020~') }
   end
 
   trait :with_approximate_creation_date_year_month_only do
-    created_edtf { EDTF.parse('2020-06?') }
+    created_edtf { EDTF.parse('2020-06~') }
   end
 
   trait :with_keywords do


### PR DESCRIPTION
closes #2739

## Why was this change made? 🤔
To align with EDTF spec.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


