### PR TITLE
Ignore MacOS-specific bogus file paths in Globus uploads

### DIFF
--- a/app/jobs/fetch_globus_job.rb
+++ b/app/jobs/fetch_globus_job.rb
@@ -11,6 +11,8 @@ class FetchGlobusJob < BaseDepositJob
     work_version.attached_files.destroy_all
 
     filepaths_for(work_version).each do |path|
+      next if ignore?(path)
+
       work_version.attached_files << new_attached_file(path, work_version)
     end
     work_version.upload_type = 'browser'
@@ -24,6 +26,10 @@ class FetchGlobusJob < BaseDepositJob
 
   def globus_prefix(work_version)
     "#{Settings.globus.uploads_directory}#{work_version.globus_endpoint}/"
+  end
+
+  def ignore?(path)
+    path.start_with?('__MACOSX') || path.end_with?('.DS_Store')
   end
 
   def new_attached_file(path, work_version)

--- a/spec/jobs/fetch_globus_job_spec.rb
+++ b/spec/jobs/fetch_globus_job_spec.rb
@@ -14,9 +14,15 @@ RSpec.describe FetchGlobusJob do
   let(:work) { build(:work) }
 
   before do
-    allow(
-      allow(GlobusClient).to(receive(:get_filenames).and_return(['/uploads/jstanford/work333/version1/file1.txt',
-                                                                 '/uploads/jstanford/work333/version1/dir1/file2.txt']))
+    allow(GlobusClient).to receive(:get_filenames).and_return(
+      [
+        '/uploads/jstanford/work333/version1/file1.txt',
+        '/uploads/jstanford/work333/version1/__MACOSX/._file1.txt',
+        '/uploads/jstanford/work333/version1/dir1/file2.txt',
+        '/uploads/jstanford/work333/version1/__MACOSX/dir1/._file2.txt',
+        '/uploads/jstanford/work333/version1/dir2/.DS_Store',
+        '/uploads/jstanford/work333/version1/__MACOSX/dir2/._.DS_Store'
+      ]
     )
     work.update!(head: first_work_version)
   end


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #2935

This commit mirrors logic already applied to zip uploads to make sure bogus MacOS files are not included in H2 items.

# How was this change tested? 🤨

CI + tested successfully by Amy in QA
