### PR TITLE
Warn user and notify admin on version mismatch.

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -35,6 +35,12 @@ class WorksController < ObjectsController
     work_version = work.head
     authorize! work_version
 
+    if invalid_version_for_edit?(work, work_version)
+      WorksMailer.with(work:).version_mismatch_email.deliver_later
+      flash.notice = I18n.t('work.flash.cannot_edit')
+      return redirect_back(fallback_location: dashboard_path), status: :see_other
+    end
+
     @form = WorkForm.new(work_version:, work: work_version.work)
     @form.prepopulate!
   end
@@ -284,6 +290,16 @@ class WorksController < ObjectsController
 
   def fetch_globus_files?
     params[:work][:fetch_globus_files] == 'true'
+  end
+
+  def invalid_version_for_edit?(work, work_version)
+    # Development does not have SDR API, so stubbing out the version check
+    if Rails.env.development?
+      # This allows for local testing by adding ?invalid_version=true
+      return params[:invalid_version].present?
+    end
+
+    work.druid && !Repository.valid_version?(druid: work.druid, h2_version: work_version.version)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/mailers/works_mailer.rb
+++ b/app/mailers/works_mailer.rb
@@ -99,4 +99,12 @@ class WorksMailer < ApplicationMailer
     @work = @work_version.work
     mail(to: @user.email, subject: 'Upload your files to the SDR using Globus')
   end
+
+  def version_mismatch_email
+    @work = params[:work]
+    @user = @work.owner
+    @work_title = @work.head.title
+    @collection_name = @work.collection_name
+    mail(to: Settings.notifications.admin_email, subject: 'An H2 version mismatch error has occurred')
+  end
 end

--- a/app/views/works_mailer/version_mismatch_email.erb
+++ b/app/views/works_mailer/version_mismatch_email.erb
@@ -1,0 +1,6 @@
+<p>Dear Administrator,</p>
+
+<%= @user.sunetid %> has attempted to edit <%= @work_title %> (<%= @work.id %>) in the <%= @collection_name %> collection and has encountered a version mismatch error.
+
+
+<p>The Stanford Digital Repository Team</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,7 @@ en:
       work_not_moved: "Unable to move the work because the collection or work changed. Please try again."
       globus_setup_not_complete: "You have not completed your Globus setup yet. Please verify you have a Globus account and then try again."
       globus_setup_complete: "Please check for email for further instructions on how to proceed with your Globus deposit."
+      cannot_edit: Your item can not currently be modified. Please contact SDR staff at sdr-contact@lists.stanford.edu or via the help link above for assistance.
   terms_of_use: User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.
   collection:
     actions: Actions

--- a/spec/mailers/works_mailer_spec.rb
+++ b/spec/mailers/works_mailer_spec.rb
@@ -336,4 +336,23 @@ RSpec.describe WorksMailer do
       expect(mail.body).to include 'Please transfer your files to the above location in Globus'
     end
   end
+
+  describe 'version_mismatch_email' do
+    let(:work) { build_stubbed(:work, head: work_version, collection:) }
+    let(:work_version) { build_stubbed(:work_version) }
+    let(:collection) { build_stubbed(:collection, head: collection_version) }
+    let(:collection_version) { build_stubbed(:collection_version) }
+    let(:mail) { described_class.with(work:, user: a_user).version_mismatch_email }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq 'An H2 version mismatch error has occurred'
+      expect(mail.to).to eq ['h2-administrators@lists.stanford.edu']
+      expect(mail.from).to eq ['no-reply@sdr.stanford.edu']
+    end
+
+    it 'renders body' do
+      expect(mail.body).to include 'Dear Administrator'
+      expect(mail.body).to include 'encountered a version mismatch error'
+    end
+  end
 end


### PR DESCRIPTION
HOLD for UI decision from Amy (?)

closes #2864

## Why was this change made? 🤔
Prevent version mismatch mayhem.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit, QA
