### PR TITLE
Show file hierarchy on the work show page

### DIFF
--- a/app/assets/stylesheets/details.scss
+++ b/app/assets/stylesheets/details.scss
@@ -10,5 +10,5 @@
 
 /* hierarchy display in work show page table */
 td.file-level {
-  padding-left: var(--index);
+  padding-left: var(--depth);
 }

--- a/app/assets/stylesheets/details.scss
+++ b/app/assets/stylesheets/details.scss
@@ -7,3 +7,8 @@
   background-color: var(--bs-table-bg);
   padding: 0.25rem;
 }
+
+/* hierarchy display in work show page table */
+td.file-level {
+  padding-left: var(--index);
+}

--- a/app/components/works/show/attached_file_component.html.erb
+++ b/app/components/works/show/attached_file_component.html.erb
@@ -1,5 +1,5 @@
 <tr>
-    <td class="file-level" style="--index: <%=index+1%>rem"><li><%= basename %>
+    <td class="file-level" style="--depth: <%=depth+1%>rem"><li><%= basename %>
         <% if can_download? %>
             <%= link_to path, class: 'ms-2', data: { turbo: false } do %>
                 <span class="fa-solid fa-download" aria-hidden="true"></span><span class="visually-hidden">Download</span>

--- a/app/components/works/show/attached_file_component.html.erb
+++ b/app/components/works/show/attached_file_component.html.erb
@@ -1,10 +1,13 @@
 <tr>
-    <td class="file-level" style="--depth: <%=depth+1%>rem"><li><%= basename %>
-        <% if can_download? %>
-            <%= link_to path, class: 'ms-2', data: { turbo: false } do %>
-                <span class="fa-solid fa-download" aria-hidden="true"></span><span class="visually-hidden">Download</span>
+    <td class="file-level" style="--depth: <%= depth+1 %>rem">
+        <li>
+            <%= basename %>
+            <% if can_download? %>
+                <%= link_to path, class: 'ms-2', data: { turbo: false } do %>
+                    <span class="fa-solid fa-download" aria-hidden="true"></span><span class="visually-hidden">Download</span>
+                <% end %>
             <% end %>
-        <% end %></li>
+        </li>
     </td>
     <td><%= label %></td>
     <td><%= hide? ? 'Yes' : 'No' %></td>

--- a/app/components/works/show/attached_file_component.html.erb
+++ b/app/components/works/show/attached_file_component.html.erb
@@ -1,10 +1,10 @@
 <tr>
-    <td><%= basename %>
+    <td class="file-level" style="--index: <%=index+1%>rem"><li><%= basename %>
         <% if can_download? %>
             <%= link_to path, class: 'ms-2', data: { turbo: false } do %>
                 <span class="fa-solid fa-download" aria-hidden="true"></span><span class="visually-hidden">Download</span>
             <% end %>
-        <% end %>
+        <% end %></li>
     </td>
     <td><%= label %></td>
     <td><%= hide? ? 'Yes' : 'No' %></td>

--- a/app/components/works/show/attached_file_component.html.erb
+++ b/app/components/works/show/attached_file_component.html.erb
@@ -1,5 +1,5 @@
 <tr>
-    <td><%= filename %>
+    <td><%= basename %>
         <% if can_download? %>
             <%= link_to path, class: 'ms-2', data: { turbo: false } do %>
                 <span class="fa-solid fa-download" aria-hidden="true"></span><span class="visually-hidden">Download</span>

--- a/app/components/works/show/attached_file_component.html.erb
+++ b/app/components/works/show/attached_file_component.html.erb
@@ -1,13 +1,12 @@
 <tr>
     <td class="file-level" style="--depth: <%= depth+1 %>rem">
-        <li>
-            <%= basename %>
-            <% if can_download? %>
-                <%= link_to path, class: 'ms-2', data: { turbo: false } do %>
-                    <span class="fa-solid fa-download" aria-hidden="true"></span><span class="visually-hidden">Download</span>
-                <% end %>
+        &bull;
+        <%= basename %>
+        <% if can_download? %>
+            <%= link_to path, class: 'ms-2', data: { turbo: false } do %>
+                <span class="fa-solid fa-download" aria-hidden="true"></span><span class="visually-hidden">Download</span>
             <% end %>
-        </li>
+        <% end %>
     </td>
     <td><%= label %></td>
     <td><%= hide? ? 'Yes' : 'No' %></td>

--- a/app/components/works/show/attached_file_component.rb
+++ b/app/components/works/show/attached_file_component.rb
@@ -4,14 +4,13 @@ module Works
   module Show
     # Displays a single attached file
     class AttachedFileComponent < ApplicationComponent
