### PR TITLE
allow globus to be put in test mode for localhost work

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ Create and migrate the database with `bundle exec rake db:prepare` and seed the 
 
 Then run tests with `bundle exec rspec`. If you also want to do style checks & linting, run Rubocop and RSpec serially via `bin/rake`.
 
+### Faking Globus Client Calls
+
+If you want to test the automated globus workflow setup on your laptop without actually making globus calls, add the following config
+to the globus section of your `settings.local.yml` file:
+
+```
+globus:
+  test_mode: true # for testing purposes in non-production only, simulates globus API calls
+  test_user_exists: true # if test_mode=true, simulates if the globus user exists
+```
+
+Setting `test_mode` to true will prevent the GlobusClient from making actual API calls and will simply assume they succeed.
+To simulate if a user is currently known to globus or not, set the `test_user_exists` to true or false depending on what you want
+to test.  You can change from false to true after creating an object and refreshing the page to simulate the user completing the
+globus account setup.  When `test_mode` is set to true, a message is shown in the top navigation to note you are in test mode.
+
 ### Integration
 
 Spin up all docker compose services for local development and in-browser testing:

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -117,7 +117,7 @@ class WorksController < ObjectsController
 
     authorize! work_version, to: :show?
 
-    if GlobusClient.user_exists?(work.depositor.sunetid)
+    if globus_user_exists?(work.depositor.email)
       GlobusSetupJob.perform_later(work_version)
       flash[:notice] = I18n.t('work.flash.globus_setup_complete')
     else
@@ -151,6 +151,12 @@ class WorksController < ObjectsController
   end
 
   private
+
+  def globus_user_exists?(user_id)
+    return Settings.globus.test_user_exists if Settings.globus.test_mode && Rails.env.development?
+
+    GlobusClient.user_exists?(user_id)
+  end
 
   # Create the next WorkVersion for this work
   def create_new_version(previous_version)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,6 +35,9 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
               <ul class="navbar-nav ms-auto mb-2 mb-md-0">
+                <% if Settings.globus.test_mode %>
+                  <li class="nav-item">Globus test mode user exists: <%= Settings.globus.test_user_exists %></li>
+                <% end %>
                 <li class="nav-item">
                   <%= link_to('Help', '#contactUsModal',
                             class: 'nav-link',

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,6 +13,8 @@ globus:
   uploads_directory: /uploads/
   transfer_endpoint_id: endpoint_uuid
   help_doc_url: https://docs.google.com/document/d/10b7y3yZCOfyVJ_uP4l7QHbkILQKnfdJi9hj-MpmmdIk
+  test_mode: false # for testing purposes in non-production only, simulates globus API calls
+  test_user_exists: true # if test_mode=true, simulates if the globus user exists
 
 accountws:
   pem_file: /etc/pki/tls/certs/sul-h2-qa.stanford.edu.pem
@@ -41,9 +43,9 @@ earliest_year: 1000
 external_links:
   what_is_a_doi: https://library.stanford.edu/research/stanford-digital-repository/documentation/purls-and-dois
 
-# feature flag
+# feature flags
 allow_sdr_content_changes: true
-globus_upload: false
+globus_upload: false  # set to true to use globus automation workflow; false is manual globus upload
 
 authorization_group_header: HTTP_X_GROUPS
 first_name_header: HTTP_X_PERSON_NAME


### PR DESCRIPTION
## Why was this change made? 🤔

Follow on from #2887 

Allow us to test the globus workflow in localhost by simulating the response from the globus API.  This is useful as we may to verify the workflow works as expected by simulating the test H2 user not having a globus account, and then later having a globus account, so we can verify H2 behaves as expected.  You configure this in your `settings.local.yml`  as explained in the updated README.  It will automatically be ignored if running in production regardless of setting.

## How was this change tested? 🤨

Localhost