### PR TITLE
[HOLD] Support recording and displaying paths of uploaded files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,8 @@ gem 'redis', '~> 4.0'
 # pinned because 2.6.0 broke the build: [Reform] Your :populator did not return a Reform::Form instance for `authors`.
 gem 'reform', '~> 2.5.0'
 gem 'reform-rails', '~> 0.2.0'
-gem 'sdr-client', '~> 0.94'
+# gem 'sdr-client', '~> 0.94'
+gem 'sdr-client', github: 'sul-dlss/sdr-client', branch: 'hfs'
 gem 'sidekiq', '~> 6.1'
 gem 'sneakers', '~> 2.11' # rabbitMQ background processing
 gem 'state_machines-activerecord'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/sul-dlss/sdr-client.git
+  revision: 9c3fe56620b153497c11e8db4b62d3b396bb3c84
+  branch: hfs
+  specs:
+    sdr-client (0.96.0)
+      activesupport
+      cocina-models (~> 0.86.0)
+      dry-monads
+      faraday (>= 0.16)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -447,11 +458,6 @@ GEM
     ruby-next-core (0.15.3)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    sdr-client (0.96.0)
-      activesupport
-      cocina-models (~> 0.86.0)
-      dry-monads
-      faraday (>= 0.16)
     serverengine (2.1.1)
       sigdump (~> 0.2.2)
     set (1.0.3)
@@ -589,7 +595,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
-  sdr-client (~> 0.94)
+  sdr-client!
   sidekiq (~> 6.1)
   simplecov
   sneakers (~> 2.11)

--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -13,29 +13,32 @@
                                   bs_toggle: 'modal',
                                   bs_target: '#contactUsModal' }) %>
       </p>
-        <div data-controller="dropzone" data-dropzone-max-file-size="10000" data-dropzone-max-files="1000">
-        <fieldset>
-          <div class="dropzone dropzone-default" data-dropzone-target="container">
-            <%= form.file_field :files, multiple: true, direct_upload: true,
-                                data: { dropzone_target: 'input' } %>
-            <div class="dz-message needsclick text-secondary">
-              <p>Drop files here</p>
+      <div data-controller="dropzone" data-dropzone-max-file-size="10000" data-dropzone-max-files="1000">
+        <div data-controller="dropzone2" data-dropzone-max-file-size="10000" data-dropzone2-max-files="1000" data-dropzone2-folders=true>
+          <fieldset>
+            <div class="dropzone dropzone-default" data-dropzone-target="container" data-dropzone2-target="container">
+              <%= form.file_field :files, multiple: true, direct_upload: true,
+                                  data: { dropzone_target: 'input', dropzone2_target: 'input' } %>
+              <div class="dz-message needsclick text-secondary">
+                <p>Drop files here</p>
+              </div>
             </div>
-          </div>
-          <span style="margin: .7rem">or</span> <button type="button" class="dz-clickable btn btn-outline-primary">Choose files</button>
-          <div class="invalid-feedback" data-dropzone-target="feedback">You must attach a file<%= error_message %></div>
-          <div class="dropzone-previews" data-dropzone-target="previewsContainer">
-            <%= form.fields_for :attached_files do |file_form| %>
+            <span style="margin: .7rem">or</span> <button type="button" class="dz-clickable btn btn-outline-primary">Choose files</button>
+            <span style="margin: .7rem">or</span> <button type="button" class="dz-clickable-folders btn btn-outline-primary">Choose folders</button>
+            <div class="invalid-feedback" data-dropzone-target="feedback" data-dropzone2-target="feedback">You must attach a file<%= error_message %></div>
+            <div class="dropzone-previews" data-dropzone-target="previewsContainer" data-dropzone2-target="previewsContainer">
+              <%= form.fields_for :attached_files do |file_form| %>
+                <%= render Works::FileRowComponent.new(form: file_form) %>
+              <% end %>
+            </div>
+          </fieldset>
+
+          <template data-dropzone-target='template' data-dropzone2-target='template'>
+            <%= form.fields_for :attached_files, AttachedFile.new, child_index: 'TEMPLATE_RECORD' do |file_form| %>
               <%= render Works::FileRowComponent.new(form: file_form) %>
             <% end %>
-          </div>
-        </fieldset>
-
-        <template data-dropzone-target='template'>
-          <%= form.fields_for :attached_files, AttachedFile.new, child_index: 'TEMPLATE_RECORD' do |file_form| %>
-            <%= render Works::FileRowComponent.new(form: file_form) %>
-          <% end %>
-        </template>
+          </template>
+        </div>
       </div>
     </div>
   </div>

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -202,7 +202,7 @@ class WorksController < ObjectsController
                      :release, 'embargo_date(1i)', 'embargo_date(2i)', 'embargo_date(3i)',
                      :agree_to_terms, :assign_doi, :globus,
                      subtype: [],