-      def initialize(attached_file:, work_version:)
+      def initialize(attached_file:)
         @attached_file = attached_file
-        @work_version = work_version
       end
 
       attr_reader :attached_file
 
-      delegate :label, :hide?, :in_preservation?, to: :attached_file
+      delegate :basename, :label, :hide?, :in_preservation?, to: :attached_file
 
       # @return a link to download the file. If the file is new in this version, then it generates an
       # activeStorage link, otherwise a preservation link.
@@ -23,10 +22,6 @@ module Works
 
       def can_download?
         !attached_file.in_globus?
-      end
-
-      def filename
-        attached_file.path
       end
     end
   end

--- a/app/components/works/show/attached_file_component.rb
+++ b/app/components/works/show/attached_file_component.rb
@@ -4,12 +4,12 @@ module Works
   module Show
     # Displays a single attached file
     class AttachedFileComponent < ApplicationComponent
-      def initialize(attached_file:, index:)
+      def initialize(attached_file:, depth:)
         @attached_file = attached_file
-        @index = index
+        @depth = depth
       end
 
-      attr_reader :attached_file, :index
+      attr_reader :attached_file, :depth
 
       delegate :basename, :label, :hide?, :in_preservation?, to: :attached_file
 

--- a/app/components/works/show/attached_file_component.rb
+++ b/app/components/works/show/attached_file_component.rb
@@ -4,11 +4,12 @@ module Works
   module Show
     # Displays a single attached file
     class AttachedFileComponent < ApplicationComponent
-      def initialize(attached_file:)
+      def initialize(attached_file:, index:)
         @attached_file = attached_file
+        @index = index
       end
 
-      attr_reader :attached_file
+      attr_reader :attached_file, :index
 
       delegate :basename, :label, :hide?, :in_preservation?, to: :attached_file
 

--- a/app/components/works/show/attached_file_component.rb
+++ b/app/components/works/show/attached_file_component.rb
@@ -11,18 +11,19 @@ module Works
 
       attr_reader :attached_file, :depth
 
-      delegate :basename, :label, :hide?, :in_preservation?, to: :attached_file
+      delegate :basename, :label, :hide?, :in_preservation?, :in_globus?, :file, to: :attached_file
 
       # @return a link to download the file. If the file is new in this version, then it generates an
       # activeStorage link, otherwise a preservation link.
       def path
         return preservation_path(attached_file) if in_preservation?
 
-        rails_blob_path(attached_file.file, disposition: 'attachment')
+        rails_blob_path(file, disposition: 'attachment')
       end
 
+      # the user can get a download link unless the file is in globus (in which case, no download link is available)
       def can_download?
-        !attached_file.in_globus?
+        !in_globus?
       end
     end
   end

--- a/app/components/works/show/directory_component.html.erb
+++ b/app/components/works/show/directory_component.html.erb
@@ -1,12 +1,12 @@
 <% if name.present? %>
   <tr>
-    <td class="file-level" style="--index: <%=index%>rem" colspan="3">
+    <td class="file-level" style="--depth: <%=depth%>rem" colspan="3">
        <i class="fa fa-folder" aria-hidden="true"></i> <strong><%= name %></strong>
     </td>
   </tr>
 <% end %>
 <% children_files.each do |file| %>
-   <%= render Works::Show::AttachedFileComponent.new(attached_file: file.attached_file, index:) %>
+   <%= render Works::Show::AttachedFileComponent.new(attached_file: file.attached_file, depth:) %>
 <% end %>
 <% children_directories.each do |directory| %>
    <%= render Works::Show::DirectoryComponent.new(directory: directory) %>

--- a/app/components/works/show/directory_component.html.erb
+++ b/app/components/works/show/directory_component.html.erb
@@ -1,10 +1,12 @@
 <% if name.present? %>
   <tr>
-    <td colspan="3"><strong><%= name %></strong></td>
+    <td class="file-level" style="--index: <%=index%>rem" colspan="3">
+       <i class="fa fa-folder" aria-hidden="true"></i> <strong><%= name %></strong>
+    </td>
   </tr>
 <% end %>
 <% children_files.each do |file| %>
-   <%= render Works::Show::AttachedFileComponent.new(attached_file: file.attached_file) %>
+   <%= render Works::Show::AttachedFileComponent.new(attached_file: file.attached_file, index:) %>
 <% end %>
 <% children_directories.each do |directory| %>
    <%= render Works::Show::DirectoryComponent.new(directory: directory) %>

