### PR TITLE
Use work id in globus attached_file blob key

### DIFF
--- a/app/models/attached_file.rb
+++ b/app/models/attached_file.rb
@@ -31,7 +31,7 @@ class AttachedFile < ApplicationRecord
   end
 
   def create_globus_active_storage_key
-    ActiveStorage::Service::GlobusService.encode_key(work_version.work.druid,
+    ActiveStorage::Service::GlobusService.encode_key(work_version.work.id,
                                                      work_version.version,
                                                      path)
   end

--- a/app/services/active_storage/service/globus_service.rb
+++ b/app/services/active_storage/service/globus_service.rb
@@ -19,6 +19,13 @@ module ActiveStorage
         # to be raised to HB either: https://app.honeybadger.io/projects/77112/faults/88770594
       end
 
+      def delete_prefixed(key)
+        # See comment for #delete above. Can be called with #destroy_all on AttachedFiles when
+        # an updated set of files is uploaded to the same work version via Globus.
+        # Would raise a NotImplementedError to HB:
+        # https://app.honeybadger.io/projects/77112/faults/92680932
+      end
+
       def self.encode_key(work_id, version, path)
         [work_id, version, path].join('/')
       end

--- a/app/services/active_storage/service/globus_service.rb
+++ b/app/services/active_storage/service/globus_service.rb
@@ -19,8 +19,8 @@ module ActiveStorage
         # to be raised to HB either: https://app.honeybadger.io/projects/77112/faults/88770594
       end
 
-      def self.encode_key(druid, version, path)
-        [druid, version, path].join('/')
+      def self.encode_key(work_id, version, path)
+        [work_id, version, path].join('/')
       end
 
       # @return [Boolean] true if this blob is for the GlobusService

--- a/spec/jobs/fetch_globus_job_spec.rb
+++ b/spec/jobs/fetch_globus_job_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe FetchGlobusJob do
     attached_file = first_work_version.reload.attached_files.first
     expect(attached_file.path).to eq('file1.txt')
     expect(attached_file.blob.service_name).to eq('globus')
+    expect(attached_file.blob.key).to eq("#{first_work_version.work.id}/1/file1.txt")
     expect(GlobusClient).to have_received(:get_filenames).with(path: 'jstanford/work333/version1',
                                                                user_id: work.owner.email)
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Resolves #2966 to use the work ID rather than the druid for globus attached file blob keys.

## How was this change tested? 🤨
Unit and QA
⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


