### PR TITLE
Ensure SDR client is authenticated in Repository class

### DIFF
--- a/app/jobs/base_deposit_job.rb
+++ b/app/jobs/base_deposit_job.rb
@@ -4,14 +4,7 @@
 class BaseDepositJob < ApplicationJob
   protected
 
-  # This allows a login using credentials from the config gem.
-  class LoginFromSettings
-    def self.run
-      { email: Settings.sdr_api.email, password: Settings.sdr_api.password }
-    end
-  end
-
   def login
-    SdrClient::Login.run(url: Settings.sdr_api.url, login_service: LoginFromSettings)
+    SdrClientAuthenticator.login
   end
 end

--- a/app/jobs/deposit_job.rb
+++ b/app/jobs/deposit_job.rb
@@ -10,6 +10,7 @@ class DepositJob < BaseDepositJob
     Honeybadger.context({ work_version_id: work_version.id, druid:,
                           work_id: work_version.work.id, depositor_sunet: work_version.work.depositor.sunetid })
 
+    # NOTE: this login ensures `Repository.find` and various SdrClient::* calls below all have a valid token
     perform_login
 
     cocina_obj = Repository.find(druid) if druid

--- a/app/services/repository.rb
+++ b/app/services/repository.rb
@@ -4,6 +4,7 @@
 class Repository
   # @return [Cocina::Models::DRO]
   def self.find(druid)
+    ensure_logged_in!
     cocina_str = SdrClient::Find.run(druid, url: Settings.sdr_api.url, logger: Rails.logger)
     cocina_json = JSON.parse(cocina_str)
     Cocina::Models.build(cocina_json)
@@ -14,4 +15,9 @@ class Repository
     cocina_obj = find(druid)
     cocina_obj.version == h2_version - 1
   end
+
+  def self.ensure_logged_in!
+    SdrClientAuthenticator.login
+  end
+  private_class_method :ensure_logged_in!
 end

--- a/app/services/sdr_client_authenticator.rb
+++ b/app/services/sdr_client_authenticator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Authenticate SDR client connections
+class SdrClientAuthenticator
+  # This allows a login using credentials from the config gem.
+  class LoginFromSettings
+    def self.run
+      { email: Settings.sdr_api.email, password: Settings.sdr_api.password }
+    end
+  end
+
+  def self.login
+    SdrClient::Login.run(url: Settings.sdr_api.url, login_service: LoginFromSettings)
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2806

This commit fixes a bug caused by the Repository class having a hidden dependency on a valid SDR client token. Moving authentication into the Repository class ensures we are not bitten by `SdrClient::Find::Failed` "Signature has expired" errors.


## How was this change tested? 🤨

CI