--- a/app/components/works/show/directory_component.html.erb
+++ b/app/components/works/show/directory_component.html.erb
@@ -1,6 +1,6 @@
 <% if name.present? %>
   <tr>
-    <td class="file-level" style="--depth: <%=depth%>rem" colspan="3">
+    <td class="file-level" style="--depth: <%= depth %>rem" colspan="3">
        <i class="fa fa-folder" aria-hidden="true"></i> <strong><%= name %></strong>
     </td>
   </tr>
@@ -9,5 +9,5 @@
    <%= render Works::Show::AttachedFileComponent.new(attached_file: file.attached_file, depth:) %>
 <% end %>
 <% children_directories.each do |directory| %>
-   <%= render Works::Show::DirectoryComponent.new(directory: directory) %>
+   <%= render Works::Show::DirectoryComponent.new(directory:) %>
 <% end %>

--- a/app/components/works/show/directory_component.html.erb
+++ b/app/components/works/show/directory_component.html.erb
@@ -1,0 +1,11 @@
+<% if name.present? %>
+  <tr>
+    <td colspan="3"><strong><%= name %></strong></td>
+  </tr>
+<% end %>
+<% children_files.each do |file| %>
+   <%= render Works::Show::AttachedFileComponent.new(attached_file: file.attached_file) %>
+<% end %>
+<% children_directories.each do |directory| %>
+   <%= render Works::Show::DirectoryComponent.new(directory: directory) %>
+<% end %>

--- a/app/components/works/show/directory_component.rb
+++ b/app/components/works/show/directory_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Works
+  module Show
+    # Displays a folder in the hierarchy for the work show page
+    class DirectoryComponent < ViewComponent::Base
+      def initialize(directory:)
+        @directory = directory
+      end
+
+      delegate :name, :children_directories, :children_files, :index, to: :directory
+
+      attr_reader :directory
+    end
+  end
+end

--- a/app/components/works/show/directory_component.rb
+++ b/app/components/works/show/directory_component.rb
@@ -8,7 +8,7 @@ module Works
         @directory = directory
       end
 
-      delegate :name, :children_directories, :children_files, :index, to: :directory
+      delegate :name, :children_directories, :children_files, :depth, to: :directory
 
       attr_reader :directory
     end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -129,11 +129,11 @@ class WorksController < ObjectsController
   def files_list
     work = Work.find(params[:id])
     work_version = work.head
-    attached_files = work_version.attached_files.sort_by { |attached_file| attached_file.path.downcase }
+    root_directory = FileHierarchyService.to_hierarchy(work_version:)
 
     authorize! work_version, to: :show?
 
-    render partial: 'works/files_list', locals: { work:, work_version:, attached_files: }
+    render partial: 'works/files_list', locals: { work:, root_directory: }
   end
 
   # We render this button lazily because it requires doing a query to see if the user has access.

--- a/app/models/attached_file.rb
+++ b/app/models/attached_file.rb
@@ -47,6 +47,17 @@ class AttachedFile < ApplicationRecord
     ActiveStorage::Service::GlobusService.accessible?(file.blob)
   end
 
+  # an array of directorie(s) that contain this file; e.g. ['folder','sub-folder']
+  # if there are no containing directories, it will be an empty array; eg []
+  def paths
+    path.split(File::SEPARATOR)[...-1]
+  end
+
+  # a string containing the base filename, removing any containing directories if they exist; e.g. 'test.pdf'
+  def basename
+    path.split(File::SEPARATOR).last
+  end
+
   private
 
   def changed_in_this_version?

--- a/app/services/file_hierarchy_service.rb
+++ b/app/services/file_hierarchy_service.rb
@@ -12,7 +12,7 @@ class FileHierarchyService
     end
   end
 
-  Directory = Struct.new(:name, :children_directories, :children_files, :index) do
+  Directory = Struct.new(:name, :children_directories, :children_files, :index, :depth) do
     def file?
       false
     end
@@ -28,7 +28,8 @@ class FileHierarchyService
 
   def initialize(work_version:)
     @work_version = work_version
-    @root_directory = Directory.new('', [], [], 0)
+    @index = 0
+    @root_directory = Directory.new('', [], [], 0, 0)
   end
 
   def to_hierarchy
@@ -39,6 +40,10 @@ class FileHierarchyService
   private
 
   attr_reader :work_version, :root_directory
+
+  def next_index
+    @index += 1
+  end
 
   def add_to_hierarchy(attached_file)
     directory = directory_for(attached_file.paths, root_directory)
