### PR TITLE
[HOLD] Displays info on uploaded globus files.

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -82,6 +82,15 @@
         <%= form.label :fetch_globus_files,
          "All files have been uploaded to Globus.",
          class: 'form-check-label' %>
+
+         <%= tag.turbo_frame id: dom_id(work, :globus_file_info), src: globus_file_info_work_path(work)  do %>
+          <div>
+            Looking for files uploaded to Globus ...
+            <div class="spinner-border spinner-border-sm" role="status">
+              <span class="visually-hidden">Loading...</span>
+            </div>
+          </div>
+         <% end %>
       <% end %>
     </div>
   </div>

--- a/app/components/works/add_files_component.rb
+++ b/app/components/works/add_files_component.rb
@@ -24,5 +24,9 @@ module Works
     def globus_endpoint?
       form.object.work_version.globus_endpoint.present?
     end
+
+    def work
+      form.object.work_version.work
+    end
   end
 end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -159,6 +159,16 @@ class WorksController < ObjectsController
     render partial: 'works/edit_button', locals: { work:, anchor: params[:tag], edit_label: }
   end
 
+  def globus_file_info
+    @work = Work.find(params[:id])
+
+    authorize! @work.head, to: :show?
+
+    files = GlobusClient.list_files(user_id: @work.depositor.email, path: @work.head.globus_endpoint)
+    @files_count = files.count
+    @total_size = files.sum(&:size)
+  end
+
   private
 
   def globus_user_exists?(user_id)

--- a/app/views/works/globus_file_info.html.erb
+++ b/app/views/works/globus_file_info.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag dom_id(@work, :globus_file_info) do %>
+  <div>Found <%= number_to_human(@files_count) %> files totaling <%= number_to_human_size(@total_size) %> uploaded to Globus.</div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
         get :details
         get :complete_globus_setup
         get :files_list
+        get :globus_file_info
         resource :owners, only: %i[edit update], controller: 'work_owners'
         resource :locks, only: %i[edit update], controller: 'work_locks'
         resource :decommission, only: %i[edit update], controller: 'work_decommission', as: :work_decommission


### PR DESCRIPTION
closes #2912

## Why was this change made? 🤔
Allows users to verify Globus upload.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


