### PR TITLE
Pin sdr-client to 0.96.x to work around HFS bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem 'redis', '~> 4.0'
 # pinned because 2.6.0 broke the build: [Reform] Your :populator did not return a Reform::Form instance for `authors`.
 gem 'reform', '~> 2.5.0'
 gem 'reform-rails', '~> 0.2.0'
-gem 'sdr-client', '~> 0.94'
+gem 'sdr-client', '~> 0.96.0'  # TODO: Unpin and fix the tests with >= 0.97
 gem 'sidekiq', '~> 6.1'
 gem 'sneakers', '~> 2.11' # rabbitMQ background processing
 gem 'state_machines-activerecord'

--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem 'redis', '~> 4.0'
 # pinned because 2.6.0 broke the build: [Reform] Your :populator did not return a Reform::Form instance for `authors`.
 gem 'reform', '~> 2.5.0'
 gem 'reform-rails', '~> 0.2.0'
-gem 'sdr-client', '~> 0.96.0'  # TODO: Unpin and fix the tests with >= 0.97
+gem 'sdr-client', '~> 0.97'
 gem 'sidekiq', '~> 6.1'
 gem 'sneakers', '~> 2.11' # rabbitMQ background processing
 gem 'state_machines-activerecord'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -447,7 +447,7 @@ GEM
     ruby-next-core (0.15.3)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    sdr-client (0.96.0)
+    sdr-client (0.97.0)
       activesupport
       cocina-models (~> 0.86.0)
       dry-monads
@@ -589,7 +589,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
-  sdr-client (~> 0.96.0)
+  sdr-client (~> 0.97)
   sidekiq (~> 6.1)
   simplecov
   sneakers (~> 2.11)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -589,7 +589,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
-  sdr-client (~> 0.94)
+  sdr-client (~> 0.96.0)
   sidekiq (~> 6.1)
   simplecov
   sneakers (~> 2.11)


### PR DESCRIPTION
## Why was this change made? 🤔

To get H2 working again.

## How was this change tested? 🤨

CI + infra-int-tests
