### PR TITLE
Showing files table with a message for globus type

### DIFF
--- a/app/components/works/show/files_component.html.erb
+++ b/app/components/works/show/files_component.html.erb
@@ -1,14 +1,28 @@
-<turbo-frame id="<%= dom_id(work, 'files_list') %>" src="<%= files_list_work_path(work) %>" loading="lazy">
+<% if work_version.browser? %>
+  <turbo-frame id="<%= dom_id(work, 'files_list') %>" src="<%= files_list_work_path(work) %>" loading="lazy">
+    <table class="table table-sm mb-5" id="filesTable">
+      <thead class="table-light">
+      <tr>
+        <th scope="col" class="table-title">Files</th>
+        <th scope="col">Description</th>
+        <th scope="col">Hide file</th>
+      </tr>
+      </thead>
+      <tbody>
+        <tr><td colspan="3" class="text-center"><%= spinner %></td></tr>
+      </tbody>
+    </table>
+  </turbo-frame>
+<% elsif work_version.globus? %>
   <table class="table table-sm mb-5" id="filesTable">
     <thead class="table-light">
     <tr>
       <th scope="col" class="table-title">Files</th>
-      <th scope="col">Description</th>
-      <th scope="col">Hide file</th>
     </tr>
     </thead>
     <tbody>
-      <tr><td colspan="3" class="text-center"><%= spinner %></td></tr>
+      <tr><td><em>Your files will appear here once you've clicked the Edit button above, checked the box to confirm file upload
+                  to Globus is complete, and either saved the draft again or completed the deposit.</em></td></tr>
     </tbody>
   </table>
-</turbo-frame>
+<% end %>

--- a/app/components/works/show/files_component.rb
+++ b/app/components/works/show/files_component.rb
@@ -12,13 +12,13 @@ module Works
 
       delegate :attached_files, :work, to: :work_version
 
-      def render?
-        # Hide this while unzipping and fetching files from Globus
-        work_version.browser?
-      end
-
       def download_all?
         work_version.attached_files.all? { |attached_file| !attached_file.in_globus? }
+      end
+
+      # show files only for browser and globus upload_types, not zipfile
+      def render?
+        work_version.browser? || work_version.globus?
       end
 
       def spinner


### PR DESCRIPTION
## Why was this change made? 🤔

Resolves #2958 to add a files component with a message for globus uploads. 

## How was this change tested? 🤨
Unit and QA. 

Here's what the box looks like on QA, @amyehodge:

![Screen Shot 2023-01-19 at 3 20 52 PM](https://user-images.githubusercontent.com/1619369/213552625-916d8a32-0ae3-4d22-b881-e01113fbdbff.png)

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


