### PR TITLE
T2846 disable deposit for globus upload

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -3,7 +3,7 @@
 
   <div class="form-check" data-complex-radio-target="selection">
     <%= form.radio_button :upload_type, 'browser', class: 'form-check-input',
-      data: { action: 'complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility' }
+      data: { action: 'complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus' }
     %>
     <%= form.label :upload_type, 'Upload files', class: 'form-check-label fw-semibold' %>
     <div id="uploaded-files-panel" data-file-uploads-target="fileUploads">
@@ -39,11 +39,22 @@
       </div>
     </div>
   </div>
-  <div class="form-check pt-3" data-complex-radio-target="selection">
-    <%= form.radio_button :upload_type, 'globus', class: 'form-check-input', 'data-file-uploads-target': 'globusRadioButton',
-      data: { action: 'complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility' }
-    %>
-    <%= form.label :upload_type, 'I have uploaded my files to a Globus endpoint provided to me by SDR staff.', class: 'form-check-label fw-semibold' %>
-    <p><em>Only select this option if you have already discussed Globus with SDR staff.</em></p>
-  </div>
+  <% if Settings.globus_upload %>
+    <div class="form-check pt-3" data-complex-radio-target="selection">
+      <%= form.radio_button :upload_type, 'globus', class: 'form-check-input', 'data-file-uploads-target': 'globusRadioButton', 'data-deposit-button-target': 'globusRadioButton',
+        data: { action: 'complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus'}
+      %>
+      <%= form.label :upload_type, "Upload one or more files (>10GB) via Globus web-based transfer software.", class: 'form-check-label fw-semibold' %>
+      Use single sign-on to activate your account first if you don't already have one, and then return here to complete this form.
+      <p>**Please check your email for further instructions on how to proceed with your deposit of files into Globus.**</p>
+    </div>
+  <% else %>
+    <div class="form-check pt-3" data-complex-radio-target="selection">
+      <%= form.radio_button :upload_type, 'globus', class: 'form-check-input', 'data-file-uploads-target': 'globusRadioButton',
+        data: { action: 'complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility'}
+      %>
+      <%= form.label :upload_type, 'I have uploaded my files to a Globus endpoint provided to me by SDR staff.', class: 'form-check-label fw-semibold' %>
+      <p><em>Only select this option if you have already discussed Globus with SDR staff.</em></p>
+    </div>
+  <% end %>
 </section>

--- a/app/components/works/buttons_component.html.erb
+++ b/app/components/works/buttons_component.html.erb
@@ -23,6 +23,7 @@
     <%= form.submit 'Save as draft', class: 'btn btn-primary', id: 'save-draft-button',
                                      data: { action: 'unsaved-changes#allowFormSubmission' } %>
     <%= form.submit submit_button_label, class: 'btn btn-primary',
-                                         data: { action: 'unsaved-changes#allowFormSubmission' } %>
+                                         disabled: false,
+                                         data: { action: 'unsaved-changes#allowFormSubmission', deposit_button_target: 'depositButton' } %>
   </div>
 </div>

--- a/app/components/works/form_component.html.erb
+++ b/app/components/works/form_component.html.erb
@@ -1,7 +1,7 @@
 <h1><%= page_title %></h1>
 <%= form_with model: work_form, url: url,
     data: {
-      controller: 'auto-citation unsaved-changes',
+      controller: data_controllers,
       action: 'change->unsaved-changes#changed beforeunload@window->unsaved-changes#leavingPage turbo:before-visit@window->unsaved-changes#leavingPage',
       auto_citation_purl: purl,
       auto_citation_doi: doi_field

--- a/app/components/works/form_component.rb
+++ b/app/components/works/form_component.rb
@@ -43,5 +43,9 @@ module Works
 
       WorkVersion::DOI_TEXT
     end
+
+    def data_controllers
+      Settings.globus_upload ? 'auto-citation unsaved-changes deposit-button' : 'auto-citation unsaved-changes'
+    end
   end
 end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -5,6 +5,7 @@
 class WorksController < ObjectsController
   before_action :authenticate_user!
   before_action :ensure_sdr_updatable
+  before_action :set_globus_based_on_param
   verify_authorized except: %i[delete_button edit_button]
 
   def index
@@ -198,7 +199,7 @@ class WorksController < ObjectsController
                      :abstract, :citation_auto, :citation, :default_citation,
                      :access, :license, :version_description,
                      :release, 'embargo_date(1i)', 'embargo_date(2i)', 'embargo_date(3i)',
-                     :agree_to_terms, :assign_doi, :upload_type,
+                     :agree_to_terms, :assign_doi, :upload_type, :globus,
                      subtype: [],
                      attached_files_attributes: %i[_destroy id label hide file],
                      authors_attributes: %i[_destroy id full_name first_name last_name role_term weight orcid],
@@ -226,6 +227,10 @@ class WorksController < ObjectsController
 
     flash[:error] = errors.join("\n")
     redirect_to dashboard_path, status: :see_other
+  end
+
+  def set_globus_based_on_param
+    Settings.globus_upload = true if params[:globus] == 'true'
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/javascript/controllers/deposit_button_controller.js
+++ b/app/javascript/controllers/deposit_button_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = ["depositButton", "globusRadioButton"]
+
+  connect() {
+    this.updateDepositButtonStatus()
+  }
+
+  updateDepositButtonStatus(_event) {
+    this.depositButtonTarget.disabled = this.globusRadioButtonTarget.checked
+  }
+}

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,6 +36,7 @@ external_links:
 
 # feature flag
 allow_sdr_content_changes: true
