### PR TITLE
Adds globus integration test support.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,6 +15,8 @@ globus:
   help_doc_url: https://docs.google.com/document/d/10b7y3yZCOfyVJ_uP4l7QHbkILQKnfdJi9hj-MpmmdIk
   test_mode: false # for testing purposes in non-production only, simulates globus API calls
   test_user_exists: true # if test_mode=true, simulates if the globus user exists
+  integration_mode: false # set to true for integration test
+  integration_endpoint: 'integration_test/work388/version1'
 
 accountws:
   pem_file: /etc/pki/tls/certs/sul-h2-qa.stanford.edu.pem


### PR DESCRIPTION
refs https://github.com/sul-dlss/infrastructure-integration-test/issues/534

## Why was this change made? 🤔
To allow an integration test to bypass a user adding files to globus.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


