### PR TITLE
do not have a default upload option selected

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -2,7 +2,7 @@
   <header>Add your files *</header>
 
   <div class="form-check" data-complex-radio-target="selection">
-    <%= form.radio_button :upload_type, 'browser', class: 'form-check-input',
+    <%= form.radio_button :upload_type, 'browser', class: 'form-check-input', 'data-file-uploads-target': 'browserRadioButton',
       data: { action: 'complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus' }
     %>
     <%= form.label :upload_type, 'Upload files', class: 'form-check-label fw-semibold' %>

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -36,11 +36,11 @@ class DraftWorkForm < Reform::Form
   validates_with EmbargoDateParts,
                  if: proc { |form| form.user_can_set_availability? && form.release == 'embargo' }
 
-  validates_with CreatedDateParts,
-                 if: proc { |form| form.created_type == 'range' }
+  validates_with CreatedDateParts, if: proc { |form| form.created_type == 'range' }
 
   validates :subtype, work_subtype: true
   validates :work_type, presence: true, work_type: true
+  validates :upload_type, presence: true
   validate :unique_filenames
 
   delegate :user_can_set_availability?, to: :collection

--- a/app/javascript/controllers/file_uploads_controller.js
+++ b/app/javascript/controllers/file_uploads_controller.js
@@ -1,13 +1,13 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  static targets = ["fileUploads", "globusRadioButton"]
+  static targets = ["fileUploads", "globusRadioButton", "browserRadioButton"]
 
   connect() {
     this.updatePanelVisibility()
   }
 
   updatePanelVisibility(_event) {
-    this.fileUploadsTarget.hidden = this.globusRadioButtonTarget.checked
+    this.fileUploadsTarget.hidden = !this.browserRadioButtonTarget.checked
   }
 }

--- a/cypress/spec/create_work_version.cy.js
+++ b/cypress/spec/create_work_version.cy.js
@@ -12,6 +12,10 @@ describe('Create work version', () => {
 
     it('deposits a work correctly after uploading a file', () => {
       cy.visit(`/works/${work_id}/edit`)
+
+      // select browser upload option
+      cy.get('#work_upload_type_browser').check()
+
       // try to deposit
       cy.get('input.btn[value="Deposit"]').click()
 
@@ -68,7 +72,7 @@ describe('Create work version', () => {
 
       // deposit button should be disabled
       cy.get('input.btn[value="Deposit"]').should('be.disabled')
-      
+
       // switch back to file upload option
       cy.get('#work_upload_type_browser').check()
 

--- a/db/migrate/20221117233130_no_upload_type_default.rb
+++ b/db/migrate/20221117233130_no_upload_type_default.rb
@@ -1,0 +1,11 @@
+class NoUploadTypeDefault < ActiveRecord::Migration[7.0]
+  def up
+    change_column_default(:work_versions, :upload_type, nil)
+    change_column_null(:work_versions, :upload_type, true)
+  end
+
+  def down
+    change_column_default(:work_versions, :upload_type, 'browser')
+    change_column_null(:work_versions, :upload_type, false)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -587,7 +587,7 @@ CREATE TABLE public.work_versions (
     work_id bigint NOT NULL,
     version_description character varying,
     published_at timestamp(6) without time zone,
-    upload_type character varying DEFAULT 'browser'::character varying NOT NULL
+    upload_type character varying
 );
 
 
@@ -1348,6 +1348,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220829114247'),
 ('20220901184555'),
 ('20220914211415'),
-('20221115215744');
+('20221115215744'),
+('20221117233130');
 
 

--- a/spec/features/create_new_draft_work_spec.rb
+++ b/spec/features/create_new_draft_work_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
     click_button 'Continue'
 
     fill_in 'Title of deposit', with: 'My Draft'
+    choose 'work_upload_type_browser'
 
     click_button 'Save as draft'
 
@@ -33,6 +34,27 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
     expect(page).to have_content 'Draft - Not deposited'
     expect(page).to have_content WorkVersion::LINK_TEXT.to_s
     expect(page).to have_content WorkVersion::DOI_TEXT.to_s
+  end
+
+  context 'when no upload type is selected' do
+    it 'does not allow user to save a draft' do
+      visit dashboard_path
+
+      click_button '+ Deposit to this collection'
+
+      expect(page).to have_content 'What type of content will you deposit?'
+
+      find('label', text: 'Sound').click
+
+      click_button 'Continue'
+
+      fill_in 'Title of deposit', with: 'My Draft'
+
+      click_button 'Save as draft'
+
+      expect(page).to have_content "Upload type can't be blank"
+      expect(current_url).to include "/collections/#{collection.id}/works/new?work_type=sound"
+    end
   end
 
   context 'when collection does not allow DOI assignment' do
@@ -50,6 +72,7 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
       click_button 'Continue'
 
       fill_in 'Title of deposit', with: 'My Draft'
+      choose 'work_upload_type_browser'
 
       click_button 'Save as draft'
 

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
           select 'month', from: 'Created month'
           select 'day', from: 'Created day'
 
+          choose 'work_upload_type_browser'
           page.attach_file(Rails.root.join('spec/fixtures/files/sul.svg')) do
             click_button('Choose files')
           end
@@ -187,6 +188,7 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
 
           click_button 'Continue'
 
+          choose 'work_upload_type_browser'
           page.attach_file(Rails.root.join('spec/fixtures/files/sul.svg')) do
             click_button('Choose files')
           end
@@ -299,6 +301,7 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
           fill_in 'Created year', with: ''
           fill_in 'Publication year', with: ''
 
+          choose 'work_upload_type_browser'
           page.attach_file(Rails.root.join('spec/fixtures/files/sul.svg')) do
             click_button('Choose files')
           end

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -290,7 +290,8 @@ RSpec.describe 'Create a new work' do
                 '_destroy' => '',
                 'url' => ''
               } },
-              'license' => 'CC-BY-NC-4.0'
+              'license' => 'CC-BY-NC-4.0',
+              upload_type: 'browser'
             },
             'commit' => 'Save as draft',
             'controller' => 'works',
@@ -326,6 +327,7 @@ RSpec.describe 'Create a new work' do
               '0' => { '_destroy' => 'false', 'label' => 'Feminism', 'uri' => 'http://id.worldcat.org/fast/922671' }
             },
             license: 'CC0-1.0',
+            upload_type: 'browser',
             release: 'immediate',
             access: 'stanford'
           }
@@ -399,6 +401,7 @@ RSpec.describe 'Create a new work' do
             abstract: '',
             license: License.license_list.first,
             work_type: 'text',
+            upload_type: 'browser',
             release: 'immediate'
           }
         end
