### PR TITLE
prepare for multiple selectable upload types

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -2,10 +2,10 @@
   <header>Add your files *</header>
 
   <div class="form-check" data-complex-radio-target="selection">
-    <%= form.radio_button :globus, false, class: 'form-check-input',
+    <%= form.radio_button :upload_type, 'browser', class: 'form-check-input',
       data: { action: 'complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility' }
     %>
-    <%= form.label :globus, 'Upload files', class: 'form-check-label fw-semibold' %>
+    <%= form.label :upload_type, 'Upload files', class: 'form-check-label fw-semibold' %>
     <div id="uploaded-files-panel" data-file-uploads-target="fileUploads">
       <p>All file types are accepted. If you have a deposit that is over 10GB, or
         have any trouble with adding your files,
@@ -40,10 +40,10 @@
     </div>
   </div>
   <div class="form-check pt-3" data-complex-radio-target="selection">
-    <%= form.radio_button :globus, true, class: 'form-check-input', 'data-file-uploads-target': 'globusRadioButton',
+    <%= form.radio_button :upload_type, 'globus', class: 'form-check-input', 'data-file-uploads-target': 'globusRadioButton',
       data: { action: 'complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility' }
     %>
-    <%= form.label :globus, 'I have uploaded my files to a Globus endpoint provided to me by SDR staff.', class: 'form-check-label fw-semibold' %>
+    <%= form.label :upload_type, 'I have uploaded my files to a Globus endpoint provided to me by SDR staff.', class: 'form-check-label fw-semibold' %>
     <p><em>Only select this option if you have already discussed Globus with SDR staff.</em></p>
   </div>
 </section>

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -200,7 +200,7 @@ class WorksController < ObjectsController
                      :abstract, :citation_auto, :citation, :default_citation,
                      :access, :license, :version_description,
                      :release, 'embargo_date(1i)', 'embargo_date(2i)', 'embargo_date(3i)',
-                     :agree_to_terms, :assign_doi, :globus,
+                     :agree_to_terms, :assign_doi, :upload_type,
                      subtype: [],
                      attached_files_attributes: %i[_destroy id label hide file],
                      authors_attributes: %i[_destroy id full_name first_name last_name role_term weight orcid],

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -96,7 +96,7 @@ class DraftWorkForm < Reform::Form
     property :file, virtual: true
     property :_destroy, virtual: true, type: Dry::Types['params.nil'] | Dry::Types['params.bool']
   end
-  property :globus, on: :work_version
+  property :upload_type, on: :work_version
 
   collection :contact_emails, populator: ContactEmailsPopulator.new(:contact_emails, ContactEmail),
                               prepopulator: ->(*) { contact_emails << ContactEmail.new if contact_emails.blank? },
@@ -163,7 +163,7 @@ class DraftWorkForm < Reform::Form
   def save_model
     super
     # if the user selects globus uploads, we cannot have any attached files
-    work_version.attached_files.destroy_all if work_version.globus
+    work_version.attached_files.destroy_all if work_version.globus?
     dedupe_keywords
     work.update(head: work_version)
   end

--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -7,9 +7,7 @@ class WorkForm < DraftWorkForm
   validates :abstract, :access, :title, presence: true, allow_nil: false
   validates :keywords, length: { minimum: 1, message: 'Please add at least one keyword.' }
   validates :attached_files, length: { minimum: 1, message: 'Please add at least one file.' },
-                             unless: lambda {
-                                       ::ActiveRecord::Type::Boolean.new.cast(globus)
-                                     }
+                             if: -> { upload_type == 'browser' }
   validates :contact_emails, length: { minimum: 1, message: 'Please add at least contact email.' }
   validates :license, presence: true, inclusion: { in: License.license_list }
   validates :authors, length: { minimum: 1, message: 'Please add at least one author.' }

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -41,6 +41,13 @@ class WorkVersion < ApplicationRecord
     world: 'world'
   }
 
+  # provides helper method to infer upload type... e.g. work_version.globus?
+  enum upload_type: {
+    browser: 'browser',
+    globus: 'globus',
+    zipfile: 'zipfile'
+  }
+
   LINK_TEXT = ':link will be inserted here automatically when available:'
   DOI_TEXT = ':DOI will be inserted here automatically when available:'
 

--- a/app/services/work_observer.rb
+++ b/app/services/work_observer.rb
@@ -42,7 +42,7 @@ class WorkObserver
             mailer.deposited_email
           end
     job.deliver_later
-    mailer.globus_deposited_email.deliver_later if work_version.globus && Settings.notify_admin_list
+    mailer.globus_deposited_email.deliver_later if work_version.globus? && Settings.notify_admin_list
   end
 
   def self.after_rejected(work_version, _transition)

