### PR TITLE
Update user message for globus setup complete button.

### DIFF
--- a/app/components/works/globus_setup_component.html.erb
+++ b/app/components/works/globus_setup_component.html.erb
@@ -1,9 +1,16 @@
 <% if work_version.globus_setup_draft? %>
    <div class="row my-5 mx-2 alert alert-danger">
       <div class="col-9">
-         Click this button when you have completed setting up your Globus account and we will email you instructions on where to upload your files.
+         <p><strong>You have initiated a Globus-mediated deposit. Here are your next steps. 
+            If you need help, visit the <%= link_to 'help page', Settings.globus.help_doc_url, target: '_blank' %>.</strong>
+         </p>
+         <ul>
+           <li>Click this button when you have completed setting up your Globus account and installing any necessary software.</li>
+           <li>Check for an email from "Globus Notification" with the link to the location for uploading your files.</li>
+           <li>Follow these <%= link_to 'instructions', "#{Settings.globus.help_doc_url}/edit?pli=1#heading=h.f2rvtrjiw01", target: '_blank' %> to transfer your files.</li>        
+         </ul>
       </div>
-      <div class="col-3">
+      <div class="col-3 d-flex align-items-center">
          <%= render Works::GlobusSetupButtonComponent.new(work_version:) %>
       </div>
    </div>


### PR DESCRIPTION
## Why was this change made? 🤔

Resolves #2953 to add instructions to globus setup complete button message. 

## How was this change tested? 🤨
Unit.

Here's what this looks like, @amyehodge. I can deploy to QA/stage if you like. (Sorry, this was an admin user so that box is in the images):

BEFORE
![Screen Shot 2023-01-18 at 8 59 56 AM](https://user-images.githubusercontent.com/1619369/213201226-942c6c27-e0d1-4232-9b51-677394a1b596.png)

AFTER
![Screen Shot 2023-01-18 at 9 27 39 AM](https://user-images.githubusercontent.com/1619369/213200763-a09f94be-4715-4d46-9f21-8d34ebf10575.png)


⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


