### PR TITLE
Increase sdr client read_timeout

### DIFF
--- a/app/jobs/deposit_job.rb
+++ b/app/jobs/deposit_job.rb
@@ -66,7 +66,7 @@ class DepositJob < BaseDepositJob
   end
 
   def connection
-    @connection ||= SdrClient::Connection.new(url: Settings.sdr_api.url)
+    @connection ||= SdrClient::Connection.new(url: Settings.sdr_api.url, read_timeout: 1800)
   end
 
   def build_file_metadata(blobs_map)


### PR DESCRIPTION
## Why was this change made? 🤔
Addressing timeout error with a deposit, resolves #2992. 


## How was this change tested? 🤨
Unit, stage integration test (although that is failing at the shelve step, which I see happening in other contexts too.)

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


