### PR TITLE
Allow deploying `main` to prod again

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,6 @@
 
 happy-heron, or H2 (from "Hydrus 2.0"), is a Rails web application enabling users to deposit scholarly content into the SDR. It replaced [Hydrus](https://github.com/sul-dlss/hydrus).
 
-**********************************
-__H2 is currently frozen in production__
-
-* The `production` branch is what is currently deployed in production.
-* Any necessary production patches should be applied to this branch and deployed with `cap prod deploy`.
-* `main` cannot be deployed to production due to changes in `config/deploy/prod.rb`. This should be removed once the freeze is lifted.
-* `sdr-deploy` has been configured to skip deploying H2 to production. This should be removed once the freeze is lifted.
-
-**********************************
-
 ## UX Design
 
 * Comps: https://projects.invisionapp.com/share/EQXC9CLKCR2

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# Server hostname is prefixed with "x" to prevent accidental deploy while frozen.
-server 'xsul-h2-prod.stanford.edu', user: 'h2', roles: %w[web app db cron]
+server 'sul-h2-prod.stanford.edu', user: 'h2', roles: %w[web app db cron]
 
 Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
## Why was this change made? 🤔

Reverts #2905

We are clear to deploy H2 `main` to prod again!


## How was this change tested? 🤨

N/A
