### PR TITLE
query local database when not in production for account service lookup

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -12,13 +12,15 @@ class AccountsController < ApplicationController
 
   private
 
-  # Does a lookup from the account service in production mode, otherwise returns a stub value
+  # Does a lookup from the account service in production mode, otherwise examines local database for users
   def lookup
     return AccountService.new.fetch(params[:id]) if Rails.env.production?
-    return {} unless params[:id].start_with?('jcoyne85')
+
+    user = User.where('email like ?', "#{params[:id]}%").first
+    return {} unless user
 
     {
-      'name' => 'Coyne, Justin Michael',
+      'name' => user.name || user.sunetid,
       'description' => 'Digital Library Systems and Services, Digital Library Software Engineer - Web & Infrastructure'
     }
   end

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe 'Accounts', type: :request do
       end
 
       it 'displays the data' do
-        get '/accounts/jcoyne85'
+        get "/accounts/#{user.sunetid}"
         expect(response).to have_http_status(:ok)
-        expect(response.body).to eq '{"name":"Coyne, Justin Michael",' \
+        expect(response.body).to eq "{\"name\":\"#{user.sunetid}\"," \
                                     '"description":"Digital Library Systems and Services, ' \
                                     'Digital Library Software Engineer - Web \\u0026 Infrastructure"}'
       end
@@ -53,9 +53,9 @@ RSpec.describe 'Accounts', type: :request do
       end
 
       it 'displays the data' do
-        get '/accounts/jcoyne85'
+        get "/accounts/#{user.sunetid}"
         expect(response).to have_http_status(:ok)
-        expect(response.body).to eq '{"name":"Coyne, Justin Michael",' \
+        expect(response.body).to eq "{\"name\":\"#{user.sunetid}\"," \
                                     '"description":"Digital Library Systems and Services, ' \
                                     'Digital Library Software Engineer - Web \\u0026 Infrastructure"}'
       end


### PR DESCRIPTION
## Why was this change made? 🤔

Because we would like to add more than just jcoyne as a depositor.

i.e. this allows us to add anyone has a depositor/reviewer on a ticket that is in our localhost database

## How was this change tested? 🤨

Localhost