### PR TITLE
Check version before deposit update.

### DIFF
--- a/app/models/concerns/work_version_state_machine.rb
+++ b/app/models/concerns/work_version_state_machine.rb
@@ -6,6 +6,10 @@ module WorkVersionStateMachine
 
   included do
     state_machine initial: :new do
+      state :depositing do
+        validate :correct_version
+      end
+
       before_transition WorkObserver.method(:before_transition)
 
       after_transition WorkObserver.method(:after_transition)
@@ -70,6 +74,14 @@ module WorkVersionStateMachine
       event :decommission do
         transition all => :decommissioned
       end
+    end
+
+    def correct_version
+      return unless work.druid
+
+      return if Repository.valid_version?(druid: work.druid, h2_version: version)
+
+      errors.add(:version, 'must be one greater than the version in SDR')
     end
   end
 end

--- a/app/services/repository.rb
+++ b/app/services/repository.rb
@@ -8,4 +8,10 @@ class Repository
     cocina_json = JSON.parse(cocina_str)
     Cocina::Models.build(cocina_json)
   end
+
+  # @return [boolean] true if H2 version is one greater than SDR version.
+  def self.valid_version?(druid:, h2_version:)
+    cocina_obj = find(druid)
+    cocina_obj.version == h2_version - 1
+  end
 end

--- a/spec/jobs/assign_pid_job_spec.rb
+++ b/spec/jobs/assign_pid_job_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe AssignPidJob do
   let(:message) { { model: }.to_json }
   let(:druid) { 'druid:bc123df4567' }
 
+  before do
+    allow(Repository).to receive(:valid_version?).and_return(true)
+  end
+
   context "with a work that doesn't have a doi (and hasn't requested one)" do
     let(:model) do
       Cocina::Models::DRO.new(externalIdentifier: druid,

--- a/spec/jobs/deposit_complete_job_spec.rb
+++ b/spec/jobs/deposit_complete_job_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe DepositCompleteJob do
     let(:message) { "{\"druid\":\"#{work.druid}\"}" }
 
     before do
+      allow(Repository).to receive(:valid_version?).and_return(true)
       collection.update(head: collection_version)
       work.update(head: work_version)
     end

--- a/spec/requests/edit_work_spec.rb
+++ b/spec/requests/edit_work_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Updating an existing work' do
   before do
     allow(Settings).to receive(:allow_sdr_content_changes).and_return(true)
     work.update(head: work_version)
+    allow(Repository).to receive(:valid_version?).and_return(true)
   end
 
   context 'with an authenticated user' do

--- a/spec/services/repository_spec.rb
+++ b/spec/services/repository_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Repository do
+  describe 'valid_version?' do
+    subject(:valid_version?) { described_class.valid_version?(druid:, h2_version:) }
+
+    let(:druid) { 'druid:bb652bq1296' }
+
+    let(:cocina_obj) { instance_double(Cocina::Models::DRO, version: 1) }
+
+    before do
+      allow(described_class).to receive(:find).and_return(cocina_obj)
+    end
+
+    context 'when the H2 version is one greater than the SDR version' do
+      let(:h2_version) { 2 }
+
+      it 'returns true' do
+        expect(valid_version?).to be true
+        expect(described_class).to have_received(:find).with(druid)
+      end
+    end
+
+    context 'when the H2 version is not one greater than the SDR version' do
+      let(:h2_version) { 1 }
+
+      it 'returns false' do
+        expect(valid_version?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #2792

## Why was this change made? 🤔
To prevent H2 and SDR versions from getting out of sync.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit
