### PR TITLE
Check validity of correct version number

### DIFF
--- a/app/models/concerns/work_version_state_machine.rb
+++ b/app/models/concerns/work_version_state_machine.rb
@@ -173,7 +173,7 @@ module WorkVersionStateMachine
 
       return if Repository.valid_version?(druid: work.druid, h2_version: version)
 
-      errors.add(:version, 'must be one greater than the version in SDR')
+      errors.add(:version, 'must be one greater than or equal to the version in SDR')
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Allow work_version drafts to be edited without running into a version check issue.

Follow on from #2994


## How was this change tested? 🤨

Existing tests and QA