### PR TITLE
readme should indicate you need to clear sessions when changing roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Then run the asset pipeline and webserver:
 bin/dev
 ```
 
-You can change user or roles by setting environment variables:
+You can change user or roles by setting environment variables.  Note that you may need to clear your browser
+session cookies to pick up the new roles set here, as they may be cached from a previous session.
+
 ```shell
 REMOTE_USER=auser@stanford.edu ROLES=dlss:hydrus-app-administrators bin/dev
 ```


### PR DESCRIPTION
## Why was this change made? 🤔

~~To me it looks like the `bin/dev` script sets a user and role by default and does not allow them to be overridden, as is currently suggested by the README.  This was confusing me during recent debugging until I noticed it.~~

Add note about clearing session when changing roles

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


