### PR TITLE
[HOLD] File description update

### DIFF
--- a/app/services/cocina_generator/structural/file_generator.rb
+++ b/app/services/cocina_generator/structural/file_generator.rb
@@ -4,16 +4,17 @@ module CocinaGenerator
   module Structural
     # This generates a Cocina File for a work
     class FileGenerator
-      def self.generate(work_version:, attached_file:)
-        new(work_version:, attached_file:).generate
+      def self.generate(work_version:, attached_file:, external_identifier: nil)
+        new(work_version:, attached_file:, external_identifier:).generate
       end
 
-      def initialize(work_version:, attached_file:)
+      def initialize(work_version:, attached_file:, external_identifier:)
         @work_version = work_version
         @attached_file = attached_file
+        @external_identifier = external_identifier
       end
 
-      attr_reader :work_version, :attached_file
+      attr_reader :work_version, :attached_file, :external_identifier
 
       def generate
         return nil unless blob
@@ -40,15 +41,15 @@ module CocinaGenerator
       end
 
       def file_attributes
-        request_file_attributes.merge(externalIdentifier: external_identifier)
+        request_file_attributes.merge(externalIdentifier: create_external_identifier)
       end
 
       def filename
         blob.filename.to_s # File.basename(filename(blob.key))
       end
 
-      def external_identifier
-        "#{work_version.work.druid}/#{filename}" if work_version.work.druid
+      def create_external_identifier
+        external_identifier || ("#{work_version.work.druid}/#{filename}" if work_version.work.druid)
       end
 
       def administrative

--- a/app/services/cocina_generator/structural/file_generator.rb
+++ b/app/services/cocina_generator/structural/file_generator.rb
@@ -11,7 +11,7 @@ module CocinaGenerator
       def initialize(work_version:, attached_file:, external_identifier:)
         @work_version = work_version
         @attached_file = attached_file
-        @external_identifier = external_identifier
+        @external_identifier = external_identifier # may be nil
       end
 
       attr_reader :work_version, :attached_file, :external_identifier

--- a/app/services/cocina_generator/structural/generator.rb
+++ b/app/services/cocina_generator/structural/generator.rb
@@ -24,22 +24,45 @@ module CocinaGenerator
       end
 
       # 1) Start with the existing filesets from SDR
-      # 1) Only keep the filesets that have attached_files that are preserved
-      # 2) Add new filesets that have attached_files in the local store.
+      # 2) Only keep the filesets that have attached_files that are preserved
+      # 3) Add new filesets that have attached_files in the local store.
       def build_filesets
         filesets = find_preserved_filesets
-        filesets + work_version.staged_files.map.with_index(filesets.size + 1) { |af, n| build_fileset(af, n) }
+        # new step to check for label differences between old cocina and preserved_files
+        existing_filesets, updated_filesets = check_labels(filesets)
+        existing_filesets + updated_filesets.map.with_index(existing_filesets.size + 1) { |af, n| rebuild_fileset(af, n) } +
+          work_version.staged_files.map.with_index(filesets.size + 1) { |af, n| build_fileset(af, n) }
       end
 
       # @return [Array<Cocina::FileSet>] the list of items where all files are already preserved.
       def find_preserved_filesets
         return [] unless cocina_obj
 
+        # need to find preserved_filesets and update their label with the work version's description for the file if it's different.
+        # h2 will only have one file per fileset
         cocina_obj.structural.contains.select do |fileset|
-          existing_file_names = Set.new(fileset.structural.contains.map(&:filename))
-          preserved_file_names = Set.new(work_version.preserved_files.map(&:filename).map(&:to_s))
-          preserved_file_names.superset?(existing_file_names)
+          existing_file_name = fileset.structural.contains.first.filename
+          preserved_file_names = work_version.preserved_files.map(&:filename).map(&:to_s)
+          preserved_file_names.include?(existing_file_name)
         end
+      end
+
+      def check_labels(preserved_filesets)
+        # The label is the only thing that might change.
+        # @return [Array<Cocina::FileSet>] list of unchanged files' cocina, and an array of changed preserved_files to get rebuilt.
+        files = preserved_filesets.partition do |fileset|
+          # find the preserved file with a filename that matches the cocina fileset
+          preserved_file = work_version.preserved_files.select { |file| file.filename.to_s == fileset.structural.contains.first.filename }
+          fileset.structural.contains.first.label == preserved_file.first.label.to_s
+        end
+
+        unchanged_files_cocina = files[0]
+        updated_files_cocina = files[1]
+        # get the filenames so we can use them to look up the matching preserved file
+        changed_filenames = updated_files_cocina.map { |fileset| fileset.structural.contains.first.filename }
+        need_to_be_rebuilt = work_version.preserved_files.select { |file| changed_filenames.include? file.filename.to_s }
+
+        return unchanged_files_cocina, need_to_be_rebuilt
       end
 
       def build_fileset(attached_file, offset)