@@ -438,6 +441,7 @@ RSpec.describe 'Create a new work' do
               abstract: '',
               license: default_license,
               work_type: 'text',
+              upload_type: 'browser',
               release: 'immediate'
             }
           end
@@ -462,6 +466,7 @@ RSpec.describe 'Create a new work' do
               abstract: '',
               license: default_license,
               work_type: 'text',
+              upload_type: 'browser',
               release: 'immediate'
             }
           end
@@ -485,6 +490,7 @@ RSpec.describe 'Create a new work' do
               title: '',
               abstract: '',
               license:,
+              upload_type: 'browser',
               work_type: 'text',
               release: 'immediate'
             }
@@ -511,6 +517,7 @@ RSpec.describe 'Create a new work' do
             title: '',
             abstract: '',
             license: License.license_list.first,
+            upload_type: 'browser',
             work_type: 'text',
             release: 'immediate',
             citation: 'manual one',
@@ -557,6 +564,7 @@ RSpec.describe 'Create a new work' do
               '0' => { '_destroy' => 'false', 'label' => 'Feminism', 'uri' => 'http://id.worldcat.org/fast/922671' }
             },
             license: 'CC0-1.0',
+            upload_type: 'browser',
             release: 'immediate'
           }
         end
@@ -631,6 +639,7 @@ RSpec.describe 'Create a new work' do
               '0' => { '_destroy' => 'false', 'label' => 'Feminism', 'uri' => 'http://id.worldcat.org/fast/922671' }
             },
             license: 'CC0-1.0',
+            upload_type: 'browser',
             release: 'embargo',
             'embargo(1i)': '2030',
             'embargo(2i)': '09',
@@ -701,6 +710,7 @@ RSpec.describe 'Create a new work' do
               '0' => { '_destroy' => 'false', 'label' => 'Feminism', 'uri' => 'http://id.worldcat.org/fast/922671' }
             },
             license: 'CC0-1.0',
+            upload_type: 'browser',
             release: 'embargo'
           }
         end
@@ -766,7 +776,8 @@ RSpec.describe 'Create a new work' do
             keywords_attributes: {
               '0' => { '_destroy' => 'false', 'label' => 'Feminism', 'uri' => 'http://id.worldcat.org/fast/922671' }
             },
-            license: 'CC0-1.0'
+            license: 'CC0-1.0',
+            upload_type: 'browser'
           }
         end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2859 -- do not select any radio button by default when creating a new work, which forces the user to select one

We still need to validate that something is selected to save as draft, but we cannot enforce at the model level because PURL reservations still need to be created without a selection.

## How was this change tested? 🤨

Localhost, added a test, modified existing tests to pre-select the previous "browser upload" default.