### PR TITLE
Separate detail message for globus wait states

### DIFF
--- a/app/assets/stylesheets/work.scss
+++ b/app/assets/stylesheets/work.scss
@@ -34,6 +34,10 @@
       @extend .fst-italic;
       margin-left: 30px;
     }
+
+    .globus-wait {
+      color: #D1660F;
+    }
   }
 
   .details {

--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -14,10 +14,10 @@
     </div>
   <% end %>
 
-  <header class="title clearfix"><%# clearfix here prevents the EditButtonCompnent from spilling outside the container if the title is long %>
+  <header class="title clearfix"><%# clearfix here prevents the EditButtonComponent from spilling outside the container if the title is long %>
     <span class="header-text"><%= title %></span>
     <%= helpers.turbo_frame_tag dom_id(work, :edit), src: edit_button_work_path(work), target: '_top' %>
-    <span class="state"><%= render Works::StateDisplayComponent.new(work_version: work_version) %></span>
+    <span class="state"><%= render Works::DetailStateDisplayComponent.new(work_version: work_version) %></span>
     <%= render Works::EditButtonComponent.new(work_version: work_version) %>
   </header>
 

--- a/app/components/works/detail_state_display_component.rb
+++ b/app/components/works/detail_state_display_component.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Works
+  # Displays information about the current state of the deposit
+  class DetailStateDisplayComponent < ApplicationComponent
+    def initialize(work_version:)
+      @work_version = work_version
+    end
+
+    attr_reader :work_version
+
+    def call
+      value = I18n.t(work_version.state, scope: 'work.state')
+      return value unless work_version.wait_state?
+
+      if work_version.fetching_globus_state?
+        message = 'Transferring your files from Globus. This could take some time depending on file size.
+                  You may leave this page or close this window and return later.'
+        tag.span(message, class: 'globus-wait')
+      else
+        safe_join([value, spinner], ' ')
+      end
+    end
+
+    def spinner
+      tag.span class: 'fa-solid fa-spinner fa-pulse'
+    end
+  end
+end

--- a/spec/components/works/detail_component_spec.rb
+++ b/spec/components/works/detail_component_spec.rb
@@ -65,6 +65,16 @@ RSpec.describe Works::DetailComponent, type: :component do
     end
   end
 
+  context 'when fetching globus files' do
+    let(:work_version) { build_stubbed(:work_version, :fetch_globus_first_draft) }
+
+    it 'renders the message about transferring files taking time' do
+      expect(rendered.css('.globus-wait').to_html).to include(
+        'Transferring your files from Globus. This could take some time depending on file size.'
+      )
+    end
+  end
+
   describe 'events' do
     let(:work) { build_stubbed(:work, events:) }
     let(:events) do

--- a/spec/factories/object_states.rb
+++ b/spec/factories/object_states.rb
@@ -35,4 +35,8 @@ FactoryBot.define do
   trait :new do
     state { 'new' }
   end
+
+  trait :fetch_globus_first_draft do
+    state { 'fetch_globus_first_draft' }
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Resolves #2959 to show a different message, without a spinner, on the detail page when waiting for Globus files to transfer. 

![Screen Shot 2023-01-18 at 3 33 58 PM](https://user-images.githubusercontent.com/1619369/213288950-00a7195a-6aae-4a02-8c16-c2093dbcf68e.png)

This will also wrap, @amyehodge was OK with that (see conversation in #2959). 

## How was this change tested? 🤨
Unit, added spec. 


⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