-                     attached_files_attributes: %i[_destroy id label hide file],
+                     attached_files_attributes: %i[_destroy id label hide path file],
                      authors_attributes: %i[_destroy id full_name first_name last_name role_term weight orcid],
                      contributors_attributes: %i[_destroy id full_name first_name last_name role_term weight orcid],
                      contact_emails_attributes: %i[_destroy id email],

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -91,6 +91,7 @@ class DraftWorkForm < Reform::Form
              on: :work_version do
     property :id, type: Dry::Types['params.nil'] | Dry::Types['params.integer']
     property :label
+    property :path
     property :hide, type: Dry::Types['params.bool']
     # The file property is only necessary if there is a server side validation error and we need to re-render the form.
     property :file, virtual: true

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,5 @@ const application = Application.start()
 application.load(definitions)
 
 application.register('autocomplete', Autocomplete)
+import DropzoneController from "./dropzone_controller"
+application.register("dropzone2", DropzoneController)

--- a/app/jobs/deposit_job.rb
+++ b/app/jobs/deposit_job.rb
@@ -18,8 +18,6 @@ class DepositJob < BaseDepositJob
 
     new_request_dro = update_dro_with_file_identifiers(request_dro, work_version)
 
-    Rails.logger.info(new_request_dro.to_json)
-
     case new_request_dro
     when Cocina::Models::RequestDRO
       create(new_request_dro, work_version)
@@ -39,10 +37,11 @@ class DepositJob < BaseDepositJob
     # Only uploading new or changed files
     blobs_to_upload = staged_blobs(work_version)
     upload_responses = perform_upload(blobs_to_upload)
-    Rails.logger.info("Upload responses: #{upload_responses}")
+    # The upload response have the actual blob filepath, but need the cocina filename to update the DRO.
+    updated_upload_responses = update_upload_responses_with_cocina_filename(work_version, upload_responses)
     # Update with any new externalIdentifiers assigned by SDR API during upload.
     SdrClient::Deposit::UpdateDroWithFileIdentifiers.update(request_dro:,
-                                                            upload_responses:)
+                                                            upload_responses: updated_upload_responses)
   end
 
   def create(new_request_dro, work_version)
@@ -60,6 +59,8 @@ class DepositJob < BaseDepositJob
                                            version_description: work_version.version_description.presence)
   end
 
