### PR TITLE
Add a banner to globus deposits on item show page

### DIFF
--- a/app/components/works/globus_setup_component.html.erb
+++ b/app/components/works/globus_setup_component.html.erb
@@ -10,8 +10,8 @@
 <% else %>
    <div class="row my-5 mx-2 alert alert-info">
       <div class="col-12">
-         Your files should now be uploaded to the Globus folder "<%=work_version.globus_endpoint%>" we created for this deposit.
-         Refer to our <%= link_to 'help page', Settings.globus.help_doc_url %> if you have questions.</p>
+         <p>Upload your files to the Globus folder "<%=work_version.globus_endpoint%>" and then click the "Edit or Deposit" button on this page to complete your deposit.
+         Refer to our <%= link_to 'help page', Settings.globus.help_doc_url %> if you have questions, or contact us at the Help link above.</p>
       </div>
    </div>
 <% end %>

--- a/app/components/works/globus_setup_component.html.erb
+++ b/app/components/works/globus_setup_component.html.erb
@@ -1,8 +1,17 @@
-<div class="row my-5 mx-2 alert alert-danger">
-  <div class="col-9">
-     Click this button when you have completed setting up your Globus account and we will email you instructions on where to upload your files.
-  </div>
-  <div class="col-3">
-     <%= render Works::GlobusSetupButtonComponent.new(work_version:) %>
-  </div>
-</div>
+<% if work_version.globus_setup_draft? %>
+   <div class="row my-5 mx-2 alert alert-danger">
+      <div class="col-9">
+         Click this button when you have completed setting up your Globus account and we will email you instructions on where to upload your files.
+      </div>
+      <div class="col-3">
+         <%= render Works::GlobusSetupButtonComponent.new(work_version:) %>
+      </div>
+   </div>
+<% else %>
+   <div class="row my-5 mx-2 alert alert-info">
+      <div class="col-12">
+         Your files should now be uploaded to the Globus folder "<%=work_version.globus_endpoint%>" we created for this deposit.
+         Refer to our <%= link_to 'help page', Settings.globus.help_doc_url %> if you have questions.</p>
+      </div>
+   </div>
+<% end %>

--- a/app/components/works/globus_setup_component.rb
+++ b/app/components/works/globus_setup_component.rb
@@ -10,7 +10,7 @@ module Works
     attr_reader :work_version
 
     def render?
-      work_version.globus_setup_draft?
+      work_version.globus?
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2915 - add a banner to the top of the item show/detail page for globus deposits in a draft state directing users to the help page and showing them the folder name we created on globus.  

This is in the same spot that the banner shows for users who still need to complete their globus account setup (i.e. that banner goes away when they complete their setup and is replaced by this one).

**Account setup complete** (new banner)

![Screen Shot 2022-12-14 at 2 55 33 PM](https://user-images.githubusercontent.com/47137/207733126-a7d4f88a-f66c-4692-ae92-f93c1c171807.png)

**Account setup needed** (existing banner)

![Screen Shot 2022-12-14 at 2 59 22 PM](https://user-images.githubusercontent.com/47137/207733635-4b06b7ac-b7f9-42b5-8771-9f2265e9c87c.png)


~~HOLD for language updates by Amy~~

## How was this change tested? 🤨

Localhost