+globus_upload: false
 
 authorization_group_header: HTTP_X_GROUPS
 first_name_header: HTTP_X_PERSON_NAME

--- a/cypress/spec/create_work_version.cy.js
+++ b/cypress/spec/create_work_version.cy.js
@@ -1,4 +1,4 @@
-describe('Create work', () => {
+describe('Create work version', () => {
     let work_id
 
     beforeEach(() => {
@@ -7,13 +7,11 @@ describe('Create work', () => {
       ]).then((results) => {
         cy.log(results[0])
         work_id = results[0].work_id
-
-        cy.visit(`/works/${work_id}/edit`)
-    })
+      })
     })
 
     it('deposits a work correctly after uploading a file', () => {
-
+      cy.visit(`/works/${work_id}/edit`)
       // try to deposit
       cy.get('input.btn[value="Deposit"]').click()
 
@@ -37,7 +35,7 @@ describe('Create work', () => {
     })
 
     it('deposits a work correctly if globus is selected (without the need to upload a file)', () => {
-
+      cy.visit(`/works/${work_id}/edit`)
       // try to deposit
       cy.get('input.btn[value="Deposit"]').click()
 
@@ -53,5 +51,28 @@ describe('Create work', () => {
       // successful deposit!
       cy.url().should('include', `/works/${work_id}/next_step`)
       cy.contains('You have successfully deposited your work')
+    })
+
+    it('is not able to deposit when globus feature enabled and globus upload option is selected ', () => {
+      // globus feature flag is set
+      cy.visit(`/works/${work_id}/edit?globus=true`)
+
+      // try to deposit
+      cy.get('input.btn[value="Deposit"]').click()
+
+      // there is a message telling us we need to upload a file
+      cy.get('div.invalid-feedback').should('contain', 'You must attach a file')
+
+      // now select globus upload option
+      cy.get('#work_upload_type_globus').check()
+
+      // deposit button should be disabled
+      cy.get('input.btn[value="Deposit"]').should('be.disabled')
+      
+      // switch back to file upload option
+      cy.get('#work_upload_type_browser').check()
+
+      // deposit button should be enabled
+      cy.get('input.btn[value="Deposit"]').should('be.enabled')
     })
 })

--- a/spec/components/works/add_files_component_spec.rb
+++ b/spec/components/works/add_files_component_spec.rb
@@ -26,4 +26,15 @@ RSpec.describe Works::AddFilesComponent do
       expect(rendered.css('button.dz-clickable').to_html).to include('Choose files')
     end
   end
+
+  context 'when globus feature enabled' do
+    before do
+      allow(Settings).to receive(:globus_upload).and_return true
+    end
+
+    it 'shows the globus upload option' do
+      expect(rendered.to_html).to include('via Globus web-based transfer software')
+      expect(rendered.to_html).not_to include('I have uploaded my files to a Globus endpoint')
+    end
+  end
 end

--- a/spec/components/works/buttons_component_spec.rb
+++ b/spec/components/works/buttons_component_spec.rb
@@ -49,4 +49,19 @@ RSpec.describe Works::ButtonsComponent do
       expect(rendered.css('input[value="Save as draft"]')).to be_present
     end
   end
+
+  context 'when globus feature enabled' do
+    let(:work) { build(:work, collection: build(:collection, id: 7)) }
+    let(:work_version) { build(:work_version, work:, state: 'new') }
+
+    before do
+      allow(Settings).to receive(:globus_upload).and_return true
+    end
+
+    it 'updates the deposit button' do
+      expect(rendered.css('input[value="Deposit"]')).to be_present
+      expect(rendered.css('input[value="Deposit"][attribute="disabled"]')).not_to be_present
+      expect(rendered.to_html).to include('data-deposit-button-target="depositButton"')
+    end
+  end
 end

--- a/spec/components/works/form_component_spec.rb
+++ b/spec/components/works/form_component_spec.rb
@@ -27,4 +27,24 @@ RSpec.describe Works::FormComponent do
     expect(rendered.to_html)
       .not_to include("What's changing?")
   end
+
+  context 'when globus feature enabled' do
+    before do
+      allow(Settings).to receive(:globus_upload).and_return true
+    end
+
+    it 'uses the deposit-button controller' do
+      expect(rendered.to_html).to include('auto-citation unsaved-changes deposit-button')
+    end
+  end
+
+  context 'when globus feature is not enabled' do
+    before do
+      allow(Settings).to receive(:globus_upload).and_return false
+    end
+
+    it 'does not use the deposit-button controller' do
+      expect(rendered.to_html).not_to include('auto-citation unsaved-changes deposit-button')
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #2846 and #2874 to disable the Deposit button when someone selects the new globus upload option. There is a feature flag so this will not show up unless desired. Also partially implements #2844 by adding new text for the new globus upload radio button option.

## How was this change tested? 🤨
Unit tests, added cypress test for feature flag, deployed to QA.

h2 integration test on QA passed, although it took a couple of retries. 

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


