### PR TITLE
Do not redirect to the root when a depositor views a collection

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -4,7 +4,7 @@
 class CollectionsController < ObjectsController
   before_action :authenticate_user!
   before_action :ensure_sdr_updatable
-  verify_authorized except: %i[deposit_button delete_button edit_link dashboard]
+  verify_authorized except: %i[admin dashboard delete_button deposit_button edit_link]
 
   def edit
     collection = Collection.find(params[:id])
@@ -87,7 +87,6 @@ class CollectionsController < ObjectsController
 
   def admin
     @collection = Collection.find(params[:id])
-    authorize! @collection
   end
 
   private


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2825 by not enforcing authorization before rendering the admin component which causes a redirect to root.

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


