### PR TITLE
Delete on Preservation Object storage should be a no-op

### DIFF
--- a/app/services/active_storage/service/sdr_service.rb
+++ b/app/services/active_storage/service/sdr_service.rb
@@ -15,6 +15,14 @@ module ActiveStorage
         end
       end
 
+      def delete(key)
+        # This is called by ActiveSupport when #destroy is called on AttachedFile due to our use
+        # of ActiveStorage for file storage.  This can happen during a decommission of a work.
+        # We define this as a noop, because we explictly do not want the related preservation
+        # file to be destroyed in this case and we do not want the NotImplementedError exception
+        # to be raised to HB either: https://app.honeybadger.io/projects/77112/faults/88770594
+      end
+
       def self.encode_key(druid, version, filepath)
         [druid, version, filepath].join('/')
       end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2785 ~~we aren't sure why a `PurgeJob` was called -- expectation is that you should not be able to purge something in preservation already.  This change will hopefully alert HB in a way that gives us a more useful backtrace than what is in~~ This makes the call to delete the Preservation file object a noop, which is what we intend.  Will prevent this HB alert from happening in the future: https://app.honeybadger.io/projects/77112/faults/88770594

## How was this change tested? 🤨

CI