@@ -49,6 +72,24 @@ module CocinaGenerator
           label: attached_file.label,
           structural: {
             contains: [FileGenerator.generate(work_version:, attached_file:)]
+          }
+        }.tap do |fileset|
+          if work_version.work.druid
+            fileset[:externalIdentifier] =
+              "#{work_version.work.druid.delete_prefix('druid:')}_#{offset}"
+          end
+        end
+      end
+
+      def rebuild_fileset(attached_file, offset)
+        # needs sdr-api's assigned externalIdentifier.
+        file_cocina = cocina_obj.structural.contains.first.structural.contains.find { |f| f.filename == attached_file.filename.to_s }
+        {
+          type: Cocina::Models::FileSetType.file,
+          version: work_version.version,
+          label: attached_file.label,
+          structural: {
+            contains: [FileGenerator.generate(work_version:, attached_file:, external_identifier: file_cocina[:externalIdentifier])]
           }
         }.tap do |fileset|
           if work_version.work.druid

--- a/spec/jobs/deposit_job_spec.rb
+++ b/spec/jobs/deposit_job_spec.rb
@@ -169,16 +169,16 @@ RSpec.describe DepositJob do
       end
 
       context 'when file description has changed' do
-        let(:attached_file_labeled) { build(:attached_file, label: 'My changed label') }
+        let(:attached_file_relabeled) { build(:attached_file, label: 'My changed label') }
         let(:second_work_version_metadata_only) do
-          build(:work_version, work:, attached_files: [attached_file_labeled], version: 2,
+          build(:work_version, work:, attached_files: [attached_file_relabeled], version: 2,
                                version_description: 'Updated metadata')
         end
 
         before do
           work.work_versions = [first_work_version, second_work_version_metadata_only]
           allow(SdrClient::Find).to receive(:run).and_return(cocina.to_json)
-          allow(attached_file_labeled).to receive_message_chain(:file, :blob).and_return(blob) # rubocop:disable RSpec/MessageChain
+          allow(attached_file_relabeled).to receive_message_chain(:file, :blob).and_return(blob) # rubocop:disable RSpec/MessageChain
         end
 
         it 'calls UpdateResource.run and uses updated label' do

--- a/spec/jobs/deposit_job_spec.rb
+++ b/spec/jobs/deposit_job_spec.rb
@@ -187,6 +187,33 @@ RSpec.describe DepositJob do
         expect(SdrClient::Deposit::UploadFiles).to have_received(:upload)
       end
     end
+
+    context 'when file description has changed' do
+      # The attached files for this version are the same as the previous version
+      let(:attached_file) { build(:attached_file, label: 'My changed label') }
+      let(:second_work_version_metadata_only) do
+        build(:work_version, work:, attached_files: [attached_file], version: 2,
+                             version_description: 'Updated metadata')
+      end
+
+      before do
+        work.work_versions = [first_work_version, second_work_version_metadata_only]
+      end
+
+      it 'calls UpdateResource.run and uses updated metadata' do
+        described_class.perform_now(second_work_version_metadata_only)
+
+        # Notice that UpdateResource.run is called but UploadFiles.upload is not.
+        # This makes this a "metadata only" update.
+        expect(SdrClient::Deposit::UpdateResource).to have_received(:run)
+          .with(a_hash_including(version_description: 'Updated metadata')) do |params|
+          external_identifier = params[:metadata].structural.contains.first.structural.contains.first.externalIdentifier
+          label = params[:metadata].structural.contains.first.structural.contains.first.label
+          expect(external_identifier).to eq('https://cocina.sul.stanford.edu/file/123-456-789')
+          expect(label).to eq('My changed label')
+        end
+      end
+    end
   end
 
   context 'when the deposit request is not successful' do


### PR DESCRIPTION
## Why was this change made? 🤔

This is ugly code, just making a draft PR to help with conversation. Tests pass (including one added to check that a label was updated), but in QA, HB alerts `"Errno::ENOENT: No such file or directory @ rb_sysopen"` ([example](https://app.honeybadger.io/projects/77112/faults/91018012))

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


