### PR TITLE
Skip check_version in dev

### DIFF
--- a/app/models/concerns/work_version_state_machine.rb
+++ b/app/models/concerns/work_version_state_machine.rb
@@ -77,6 +77,9 @@ module WorkVersionStateMachine
     end
 
     def correct_version
+      # Skip this check since no SDR API in dev.
+      return if Rails.env.development?
+
       return unless work.druid
 
       return if Repository.valid_version?(druid: work.druid, h2_version: version)

--- a/spec/features/mediated_deposit_versioning_spec.rb
+++ b/spec/features/mediated_deposit_versioning_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Edit a new version of a work in a collection using mediated depo
   before do
     work.update(head: work_version)
     create(:attached_file, :with_file, work_version:)
+    allow(Repository).to receive(:valid_version?).and_return(true)
   end
 
   context 'when reviewer rejects, then approves work' do

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -350,9 +350,11 @@ RSpec.describe WorkVersion do
         let(:work_version) { create(:work_version, :version_draft) }
 
         let(:druid) { 'druid:bb652bq1296' }
+        let(:cocina_obj) { instance_double(Cocina::Models::DRO, version: 1) }
 
         before do
           work_version.work.druid = druid
+          allow(SdrClient::Find).to receive(:run).and_return(cocina_obj)
         end
 
         context 'when valid version' do


### PR DESCRIPTION
## Why was this change made? 🤔
To get tests to pass in local development 

## How was this change tested? 🤨
Local testing

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


