### PR TITLE
Remove sidekiq logging configuration.

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,8 +2,6 @@
 
 Sidekiq.configure_server do |config|
   config.redis = { url: ENV.fetch('REDIS_URL', Settings.redis_url) }
-  ActiveRecord::Base.logger = Sidekiq.logger
-  Rails.logger = Sidekiq.logger
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
## Why was this change made? 🤔
Sidekiq wasn't getting logged anywhere. With this removed, sidekiq logs to production.log.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


