### PR TITLE
remove globus setup complete button from dashboard

### DIFF
--- a/app/components/dashboard/in_progress_row_component.html.erb
+++ b/app/components/dashboard/in_progress_row_component.html.erb
@@ -7,7 +7,6 @@
   <td><%= show_collection_link %></td>
   <td>
     <%= render Works::StateDisplayComponent.new(work_version: work_version) %>
-    <%= render Works::GlobusSetupButtonComponent.new(work_version: work_version) %>
   </td>
   <td><%= render LocalTimeComponent.new(datetime: work_version.updated_at, show_time: false) %></td>
 </tr>

--- a/app/components/works/globus_setup_button_component.html.erb
+++ b/app/components/works/globus_setup_button_component.html.erb
@@ -1,1 +1,1 @@
-<%= link_to (button_tag 'Globus setup complete', type: 'button', class: "btn btn-outline-primary btn-light"), complete_globus_setup_work_path(work_version.work) %>
+<%= link_to (button_tag 'Globus setup complete', type: 'button', class: "btn btn-outline-primary btn-light"), complete_globus_setup_work_path(work_version.work), target: '_top'  %>

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -123,7 +123,7 @@ class WorksController < ObjectsController
       flash[:warning] = I18n.t('work.flash.globus_setup_not_complete')
     end
 
-    redirect_to dashboard_path
+    redirect_to work_path(work)
   end
 
   # We render this button lazily because it requires doing a query to see if the user has access.


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2916 - remove button from dashboard, and change where we re-direct to after globus setup complete

## How was this change tested? 🤨

Localhost and existing tests