+  # @return [Array<Files::DirectUploadResponse>] the responses from the server for the uploads
+  # The filename is the actual blob filepath
   def perform_upload(blobs)
     SdrClient::Deposit::UploadFiles.upload(file_metadata: build_file_metadata(blobs),
                                            logger: Rails.logger,
@@ -70,9 +71,10 @@ class DepositJob < BaseDepositJob
     @connection ||= SdrClient::Connection.new(url: Settings.sdr_api.url)
   end
 
+  # @return [Hash<String, SdrClient::Deposit::Files::DirectUploadRequest] actual blob filepath, DirectUploadRequest
   def build_file_metadata(blobs)
     blobs.each_with_object({}) do |blob, obj|
-      obj[filename(blob.key)] = SdrClient::Deposit::Files::DirectUploadRequest.new(
+      obj[blob_filepath_for(blob)] = SdrClient::Deposit::Files::DirectUploadRequest.new(
         checksum: blob.checksum,
         byte_size: blob.byte_size,
         content_type: clean_content_type(blob.content_type),
@@ -86,11 +88,26 @@ class DepositJob < BaseDepositJob
     content_type&.split(';')&.first
   end
 
-  def filename(key)
-    ActiveStorage::Blob.service.path_for(key)
+  def blob_filepath_for(blob)
+    ActiveStorage::Blob.service.path_for(blob.key)
   end
 
+  # @return [Array<ActiveStorage::Blob>] the blobs that are not in SDR
   def staged_blobs(work_version)
-    work_version.staged_files.map { |af| af.file.blob }
+    work_version.staged_files.map { |attached_file| attached_file.file.blob }
+  end
+
+  def blob_filepath_to_cocina_filename(work_version)
+    # attached_file.path contains the cocina filename (e.g. 'dir1/file1.txt')
+    work_version.staged_files.to_h do |attached_file|
+      [blob_filepath_for(attached_file.file.blob), attached_file.path]
+    end
+  end
+
+  def update_upload_responses_with_cocina_filename(work_version, upload_responses)
+    blob_filepath_map = blob_filepath_to_cocina_filename(work_version)
+    upload_responses.each do |upload_response|
+      upload_response.filename = blob_filepath_map[upload_response.filename]
+    end
   end
 end

--- a/app/jobs/deposit_job.rb
+++ b/app/jobs/deposit_job.rb
@@ -18,6 +18,8 @@ class DepositJob < BaseDepositJob
 
     new_request_dro = update_dro_with_file_identifiers(request_dro, work_version)
 
+    Rails.logger.info(new_request_dro.to_json)
+
     case new_request_dro
     when Cocina::Models::RequestDRO
       create(new_request_dro, work_version)
@@ -37,6 +39,7 @@ class DepositJob < BaseDepositJob
     # Only uploading new or changed files
     blobs_to_upload = staged_blobs(work_version)
     upload_responses = perform_upload(blobs_to_upload)
+    Rails.logger.info("Upload responses: #{upload_responses}")
     # Update with any new externalIdentifiers assigned by SDR API during upload.
     SdrClient::Deposit::UpdateDroWithFileIdentifiers.update(request_dro:,
                                                             upload_responses:)

--- a/app/models/attached_file.rb
+++ b/app/models/attached_file.rb
@@ -10,7 +10,7 @@ class AttachedFile < ApplicationRecord
   # end
 
   delegate :blob, to: :file
-  delegate :filename, :content_type, :byte_size, to: :blob
+  delegate :content_type, :byte_size, to: :blob
 
   # This is a temporary method that makes the blobs that haven't yet been updated
   # appear to be from preservation, but it only changes the blob in memory.
@@ -35,6 +35,10 @@ class AttachedFile < ApplicationRecord
     ActiveStorage::Service::SdrService.accessible?(file.blob) ||
       work_version.deposited? ||
       !changed_in_this_version?
+  end
+
+  def filename
+    path.presence || blob.filename
   end
 
   private

--- a/app/services/cocina_generator/structural/file_generator.rb
+++ b/app/services/cocina_generator/structural/file_generator.rb
@@ -44,7 +44,7 @@ module CocinaGenerator
       end
 
       def filename
-        blob.filename.to_s # File.basename(filename(blob.key))
+        attached_file.filename.to_s
       end
 
       def external_identifier

--- a/db/migrate/20221013194032_add_path_to_attached_file.rb
+++ b/db/migrate/20221013194032_add_path_to_attached_file.rb
@@ -1,0 +1,5 @@
+class AddPathToAttachedFile < ActiveRecord::Migration[7.0]
+  def change
+    add_column :attached_files, :path, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -183,7 +183,8 @@ CREATE TABLE public.attached_files (
     hide boolean DEFAULT false NOT NULL,
     work_version_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    path character varying
 );
 
 
@@ -1347,6 +1348,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220824225302'),
 ('20220829114247'),
 ('20220901184555'),
-('20220914211415');
+('20220914211415'),
+('20221013194032');
 
 

--- a/spec/factories/attached_files.rb
+++ b/spec/factories/attached_files.rb
@@ -4,10 +4,15 @@ FactoryBot.define do
   factory :attached_file do
     label { 'MyString' }
     hide { false }
+    path { nil }
     work_version
   end
 
   trait :with_file do
     file { fixture_file_upload(Rails.root.join('spec/fixtures/files/sul.svg'), 'image/svg+xml') }
+  end
+
+  trait :with_path do
+    path { 'images/sul.svg' }
   end
 end

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -16,16 +16,20 @@ RSpec.describe WorkForm do
         content_type: 'image/svg+xml'
       )
     end
+    let(:file_path) { "my/directory/#{blob.signed_id}" }
 
     after do
       blob.destroy
     end
 
     it 'populates attached_files' do
-      form.validate(attached_files: [{ 'label' => 'hello', 'hide' => true, 'file' => blob.signed_id }])
+      form.validate(
+        attached_files: [{ 'label' => 'hello', 'path' => file_path, 'hide' => true, 'file' => blob.signed_id }]
+      )
 
       expect(form.attached_files.size).to eq 1
       expect(form.attached_files.first.label).to eq 'hello'
+      expect(form.attached_files.first.path).to eq(file_path)
       expect(form.attached_files.first.hide).to be true
       expect(form.attached_files.first.model.file.blob_id).to eq blob.id
     end

--- a/spec/models/attached_file_spec.rb
+++ b/spec/models/attached_file_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe AttachedFile, type: :model do
     expect(attached_file.label).to be_present
   end
 
+  it 'has no path' do
+    expect(attached_file.path).to be_nil
+  end
+
   it 'has a hide bit' do
     expect(attached_file).not_to be_hide
   end
@@ -21,5 +25,17 @@ RSpec.describe AttachedFile, type: :model do
     expect(attached_file.filename).to eq(attached_file.file.attachment.blob.filename)
     expect(attached_file.content_type).to eq(attached_file.file.attachment.blob.content_type)
     expect(attached_file.byte_size).to eq(attached_file.file.attachment.blob.byte_size)
+  end
+
+  context 'with a path' do
+    subject(:attached_file) { build(:attached_file, :with_file, :with_path) }
+
+    it 'has a path' do
+      expect(attached_file.path).to be_present
+    end
+
+    it 'uses the path for the filename' do
+      expect(attached_file.filename).to eq(attached_file.path)
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

[HOLD] keeping around in case there is useful code ... likely will close when work is complete

Connects to sul-dlss/dor-services-app#4256

This commit adds a new attribute to the AttachedFile model in order to record, and later display, the full source path of an uploaded file (if supplied). It modifies the Dropzone controller to display paths (if present) instead of base filenames, and makes the duplicate filename checker smart about this. It also fixes a bug with duplicate filename checking caused by https://github.com/sul-dlss/happy-heron/pull/2583/files#diff-81e6b6427ea21d10a73dc41dd6b55cbdccd6002a200ddf5cce9b5e26daee19f6R9.

## How was this change tested? 🤨

CI, and tested in a deployed env
