### PR TITLE
Always rebuild structural cocina

### DIFF
--- a/app/services/cocina_generator/dro_generator.rb
+++ b/app/services/cocina_generator/dro_generator.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module CocinaGenerator
+  ID_NAMESPACE = 'https://cocina.sul.stanford.edu'
+
   # This generates a RequestDRO for a work
   class DROGenerator
     def self.generate_model(work_version:, cocina_obj: nil)

--- a/app/services/cocina_generator/structural/generator.rb
+++ b/app/services/cocina_generator/structural/generator.rb
@@ -24,38 +24,63 @@ module CocinaGenerator
       end
 
       # 1) Start with the existing filesets from SDR
-      # 1) Only keep the filesets that have attached_files that are preserved
-      # 2) Add new filesets that have attached_files in the local store.
+      # 2) Rebuild filesets that have attached_files that are preserved
+      # 3) Add new filesets that have attached_files in the local store.
       def build_filesets
-        filesets = find_preserved_filesets
-        filesets + work_version.staged_files.map.with_index(filesets.size + 1) { |af, n| build_fileset(af, n) }
-      end
-
-      # @return [Array<Cocina::FileSet>] the list of items where all files are already preserved.
-      def find_preserved_filesets
-        return [] unless cocina_obj
-
-        cocina_obj.structural.contains.select do |fileset|
-          existing_file_names = Set.new(fileset.structural.contains.map(&:filename))
-          preserved_file_names = Set.new(work_version.preserved_files.map(&:filename).map(&:to_s))
-          preserved_file_names.superset?(existing_file_names)
+        filesets = find_preserved_filesets.to_h do |filename, fileset|
+          [
+            filename,
+            build_fileset(attached_file: get_preserved_file(filename), fileset:)
+          ]
         end
+        filesets.values + work_version.staged_files.map { |af| build_fileset(attached_file: af) }
       end
 
-      def build_fileset(attached_file, offset)
+      # @return [Hash] map of filename to matching fileset's cocina for preserved files.
+      def find_preserved_filesets
+        return {} unless cocina_obj
+
+        preserved_file_names = work_version.preserved_files.map(&:filename).map(&:to_s)
+        create_filesmap(preserved_file_names)
+      end
+
+      def get_preserved_file(filename)
+        work_version.preserved_files.find { |attached_file| attached_file.filename.to_s == filename }
+      end
+
+      # rubocop:disable Rails/IndexBy
+      def create_filesmap(preserved_file_names)
+        # h2 only has one file per fileset
+        cocina_obj.structural.contains
+                  .select { |fileset| preserved_file_names.include?(fileset.structural.contains.first.filename) }
+                  .to_h { |fileset| [fileset.structural.contains.first.filename, fileset] }
+      end
+      # rubocop:enable Rails/IndexBy
+
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/MethodLength
+      def build_fileset(attached_file:, fileset: nil)
+        # h2 only has one file per fileset
+        cocina_file = fileset&.structural&.contains&.first
+        resource_id = SecureRandom.uuid if cocina_file.blank?
         {
           type: Cocina::Models::FileSetType.file,
           version: work_version.version,
           label: attached_file.label,
           structural: {
-            contains: [FileGenerator.generate(work_version:, attached_file:)]
+            contains: [FileGenerator.generate(work_version:, attached_file:, resource_id:, cocina_file:)]
           }
-        }.tap do |fileset|
-          if work_version.work.druid
-            fileset[:externalIdentifier] =
-              "#{work_version.work.druid.delete_prefix('druid:')}_#{offset}"
+        }.tap do |new_fileset|
+          if fileset
+            new_fileset[:externalIdentifier] = fileset&.externalIdentifier
+          elsif work_version.work.druid
+            # see https://github.com/sul-dlss/dor-services-app/blob/main/app/services/cocina/id_generator.rb
+            new_fileset[:externalIdentifier] =
+              "#{ID_NAMESPACE}/fileSet/#{work_version.work.druid.delete_prefix('druid:')}-#{resource_id}"
           end
         end
+        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/MethodLength
       end
     end
   end

--- a/spec/factories/attached_files.rb
+++ b/spec/factories/attached_files.rb
@@ -10,4 +10,9 @@ FactoryBot.define do
   trait :with_file do
     file { fixture_file_upload(Rails.root.join('spec/fixtures/files/sul.svg'), 'image/svg+xml') }
   end
+
+  trait :with_preserved_file do
+    with_file
+    after(:build, &:transform_blob_to_preservation)
+  end
 end

--- a/spec/services/cocina_generator/dro_generator_spec.rb
+++ b/spec/services/cocina_generator/dro_generator_spec.rb
@@ -493,13 +493,13 @@ RSpec.describe CocinaGenerator::DROGenerator do
                         label: 'MyString',
                         size: 17_675,
                         type: Cocina::Models::ObjectType.file,
-                        externalIdentifier: 'druid:bk123gh4567/sul.svg',
+                        externalIdentifier: '9999999',
                         version: 1
                       }
                     ]
                   },
                   type: Cocina::Models::FileSetType.file,
-                  externalIdentifier: 'bk123gh4567_1',
+                  externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/bk123gh4567-123456',
                   version: 1
                 }
               ],
@@ -507,6 +507,11 @@ RSpec.describe CocinaGenerator::DROGenerator do
             }
           }
         )
+      end
+
+      before do
+        allow(SecureRandom).to receive(:uuid).and_return '123456'
+        allow(blob).to receive(:signed_id).and_return '9999999'
       end
 
       it 'generates the model' do

--- a/spec/services/cocina_generator/structural/file_generator_spec.rb
+++ b/spec/services/cocina_generator/structural/file_generator_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CocinaGenerator::Structural::FileGenerator do
-  let(:model) { described_class.generate(work_version:, attached_file:) }
+  let(:model) { described_class.generate(work_version:, attached_file:, resource_id: '1234', cocina_file: nil) }
 
   describe '#access' do
     subject { model.access }
@@ -36,6 +36,20 @@ RSpec.describe CocinaGenerator::Structural::FileGenerator do
       let(:attached_file) { create(:attached_file, :with_file, work_version:, hide: true) }
 
       it { is_expected.to eq Cocina::Models::FileAccess.new(view: 'dark', download: 'none') }
+    end
+  end
+
+  describe '#initialize' do
+    context 'when neither resource_id nor file cocina is provided' do
+      let(:work_version) { build(:work_version) }
+      let(:attached_file) { create(:attached_file, :with_file, work_version:) }
+
+      it 'raises an error' do
+        expect do
+          described_class.generate(work_version:, attached_file:, resource_id: nil,
+                                   cocina_file: nil)
+        end.to raise_error('Either resource_id or cocina_file should be provided.')
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #2878, #2879, #2886 to

- update cocina structural metadata on later versions of works, rebuilding cocina (rather than copying) for current and existing filesets. Rebuilding cocina will update the label, publish/shelve options, and access rights.
- fixes the externalIdentifier format for filesets and files

## How was this change tested? 🤨
Integration, unit. 

DONE: This also needs sul-dlss/sdr-api#535 to be deployed to have the file ids match the fileSet ids. 


⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


