### PR TITLE
Hide globus confirmation checkbox until new version draft saved

### DIFF
--- a/app/components/works/add_files_component.rb
+++ b/app/components/works/add_files_component.rb
@@ -22,7 +22,8 @@ module Works
     end
 
     def globus_endpoint?
-      form.object.work_version.globus_endpoint.present?
+      # Only show checkbox once a new work_version with a cleared out globus_endpoint has been created.
+      !form.object.work_version.deposited? && form.object.work_version.globus_endpoint.present?
     end
   end
 end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -172,6 +172,8 @@ class WorksController < ObjectsController
     previous_version.dup.tap do |work_version|
       work_version.state = 'version_draft'
       work_version.version = previous_version.version + 1
+      # reset globus endpoint
+      work_version.globus_endpoint = nil
       CollectionObserver.version_draft_created(work_version, nil)
     end
   end

--- a/spec/components/works/add_files_component_spec.rb
+++ b/spec/components/works/add_files_component_spec.rb
@@ -30,7 +30,16 @@ RSpec.describe Works::AddFilesComponent do
   context 'when globus section' do
     it 'shows the globus upload option' do
       expect(rendered.to_html).to include('Set up a Stanford Globus account')
-      expect(rendered.to_html).not_to include('I have uploaded my files to a Globus endpoint')
+      expect(rendered.to_html).not_to include('Check this box once all your files have been uploaded to Globus.')
+    end
+  end
+
+  context 'when creating a new work version from a previous globus upload version' do
+    let(:work_version) { build(:work_version, :with_globus_endpoint, work:) }
+    let(:work_form) { WorkForm.new(work_version:, work:) }
+
+    it 'does not shows the globus files confirmation checkbox' do
+      expect(rendered.to_html).not_to include('Check this box once all your files have been uploaded to Globus.')
     end
   end
 end

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -227,4 +227,9 @@ FactoryBot.define do
        association(:attached_file, path: 'sul.svg', file: uploads[1].signed_id)]
     end
   end
+
+  trait :with_globus_endpoint do
+    globus_endpoint { 'userid/workid/version1' }
+    deposited
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #2970 so that previous version's globus endpoint is not used on a new work version. 

## How was this change tested? 🤨
Unit and QA

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


