### PR TITLE
Collection decommish tweaks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,8 @@ AllCops:
     - db/**/*
     - node_modules/**/*
     - bin/**/*
+    - log/**/*
+    - tmp/**/*
     - vendor/**/*
 
 Lint/MissingSuper: # (new in 0.89)

--- a/app/components/admin/all_collections_row_component.html.erb
+++ b/app/components/admin/all_collections_row_component.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= link_to collection.head.name, collection %><%= draft_label %></td>
+  <td><%= link_to collection.head.name, collection %><%= state_label %></td>
   <td><%= total %></td>
   <td><%= state_count('deposited') %></td>
   <td><%= state_count('first_draft') %></td>

--- a/app/components/admin/all_collections_row_component.rb
+++ b/app/components/admin/all_collections_row_component.rb
@@ -10,14 +10,17 @@ module Admin
 
     attr_reader :collection, :counts
 
-    def draft_label
-      return unless @collection.head&.state&.include? 'draft'
+    def state_label # rubocop:disable Metric/CyclomaticComplexity
+      state = @collection.head&.state
+      return unless state&.include?('draft') || state == 'decommissioned'
 
-      case @collection.head&.state
+      case state
       when 'first_draft'
         tag.span ' - Draft', class: 'draft-tag'
       when 'version_draft'
         tag.span ' - Version Draft', class: 'draft-tag'
+      when 'decommissioned'
+        tag.span ' - Decommissioned', class: 'draft-tag'
       end
     end
 

--- a/app/components/admin/all_collections_row_component.rb
+++ b/app/components/admin/all_collections_row_component.rb
@@ -10,7 +10,7 @@ module Admin
 
     attr_reader :collection, :counts
 
-    def state_label # rubocop:disable Metric/CyclomaticComplexity
+    def state_label # rubocop:disable Metrics/CyclomaticComplexity
       state = @collection.head&.state
       return unless state&.include?('draft') || state == 'decommissioned'
 

--- a/app/components/collections/show/settings_header_component.html.erb
+++ b/app/components/collections/show/settings_header_component.html.erb
@@ -12,6 +12,9 @@
     </div>
   </div>
   <span class="header-text"><%= name %></span><%= render Collections::DraftComponent.new(collection_version: collection_version) %>
+  <% if collection.head&.decommissioned? %>
+    <span class="state">Decommissioned</span>
+  <% end %>
   <%= helpers.turbo_frame_tag dom_id(collection, :edit),
                               src: edit_link_collection_path(collection),
                               target: '_top' %>

--- a/app/controllers/admin/collection_reports_controller.rb
+++ b/app/controllers/admin/collection_reports_controller.rb
@@ -38,7 +38,8 @@ module Admin
 
     def collections_report_params
       params.require(:admin_collections_report).permit(:status_first_draft, :status_version_draft,
-                                                       :status_deposited, :date_created_start, :date_created_end,
+                                                       :status_deposited, :status_decommissioned,
+                                                       :date_created_start, :date_created_end,
                                                        :date_modified_start, :date_modified_end)
     end
   end

--- a/app/models/admin/collections_report.rb
+++ b/app/models/admin/collections_report.rb
@@ -9,6 +9,7 @@ module Admin
     attribute :status_deposited, :boolean, default: false
     attribute :status_first_draft, :boolean, default: false
     attribute :status_version_draft, :boolean, default: false
+    attribute :status_decommissioned, :boolean, default: false
     attribute :date_created_start, :date
     attribute :date_created_end, :date
     attribute :date_modified_start, :date
@@ -19,6 +20,7 @@ module Admin
         statuses << 'deposited' if status_deposited
         statuses << 'first_draft' if status_first_draft
         statuses << 'version_draft' if status_version_draft
+        statuses << 'decommissioned' if status_decommissioned
       end
     end
   end

--- a/app/views/admin/collection_reports/new.html.erb
+++ b/app/views/admin/collection_reports/new.html.erb
@@ -52,7 +52,11 @@
           <div class="form-check">
             <%= form.check_box :status_deposited, class: 'form-check-input' %>
             <%= form.label :status_deposited, "Deposited", class: 'form-check-label' %>
-          </div>                
+          </div>
+          <div class="form-check">
+            <%= form.check_box :status_decommissioned, class: 'form-check-input' %>
+            <%= form.label :status_decommissioned, "Decommissioned", class: 'form-check-label' %>
+          </div>
           <%= form.submit "Submit", class: 'btn btn-primary my-3' %>
       <% end %>
 
@@ -67,6 +71,7 @@
           <%= form.hidden_field :status_first_draft %>
           <%= form.hidden_field :status_version_draft %>
           <%= form.hidden_field :status_deposited %>
+          <%= form.hidden_field :status_decommissioned %>
           <%= form.submit "Download", class: 'btn btn-success my-3' %>
         <% end %>
       <% end %>

--- a/spec/components/admin/all_collections_row_component_spec.rb
+++ b/spec/components/admin/all_collections_row_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Admin::AllCollectionsRowComponent, type: :component do
   context 'with a new, first draft collection' do
     let(:collection_version) { build_stubbed(:collection_version, :first_draft) }
 
-    it 'adds the Draft to the label' do
+    it 'adds Draft to the label' do
       expect(rendered.to_html).to include 'Draft'
       expect(rendered.to_html).not_to include 'Version Draft'
     end
