### PR TITLE
Load work files table with turbo

### DIFF
--- a/app/assets/stylesheets/work.scss
+++ b/app/assets/stylesheets/work.scss
@@ -53,6 +53,18 @@
     }
   }
 
+  // For files table
+  .files-list {
+    max-height: 550px;
+    overflow-y: auto;
+  }
+
+  .files-list thead th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+
   // The pencil icon
   .edit {
     margin-left: 10px;

--- a/app/components/works/show/files_component.html.erb
+++ b/app/components/works/show/files_component.html.erb
@@ -1,22 +1,14 @@
-<table class="table table-sm mb-5" id="filesTable">
-  <thead class="table-light">
-  <tr>
-    <th scope="col" class="table-title">Files
-      <span class="ms-3">
-        <%= helpers.turbo_frame_tag dom_id(work, 'edit_file'), src: edit_button_work_path(work, tag: 'file'), target: '_top' %>
-      </span>
-      <% if download_all? %>
-        <%= link_to work_zip_path(work), class: 'ms-4', data: { turbo: false } do %>
-          <span class="fa-solid fa-download" aria-hidden="true"></span><span class="visually-hidden">Download All Files</span>
-        <% end %>
-      <% end %>
-    </th>
-    <th scope="col">Description</th>
-    <th scope="col">Hide file</th>
-  </tr>
-  </thead>
-  <tbody>
-    <%= render Works::Show::AttachedFileComponent.with_collection(attached_files.sort_by { |attached_file| attached_file.path.downcase },
-                                                                  work_version: work_version) %>
-  </tbody>
-</table>
+<turbo-frame id="<%= dom_id(work, 'files_list') %>" src="<%= files_list_work_path(work) %>" loading="lazy">
+  <table class="table table-sm mb-5" id="filesTable">
+    <thead class="table-light">
+    <tr>
+      <th scope="col" class="table-title">Files</th>
+      <th scope="col">Description</th>
+      <th scope="col">Hide file</th>
+    </tr>
+    </thead>
+    <tbody>
+      <tr><td colspan="3" class="text-center"><%= spinner %></td></tr>
+    </tbody>
+  </table>
+</turbo-frame>

--- a/app/components/works/show/files_component.rb
+++ b/app/components/works/show/files_component.rb
@@ -20,6 +20,10 @@ module Works
       def download_all?
         work_version.attached_files.all? { |attached_file| !attached_file.in_globus? }
       end
+
+      def spinner
+        tag.span class: 'fa-solid fa-spinner fa-pulse fa-2xl my-5'
+      end
     end
   end
 end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -126,6 +126,16 @@ class WorksController < ObjectsController
     redirect_to work_path(work)
   end
 
+  def files_list
+    work = Work.find(params[:id])
+    work_version = work.head
+    attached_files = work_version.attached_files.sort_by { |attached_file| attached_file.path.downcase }
+
+    authorize! work_version, to: :show?
+
+    render partial: 'works/files_list', locals: { work:, work_version:, attached_files: }
+  end
+
   # We render this button lazily because it requires doing a query to see if the user has access.
   # The access can vary depending on the user and the state of the work.
   def delete_button

--- a/app/views/works/_files_list.html.erb
+++ b/app/views/works/_files_list.html.erb
@@ -1,0 +1,23 @@
+<%= turbo_frame_tag dom_id(work, 'files_list') do %>
+<div class="files-list mb-5">
+  <table class="table table-sm" id="filesTable">
+    <thead class="files-list-header table-light">
+    <tr>
+      <th scope="col" class="table-title">Files
+        <span class="ms-3">
+          <%= turbo_frame_tag dom_id(work, 'edit_file'), src: edit_button_work_path(work, tag: 'file'), target: '_top' %>
+        </span>
+        <%= link_to work_zip_path(work), class: 'ms-4', data: { turbo: false } do %>
+          <span class="fa-solid fa-download" aria-hidden="true"></span><span class="visually-hidden">Download All Files</span>
+        <% end %>
+      </th>
+      <th scope="col">Description</th>
+      <th scope="col">Hide file</th>
+    </tr>
+    </thead>
+    <tbody>
+      <%= render Works::Show::AttachedFileComponent.with_collection(attached_files, work_version: work_version) %>
+    </tbody>
+  </table>
+</div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
         get :next_step_review
         get :details
         get :complete_globus_setup
+        get :files_list
         resource :owners, only: %i[edit update], controller: 'work_owners'
         resource :locks, only: %i[edit update], controller: 'work_locks'
         resource :decommission, only: %i[edit update], controller: 'work_decommission', as: :work_decommission

--- a/spec/components/works/show/attached_file_component_spec.rb
+++ b/spec/components/works/show/attached_file_component_spec.rb
@@ -3,13 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe Works::Show::AttachedFileComponent, type: :component do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:rendered) { render_inline(described_class.new(attached_file:, work_version:)) }
+  let(:work_version) { create(:work_version, attached_files: [attached_file]) }
+  let(:attached_file) { build(:attached_file, :with_file) }
 