@@ -51,7 +56,7 @@ class FileHierarchyService
     path = paths.shift
     child_directory = directory.children_directories.find { |cd| cd.name == path }
     unless child_directory
-      child_directory = Directory.new(path, [], [], directory.index + 1)
+      child_directory = Directory.new(path, [], [], next_index, directory.depth + 1)
       directory.children_directories << child_directory
     end
 

--- a/app/services/file_hierarchy_service.rb
+++ b/app/services/file_hierarchy_service.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Arranges Attached Files into a hierarchy of directories and files.
+class FileHierarchyService
+  File = Struct.new(:attached_file) do
+    def file?
+      true
+    end
+
+    def directory?
+      false
+    end
+  end
+
+  Directory = Struct.new(:name, :children_directories, :children_files, :index) do
+    def file?
+      false
+    end
+
+    def directory?
+      true
+    end
+  end
+
+  def self.to_hierarchy(work_version:)
+    new(work_version:).to_hierarchy
+  end
+
+  def initialize(work_version:)
+    @work_version = work_version
+    @index = 0
+    @root_directory = Directory.new('', [], [], next_index)
+  end
+
+  def to_hierarchy
+    work_version.attached_files.each { |attached_file| add_to_hierarchy(attached_file) }
+    root_directory
+  end
+
+  private
+
+  attr_reader :work_version, :root_directory
+
+  def next_index
+    @index += 1
+  end
+
+  def add_to_hierarchy(attached_file)
+    directory = directory_for(attached_file.paths, root_directory)
+    directory.children_files << File.new(attached_file)
+  end
+
+  def directory_for(paths, directory)
+    return directory if paths.empty?
+
+    path = paths.shift
+    child_directory = directory.children_directories.find { |cd| cd.name == path }
+    unless child_directory
+      child_directory = Directory.new(path, [], [], next_index)
+      directory.children_directories << child_directory
+    end
+
+    return child_directory if paths.empty?
+
+    directory_for(paths, child_directory)
+  end
+end

--- a/app/services/file_hierarchy_service.rb
+++ b/app/services/file_hierarchy_service.rb
@@ -28,8 +28,7 @@ class FileHierarchyService
 
   def initialize(work_version:)
     @work_version = work_version
-    @index = 0
-    @root_directory = Directory.new('', [], [], @index)
+    @root_directory = Directory.new('', [], [], 0)
   end
 
   def to_hierarchy
@@ -40,10 +39,6 @@ class FileHierarchyService
   private
 
   attr_reader :work_version, :root_directory
-
-  def next_index
-    @index += 1
-  end
 
   def add_to_hierarchy(attached_file)
     directory = directory_for(attached_file.paths, root_directory)
@@ -56,7 +51,7 @@ class FileHierarchyService
     path = paths.shift
     child_directory = directory.children_directories.find { |cd| cd.name == path }
     unless child_directory
-      child_directory = Directory.new(path, [], [], next_index)
+      child_directory = Directory.new(path, [], [], directory.index + 1)
       directory.children_directories << child_directory
     end
 

--- a/app/services/file_hierarchy_service.rb
+++ b/app/services/file_hierarchy_service.rb
@@ -29,11 +29,11 @@ class FileHierarchyService
   def initialize(work_version:)
     @work_version = work_version
     @index = 0
-    @root_directory = Directory.new('', [], [], next_index)
+    @root_directory = Directory.new('', [], [], @index)
   end
 
   def to_hierarchy
-    work_version.attached_files.each { |attached_file| add_to_hierarchy(attached_file) }
+    work_version.attached_files.sort_by(&:filename).each { |attached_file| add_to_hierarchy(attached_file) }
     root_directory
   end
 

--- a/app/views/works/_files_list.html.erb
+++ b/app/views/works/_files_list.html.erb
@@ -16,7 +16,7 @@
     </tr>
     </thead>
     <tbody>
-      <%= render Works::Show::AttachedFileComponent.with_collection(attached_files, work_version: work_version) %>
+      <%= render Works::Show::DirectoryComponent.new(directory: root_directory) %>
     </tbody>
   </table>
 </div>

--- a/spec/components/works/show/attached_file_component_spec.rb
+++ b/spec/components/works/show/attached_file_component_spec.rb
@@ -3,9 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Works::Show::AttachedFileComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(attached_file:, work_version:)) }
+  let(:rendered) { render_inline(described_class.new(attached_file:, index:)) }
   let(:work_version) { create(:work_version, attached_files: [attached_file]) }
   let(:attached_file) { build(:attached_file, :with_file) }