@@ -20,8 +20,16 @@ RSpec.describe Admin::AllCollectionsRowComponent, type: :component do
   context 'with a version draft collection' do
     let(:collection_version) { build_stubbed(:collection_version, :version_draft) }
 
-    it 'adds the Version Draft to the label' do
+    it 'adds Version Draft to the label' do
       expect(rendered.to_html).to include 'Version Draft'
+    end
+  end
+
+  context 'with a decommissioned collection' do
+    let(:collection_version) { build_stubbed(:collection_version, :decommissioned) }
+
+    it 'adds Decommission to the label' do
+      expect(rendered.to_html).to include 'Decommissioned'
     end
   end
 
@@ -31,6 +39,7 @@ RSpec.describe Admin::AllCollectionsRowComponent, type: :component do
     it 'does not change the label' do
       expect(rendered.to_html).not_to include 'Version Draft'
       expect(rendered.to_html).not_to include 'Draft'
+      expect(rendered.to_html).not_to include 'Decommissioned'
     end
   end
 

--- a/spec/factories/object_states.rb
+++ b/spec/factories/object_states.rb
@@ -28,6 +28,10 @@ FactoryBot.define do
     # events { [build(:event, event_type: 'reject', description: 'Add something to make it pop.')] }
   end
 
+  trait :decommissioned do
+    state { 'decommissioned' }
+  end
+
   trait :new do
     state { 'new' }
   end

--- a/spec/features/decommission_collection_spec.rb
+++ b/spec/features/decommission_collection_spec.rb
@@ -23,6 +23,9 @@ RSpec.describe 'Decommission a collection', js: true do
       expect(page).to have_content 'Decommissioned'
     end
 
+    # State
+    expect(find('span.state').text).to eq 'Decommissioned'
+
     # Event added
     within '#events' do
       expect(page).to have_content 'Decommissioned'

--- a/spec/services/admin/collections_report_query_spec.rb
+++ b/spec/services/admin/collections_report_query_spec.rb
@@ -18,12 +18,15 @@ RSpec.describe Admin::CollectionsReportQuery do
     collection.save!
     collection
   end
+  # rubocop:disable Metrics/LineLength
+  let!(:collection4) { create(:collection_version_with_collection, state: 'decommissioned', name: 'dCollection').collection }
+  # rubocop:enable Metrics/LineLength
 
   context 'without filters' do
     let(:report) { Admin::CollectionsReport.new }
 
     it 'returns all collections sorted by name' do
-      expect(request).to eq [collection3, collection1, collection2]
+      expect(request).to eq [collection3, collection1, collection2, collection4]
     end
   end
 
@@ -51,11 +54,19 @@ RSpec.describe Admin::CollectionsReportQuery do
     end
   end
 
+  context 'with decommissioned status' do
+    let(:report) { Admin::CollectionsReport.new(status_decommissioned: true) }
+
+    it 'returns decommissioned collections' do
+      expect(request).to eq [collection4]
+    end
+  end
+
   context 'with date created start' do
     let(:report) { Admin::CollectionsReport.new(date_created_start: '2019-01-01') }
 
     it 'returns collections created after the date' do
-      expect(request).to eq [collection1, collection2]
+      expect(request).to eq [collection1, collection2, collection4]
     end
   end
 
@@ -71,7 +82,7 @@ RSpec.describe Admin::CollectionsReportQuery do
     let(:report) { Admin::CollectionsReport.new(date_modified_start: '2019-06-01') }
 
     it 'returns collections modified after the date' do
-      expect(request).to eq [collection1, collection2]
+      expect(request).to eq [collection1, collection2, collection4]
     end
   end
 

--- a/spec/services/admin/collections_report_query_spec.rb
+++ b/spec/services/admin/collections_report_query_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe Admin::CollectionsReportQuery do
     collection.save!
     collection
   end
-  # rubocop:disable Metrics/LineLength
-  let!(:collection4) { create(:collection_version_with_collection, state: 'decommissioned', name: 'dCollection').collection }
-  # rubocop:enable Metrics/LineLength
+  let!(:collection4) do
+    create(:collection_version_with_collection, state: 'decommissioned', name: 'dCollection').collection }
+  end
 
   context 'without filters' do
     let(:report) { Admin::CollectionsReport.new }

--- a/spec/services/admin/collections_report_query_spec.rb
+++ b/spec/services/admin/collections_report_query_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Admin::CollectionsReportQuery do
     collection
   end
   let!(:collection4) do
-    create(:collection_version_with_collection, state: 'decommissioned', name: 'dCollection').collection }
+    create(:collection_version_with_collection, state: 'decommissioned', name: 'dCollection').collection
   end
 
   context 'without filters' do


### PR DESCRIPTION
~~HOLD for PO review~~  Amy approved.

## Why was this change made? 🤔

Addressed tweaks to UI for decommissioned collections 

Fixes #2748

### Add Decommissioned to collection show page

![image](https://user-images.githubusercontent.com/96775/192864120-8034bb93-730b-4a17-abbe-941de490eb3a.png)

### Add Decommissioned to Admin All Collections table

![image](https://user-images.githubusercontent.com/96775/192864392-eb196400-ec5f-49d1-9bc7-9de792f3e1c3.png)

### Add Decommissioned to collection report filters

![image](https://user-images.githubusercontent.com/96775/192864545-ed367349-a74b-42d0-98f2-3e4ef2faa285.png)


## How was this change tested? 🤨

locally, and specs written

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


