### PR TITLE
Check validity of correct version number

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -301,7 +301,8 @@ class WorksController < ObjectsController
       return params[:invalid_version].present?
     end
 
-    work.druid && !Repository.valid_version?(druid: work.druid, h2_version: work_version.version)
+    # new work_version has not been created yet, so adding 1 to current version
+    work.druid && !Repository.valid_version?(druid: work.druid, h2_version: work_version.version + 1)
   end
 end
 # rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
## Why was this change made? 🤔
Fixes problem where there is an acceptable version mismatch (H2 version is one less than Argo) but H2 is not allowing a new version to be created. 


## How was this change tested? 🤨
Unit, QA with integration test

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


