### PR TITLE
Adding globus_setup_complete event text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,7 @@ en:
       unzip_and_submit_for_review: Starting unzip
       unzip_and_begin_deposit: Starting unzip
       unzip_complete: Unzip complete
+      globus_setup_complete: Setting up Globus endpoint
       fetch_globus: Starting fetch from Globus
       fetch_globus_and_submit_for_review: Starting fetch from Globus
       fetch_globus_and_begin_deposit: Starting fetch from Globus


### PR DESCRIPTION
## Why was this change made? 🤔
Adding a translation for the `globus_setup_complete` event to go from:

![Screen Shot 2023-01-12 at 4 49 13 PM](https://user-images.githubusercontent.com/1619369/212188596-3cd7c276-883b-4377-b66e-85dfd21950f0.png)

to 

![Screen Shot 2023-01-12 at 4 39 23 PM](https://user-images.githubusercontent.com/1619369/212188299-3c2edca9-4f17-4266-aefe-06087349c0ff.png)

@amyehodge if you would like different wording, just let me know.

## How was this change tested? 🤨
Unit

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


