### PR TITLE
add sdr-contact email for form submission

### DIFF
--- a/app/mailers/helps_mailer.rb
+++ b/app/mailers/helps_mailer.rb
@@ -11,7 +11,7 @@ class HelpsMailer < ApplicationMailer
     @why_contact = params[:why_contact]
     @collections = params[:collections]
 
-    mail(to: 'sdr-support@jirasul.stanford.edu',
+    mail(to: ['sdr-support@jirasul.stanford.edu', 'sdr-contact@lists.stanford.edu'],
          from: email,
          subject:)
   end

--- a/spec/mailers/helps_mailer_spec.rb
+++ b/spec/mailers/helps_mailer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe HelpsMailer, type: :mailer do
 
     it 'renders the headers' do
       expect(mail.subject).to eq 'who should marry Rosina?'
-      expect(mail.to).to eq ['sdr-support@jirasul.stanford.edu']
+      expect(mail.to).to eq ['sdr-support@jirasul.stanford.edu', 'sdr-contact@lists.stanford.edu']
       expect(mail.from).to eq ['razor@haircuts.it']
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

#2821 shows that emails do not appear to be making through to Jira.  This adds the sdr-contact list as an alternate location which allows email to get through even if Jira integraiton is not working (though of course, will still be a problem if the sever can't send emails at all).

Re-evaluate if still needed once #2821 is fixed.  

See https://stanfordlib.slack.com/archives/C09M7P91R/p1666380457093009

## How was this change tested? 🤨

Localhost and updated test


