### PR TITLE
preservation-client is now version 5.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,12 +64,12 @@ gem 'jsbundling-rails', '~> 0.1.9'
 gem 'lograge', '~> 0.11.2'
 gem 'okcomputer'
 gem 'pg'
+gem 'preservation-client', '~> 5.0'
 gem 'propshaft'
 gem 'pry'
 gem 'redis', '~> 4.0'
 # TODO: Deal with this
 # pinned because 2.6.0 broke the build: [Reform] Your :populator did not return a Reform::Form instance for `authors`.
-gem 'preservation-client', '~> 4.0'
 gem 'reform', '~> 2.5.0'
 gem 'reform-rails', '~> 0.2.0'
 gem 'sdr-client', '~> 0.94'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,7 +319,7 @@ GEM
     patience_diff (1.2.0)
       optimist (~> 3.0)
     pg (1.4.3)
-    preservation-client (4.0.0)
+    preservation-client (5.0.0)
       activesupport (>= 4.2, < 8)
       faraday (~> 2.0)
       moab-versioning (~> 5.0)
@@ -567,7 +567,7 @@ DEPENDENCIES
   multi_json
   okcomputer
   pg
-  preservation-client (~> 4.0)
+  preservation-client (~> 5.0)
   propshaft
   pry
   puma (~> 5.6, >= 5.6.4)


### PR DESCRIPTION
## Why was this change made? 🤔

preservation-client version 5.0 removes primary_moab_location, which is never used here, thus perfectly safe here.

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