-  # it "renders something useful" do
-  #   expect(
-  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
-  #   ).to include(
-  #     "Hello, components!"
-  #   )
-  # end
+  context 'with an attached file' do
+    it 'shows a download link and the hide status' do
+      expect(rendered.css('a').last['href']).to start_with '/rails/active_storage/blobs/redirect/'
+      expect(rendered.css('td').last.to_html).to include 'No'
+    end
+  end
 end

--- a/spec/components/works/show/files_component_spec.rb
+++ b/spec/components/works/show/files_component_spec.rb
@@ -11,20 +11,9 @@ RSpec.describe Works::Show::FilesComponent, type: :component do
       create(:attached_file, :with_file, work_version:)
     end
 
-    it 'shows a download link and the hide status' do
-      expect(rendered.css('a').last['href']).to start_with '/rails/active_storage/blobs/redirect/'
-      expect(rendered.css('td').last.to_html).to include 'No'
-    end
-  end
-
-  context 'with multiple attached files' do
-    let(:attached_file) { create(:attached_file, :with_file, path: 'sul.svg') }
-    let(:attached_file2) { create(:attached_file, :with_file, path: 'favicon.ico') }
-    let(:work_version) { create(:work_version, attached_files: [attached_file, attached_file2]) }
-
-    it 'shows them in alpha order' do
-      expect(rendered.css('tr')[1].to_html).to include 'favicon.ico'
-      expect(rendered.css('tr')[2].to_html).to include 'sul.svg'
+    it 'renders the turbo frame and spinner' do
+      expect(rendered.css('turbo-frame')[0]['src']).to eq "/works/#{work_version.work.id}/files_list"
+      expect(rendered.to_html).to include 'fa-solid fa-spinner fa-pulse'
     end
   end
 end

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -99,6 +99,11 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
           expect(page).not_to have_content('Duplicate file')
           # End of client-side validation testing
 
+          choose 'work_upload_type_browser'
+          page.attach_file(Rails.root.join('spec/fixtures/files/favicon.ico')) do
+            click_button('Choose files')
+          end
+
           fill_in 'Title of deposit', with: 'My Title'
           fill_in 'Contact email', with: user.email
 
@@ -162,6 +167,12 @@ RSpec.describe 'Create a new work in a deposited collection', js: true do
           expect(page).to have_content 'Citation from user input'
           expect(page).to have_content 'Everyone'
           expect(page).to have_content 'CC0-1.0'
+
+          within('#filesTable') do
+            # files are sorted alphabetically
+            expect(all('tr')[1]).to have_content 'favicon.ico'
+            expect(all('tr')[2]).to have_content 'sul.svg'
+          end
 
           within '#events' do
             # New work gets a description of what's changed (except subtypes)


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #2910 to put files in a scrollable container and lazy load with turbo.

## How was this change tested? 🤨
Unit. 

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


