### PR TITLE
Allow version validation to accomodate PURL reservation.

### DIFF
--- a/app/services/repository.rb
+++ b/app/services/repository.rb
@@ -13,6 +13,10 @@ class Repository
   # @return [boolean] true if H2 version is one greater than SDR version.
   def self.valid_version?(druid:, h2_version:)
     cocina_obj = find(druid)
+
+    # This occurs when reserving a PURL.
+    return true if cocina_obj.version == 1 && h2_version == 1
+
     cocina_obj.version == h2_version - 1
   end
 

--- a/spec/services/repository_spec.rb
+++ b/spec/services/repository_spec.rb
@@ -58,10 +58,18 @@ RSpec.describe Repository do
     end
 
     context 'when the H2 version is not one greater than the SDR version' do
-      let(:h2_version) { 1 }
+      let(:h2_version) { 3 }
 
       it 'returns false' do
         expect(valid_version?).to be false
+      end
+    end
+
+    context 'when the H2 version and SDR version are 1' do
+      let(:h2_version) { 1 }
+
+      it 'returns true' do
+        expect(valid_version?).to be true
       end
     end
   end


### PR DESCRIPTION
closes #2816

## Why was this change made? 🤔
Version validation was disallowing PURL reservation.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit, stage

