### PR TITLE
Retain path in new work versions.

### DIFF
--- a/app/components/works/edit/attached_file_component.html.erb
+++ b/app/components/works/edit/attached_file_component.html.erb
@@ -1,5 +1,6 @@
 <tr class="attached-files <%= 'dz-complete' if uploaded? %>" data-dropzone-target="preview">
     <%= form.fields_for :attached_files, attached_file do |file_form| %>
+    <%= file_form.hidden_field :path %>
     <td class="file-level" style="--depth: <%= depth %>rem" data-dropzone-path="<%= path %>">
         <span class="fa-regular fa-file" aria-hidden="true"></span> <%= basename %>
     </td>


### PR DESCRIPTION
closes #2998

## Why was this change made? 🤔
So that hierarchy isn't lost on new work versions.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Local
