### PR TITLE
Clean content type when depositing.

### DIFF
--- a/app/jobs/deposit_job.rb
+++ b/app/jobs/deposit_job.rb
@@ -69,11 +69,18 @@ class DepositJob < BaseDepositJob
 
   def build_file_metadata(blobs)
     blobs.each_with_object({}) do |blob, obj|
-      obj[filename(blob.key)] = SdrClient::Deposit::Files::DirectUploadRequest.new(checksum: blob.checksum,
-                                                                                   byte_size: blob.byte_size,
-                                                                                   content_type: blob.content_type,
-                                                                                   filename: blob.filename.to_s)
+      obj[filename(blob.key)] = SdrClient::Deposit::Files::DirectUploadRequest.new(
+        checksum: blob.checksum,
+        byte_size: blob.byte_size,
+        content_type: clean_content_type(blob.content_type),
+        filename: blob.filename.to_s
+      )
     end
+  end
+
+  def clean_content_type(content_type)
+    # ActiveStorage is expecting "application/x-stata-dta" not "application/x-stata-dta;version=14"
+    content_type&.split(';')&.first
   end
 
   def filename(key)


### PR DESCRIPTION
closes #2833

## Why was this change made? 🤔
Prod bug causing deposits to fail.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit, QA, prod
