### PR TITLE
change text of email on globus deposit

### DIFF
--- a/app/views/works_mailer/globus_deposited_email.html.erb
+++ b/app/views/works_mailer/globus_deposited_email.html.erb
@@ -1,6 +1,6 @@
 Dear Administrator,
 
-<p>The following item has been deposited with the "Files have been uploaded to Globus" option checked.</p>
+<p>The following item has been deposited with the "Globus option" selected."</p>
 
 <p>
   Item: <%= link_to @work_version.title, work_url(@work) %>


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2898 - change text of email to sdr-support when a globus deposit is made

## How was this change tested? 🤨

Existing tests