### PR TITLE
ensure we do not run the object update method after creating it

### DIFF
--- a/app/models/concerns/work_version_state_machine.rb
+++ b/app/models/concerns/work_version_state_machine.rb
@@ -13,7 +13,10 @@ module WorkVersionStateMachine
       before_transition WorkObserver.method(:before_transition)
 
       after_transition WorkObserver.method(:after_transition)
-      after_transition to: :depositing, do: WorkObserver.method(:after_begin_deposit)
+      # we do not want to fire this WorkObserver event twice, which will occur after when a new object is
+      # registered, first on object registration, and second after the PID is assigned... so only run
+      # this method the first time we enter the depositing state
+      after_transition except_from: :depositing, to: :depositing, do: WorkObserver.method(:after_begin_deposit)
       after_transition on: :reserve_purl, do: WorkObserver.method(:after_begin_reserve)
       after_transition on: :pid_assigned, do: WorkObserver.method(:after_druid_assigned)
       after_transition on: :reject, do: WorkObserver.method(:after_rejected)


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #2997 - the PURL and DOI link placeholders should be replaced with the actual values in the cocina (and thus on the PURL)

What we found:
- in some example druids, e.g. https://argo.stanford.edu/view/druid:tb076ph9251 we noticed that the cocina had correctly replaced the placeholder links in a "create" event, but then there was an "update" event shortly after with the incorrect cocina
- DSA shows that the create action will replace the link placeholders but the update action will not (see https://github.com/sul-dlss/dor-services-app/blob/main/app/services/create_object_service.rb#L116-L123)
- we then tried to investigate why an update event occurred with bad data after the correct data was posted by looking at sdr-api logs
- the only part of H2 that appears to call sdr-api is the DepositJob, which is only called from one place, which is the WorkObserver after you transition to "depositing"
- we then noticed that the work version state machine changed how this deposit job was invoked, before: https://github.com/sul-dlss/happy-heron/blob/production/app/models/concerns/work_version_state_machine.rb#L16-L19  and after: https://github.com/sul-dlss/happy-heron/blob/main/app/models/concerns/work_version_state_machine.rb#L16

We then speculated that the job is being invoked twice unnecessarily, because the transition occurs twice and getting a PID has a transition from 'deposting' back to the same, possibly invoking the job twice now, with the second time being an update call to SDR, which would not replace to the link text.  

## How was this change tested? 🤨

Tested on -stage with a zip and a regular object