+  let(:index) { 1 }
 
   context 'with an attached file' do
     it 'shows a download link and the hide status' do

--- a/spec/components/works/show/attached_file_component_spec.rb
+++ b/spec/components/works/show/attached_file_component_spec.rb
@@ -3,10 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Works::Show::AttachedFileComponent, type: :component do
-  let(:rendered) { render_inline(described_class.new(attached_file:, index:)) }
+  let(:rendered) { render_inline(described_class.new(attached_file:, depth: 1)) }
   let(:work_version) { create(:work_version, attached_files: [attached_file]) }
   let(:attached_file) { build(:attached_file, :with_file) }
-  let(:index) { 1 }
 
   context 'with an attached file' do
     it 'shows a download link and the hide status' do

--- a/spec/services/file_hierarchy_service_spec.rb
+++ b/spec/services/file_hierarchy_service_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FileHierarchyService do
+  subject(:root_directory) { described_class.to_hierarchy(work_version:) }
+
+  let(:paths) do
+    [
+      'dir1/dir2/file12.pdf',
+      'dir1/dir3/file13.pdf',
+      'dir1/file1.pdf',
+      'dir1/file2.pdf',
+      'dir1/file3.pdf',
+      'file4.pdf'
+    ]
+  end
+  let(:attached_files) { paths.map { |path| create(:attached_file, path:) } }
+  let(:work_version) { build(:work_version, attached_files:) }
+
+  before do
+    attached_files.each_with_index do |attached_file, i|
+      allow(attached_file).to receive(:filename).and_return(paths[i])
+    end
+  end
+
+  # rubocop:disable Layout/ArgumentAlignment
+  it 'returns a hash of the file hierarchy' do
+    expect(root_directory).to match(
+      FileHierarchyService::Directory.new('',
+        [
+          FileHierarchyService::Directory.new('dir1',
+            [
+              FileHierarchyService::Directory.new('dir2', [],
+                [
+                  FileHierarchyService::File.new(attached_files[0])
+                ], 2),
+              FileHierarchyService::Directory.new('dir3', [],
+                [
+                  FileHierarchyService::File.new(attached_files[1])
+                ], 3) # <--- this index should be 2 and not 3, since it is at the second level (same level as dir2)
+            ],
+            [
+              FileHierarchyService::File.new(attached_files[2]),
+              FileHierarchyService::File.new(attached_files[3]),
+              FileHierarchyService::File.new(attached_files[4])
+            ], 1)
+        ],
+        [
+          FileHierarchyService::File.new(attached_files[5])
+        ], 0)
+    )
+  end
+  # rubocop:enable Layout/ArgumentAlignment
+end

--- a/spec/services/file_hierarchy_service_spec.rb
+++ b/spec/services/file_hierarchy_service_spec.rb
@@ -34,21 +34,21 @@ RSpec.describe FileHierarchyService do
               FileHierarchyService::Directory.new('dir2', [],
                 [
                   FileHierarchyService::File.new(attached_files[0])
-                ], 2),
+                ], 2, 2),
               FileHierarchyService::Directory.new('dir3', [],
                 [
                   FileHierarchyService::File.new(attached_files[1])
-                ], 2)
+                ], 3, 2)
             ],
             [
               FileHierarchyService::File.new(attached_files[2]),
               FileHierarchyService::File.new(attached_files[3]),
               FileHierarchyService::File.new(attached_files[4])
-            ], 1)
+            ], 1, 1)
         ],
         [
           FileHierarchyService::File.new(attached_files[5])
-        ], 0)
+        ], 0, 0)
     )
   end
   # rubocop:enable Layout/ArgumentAlignment

--- a/spec/services/file_hierarchy_service_spec.rb
+++ b/spec/services/file_hierarchy_service_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe FileHierarchyService do
               FileHierarchyService::Directory.new('dir3', [],
                 [
                   FileHierarchyService::File.new(attached_files[1])
-                ], 3) # <--- this index should be 2 and not 3, since it is at the second level (same level as dir2)
+                ], 2)
             ],
             [
               FileHierarchyService::File.new(attached_files[2]),


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2943 - show file hierarchy on the work show page, as mocked up here: https://projects.invisionapp.com/share/YQ132HXFX2GR#/screens/471005875

Borrowing from the Argo display: https://github.com/sul-dlss/argo/pull/3913/files

Questions:

- what does the empty vs filled in folder icon mean in the mockups? note: we will never have a folder with no files in it in H2 (and how to render an empty folder?)

## How was this change tested? 🤨

- Localhost
- Existing tests
- Updated/added tests
