### PR TITLE
Tweak version checking strategy.

### DIFF
--- a/app/services/repository.rb
+++ b/app/services/repository.rb
@@ -14,10 +14,9 @@ class Repository
   def self.valid_version?(druid:, h2_version:)
     cocina_obj = find(druid)
 
-    # This occurs when reserving a PURL.
-    return true if cocina_obj.version == 1 && h2_version == 1
-
-    cocina_obj.version == h2_version - 1
+    # This is the same logic as SDR API.
+    allowed_versions = [cocina_obj.version, cocina_obj.version + 1]
+    allowed_versions.include?(h2_version)
   end
 
   def self.ensure_logged_in!

--- a/spec/services/repository_spec.rb
+++ b/spec/services/repository_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Repository do
         externalIdentifier: druid,
         type: Cocina::Models::ObjectType.book,
         label: 'Test DRO',
-        version: 1,
+        version: cocina_version,
         description: {
           title: [{ value: 'Test DRO' }],
           purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
@@ -23,6 +23,8 @@ RSpec.describe Repository do
         structural: {}
       }
     end
+
+    let(:cocina_version) { 1 }
 
     before do
       allow(SdrClient::Find).to receive(:run).and_return(cocina.to_json)
@@ -65,8 +67,17 @@ RSpec.describe Repository do
       end
     end
 
-    context 'when the H2 version and SDR version are 1' do
+    context 'when the H2 version and SDR version are 1 (PURL reservation)' do
       let(:h2_version) { 1 }
+
+      it 'returns true' do
+        expect(valid_version?).to be true
+      end
+    end
+
+    context 'when the H2 version and SDR version are same (embargo lifted)' do
+      let(:h2_version) { 2 }
+      let(:cocina_version) { 2 }
 
       it 'returns true' do
         expect(valid_version?).to be true


### PR DESCRIPTION
closes #2971

## Why was this change made? 🤔
To allow embargoes to be lifted without creating a kurflufel.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit, Amy
