### PR TITLE
[HOLD] Catch Globus token error and raise

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -164,6 +164,13 @@ class WorksController < ObjectsController
   def globus_user_exists?(user_id)
     return Settings.globus.test_user_exists if Settings.globus.test_mode && Rails.env.development?
 
+    # Temporary debugging: notify via HB if error raised getting identity from Globus.
+    begin
+      GlobusClient::Identity.new(GlobusClient.config).get_identity_id(user_id)
+    rescue StandardError => e
+      Honeybadger.notify(e)
+    end
+
     GlobusClient.user_exists?(user_id)
   end
 

--- a/spec/requests/complete_globus_setup_spec.rb
+++ b/spec/requests/complete_globus_setup_spec.rb
@@ -14,6 +14,16 @@ RSpec.describe 'User indicates globus setup is complete' do
     work.update(head: work_version)
     sign_in user, groups: ['dlss:hydrus-app-administrators']
     allow(GlobusSetupJob).to receive(:perform_later)
+    stub_request(:get, /auth.globus.org/)
+      .with(
+        headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Authorization' => 'Bearer',
+          'User-Agent' => 'Faraday v2.7.2'
+        }
+      )
+      .to_return(status: 200)
   end
 
   context 'when the user has not yet completed their globus setup' do


### PR DESCRIPTION
## Why was this change made? 🤔
First step in resolving #2929 to trap error first raised in Globus interaction if there is a problem with looking up a user's identity. This is temporary to gather info until we complete work to refresh the token. (See #2937, for requesting a new access token as needed.)

HOLD since we think #2937 will resolve this.

## How was this change tested? 🤨
Unit

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