--- a/cypress/spec/create_work.cy.js
+++ b/cypress/spec/create_work.cy.js
@@ -45,7 +45,7 @@ describe('Create work', () => {
       cy.get('div.invalid-feedback').should('contain', 'You must attach a file')
 
       // now select globus upload option
-      cy.get('#work_globus_true').check()
+      cy.get('#work_upload_type_globus').check()
 
       // now try to deposit again
       cy.get('input.btn[value="Deposit"]').click()

--- a/db/migrate/20221115215744_work_upload_type.rb
+++ b/db/migrate/20221115215744_work_upload_type.rb
@@ -1,0 +1,22 @@
+class WorkUploadType < ActiveRecord::Migration[7.0]
+  def up
+    # new column to store which type of upload mechanism the user wants for their files
+    add_column :work_versions, :upload_type, :string, default: 'browser', null: false
+
+    # update state of new column based on previous globus true/false column
+    WorkVersion.where(globus: true).update_all(upload_type: 'globus')
+    WorkVersion.where(globus: false).update_all(upload_type: 'browser')
+
+    # remove globus column
+    remove_column :work_versions, :globus
+  end
+
+  def down
+    add_column :work_versions, :globus, :boolean, default: false, null: false
+
+    WorkVersion.where(upload_type: 'globus').update_all(globus: true)
+    WorkVersion.where(upload_type: 'browser').update_all(globus: false)
+
+    remove_column :work_versions, :upload_type
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -587,7 +587,7 @@ CREATE TABLE public.work_versions (
     work_id bigint NOT NULL,
     version_description character varying,
     published_at timestamp(6) without time zone,
-    globus boolean DEFAULT false NOT NULL
+    upload_type character varying DEFAULT 'browser'::character varying NOT NULL
 );
 
 
@@ -1347,6 +1347,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220824225302'),
 ('20220829114247'),
 ('20220901184555'),
-('20220914211415');
+('20220914211415'),
+('20221115215744');
 
 

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     state { 'first_draft' }
     version_description { 'initial version' }
     published_at { Time.zone.parse('2019-01-01') }
-    globus { false }
+    upload_type { 'browser' }
     work
 
     factory :valid_work_version do

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -338,24 +338,26 @@ RSpec.describe WorkForm do
       blob.destroy
     end
 
-    it 'does not validate when no files and globus is false' do
-      form.validate(attached_files: [], globus: false)
+    it 'does not validate when no files and upload is not globus' do
+      form.validate(attached_files: [], upload_type: 'browser')
       expect(form).not_to be_valid
       expect(messages).to eq ['Please add at least one file.']
     end
 
-    it 'validates when has files and globus is true' do
-      form.validate(attached_files: [{ 'label' => 'hello', 'hide' => true, 'file' => blob.signed_id }], globus: true)
+    it 'validates when has files and upload is globus' do
+      form.validate(attached_files: [{ 'label' => 'hello', 'hide' => true, 'file' => blob.signed_id }],
+                    upload_type: 'globus')
       expect(messages).to be_empty
     end
 
-    it 'validates when no files and globus is true' do
-      form.validate(attached_files: [], globus: true)
+    it 'validates when no files and upload is globus' do
+      form.validate(attached_files: [], upload_type: 'globus')
       expect(messages).to be_empty
     end
 
-    it 'validate when has files and globus is false' do
-      form.validate(attached_files: [{ 'label' => 'hello', 'hide' => true, 'file' => blob.signed_id }], globus: false)
+    it 'validate when has files and upload is not globus' do
+      form.validate(attached_files: [{ 'label' => 'hello', 'hide' => true, 'file' => blob.signed_id }],
+                    upload_type: 'browser')
       expect(messages).to be_empty
     end
   end

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -439,7 +439,7 @@ RSpec.describe WorkVersion do
       end
 
       context 'when a deposit with globus' do
-        let(:work_version) { build(:work_version, :depositing, work:, globus: true) }
+        let(:work_version) { build(:work_version, :depositing, work:, upload_type: 'globus') }
         let(:collection) { create(:collection) }
 
         before do

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -852,7 +852,7 @@ RSpec.describe 'Create a new work' do
             contact_emails_attributes: contact_emails,
             abstract: 'test abstract',
             attached_files_attributes: {},
-            globus: 'true',
+            upload_type: 'globus',
             authors_attributes: authors,
             keywords_attributes: {
               '0' => { '_destroy' => 'false', 'label' => 'Feminism', 'uri' => 'http://id.worldcat.org/fast/922671' }
@@ -885,7 +885,8 @@ RSpec.describe 'Create a new work' do
           expect(response).to have_http_status(:found)
           work_version = Work.last.head
           expect(work_version.attached_files).to be_empty
-          expect(work_version.globus).to be true
+          expect(work_version.globus?).to be true
+          expect(work_version.upload_type).to eq 'globus'
           expect(work_version.state).to eq 'depositing'
         end
       end

--- a/spec/requests/edit_work_spec.rb
+++ b/spec/requests/edit_work_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe 'Updating an existing work' do
         end
 
         context 'with globus upload selected' do
-          before { work_params[:globus] = true }
+          before { work_params[:upload_type] = 'globus' }
 
           context 'when deposited' do
             it 'removes any attached files' do

--- a/spec/services/work_version_event_description_builder_spec.rb
+++ b/spec/services/work_version_event_description_builder_spec.rb
@@ -409,7 +409,7 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
               'citation' => '',
               'default_citation' => 'true',
               'agree_to_terms' => '0',
-              'globus' => 'false',
+              'upload_type' => 'browser',
               'authors_attributes' => {
                 '0' => {
                   '_destroy' => '',


### PR DESCRIPTION
## Why was this change made? 🤔

In this workcycle, we will need to expand the options available for users to select from when adding files to an object from two choices (browser upload and globus) to three choices: 

- browser upload 
- globus
- single ZIP file to be expanded

Our current database schema uses a `globus` boolean type column on the `work_version` to designate if an object uses globus uploads or not.  This PR switches the name of the column, makes it an enum to allow for more than two options, and fixes up the code to use the new schema.

This is pre-requisite work for #2843 (and possibly others).

## How was this change tested? 🤨

Exiting test suite (updated as needed) and localhost


