### PR TITLE
add redirect for old contact form to new help form

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,8 @@ Rails.application.routes.draw do
     { controller: 'welcome', action: 'show', anchor: 'help' }
   end
   # legacy /contact links in PURLs should redirect to new contact form URL
+  # see https://jirasul.stanford.edu/jira/browse/PURL-1206
+  # e.g. https://purl.stanford.edu/gp739cs2671 which has the old URL encoded in the rightsMetadata XML
   get 'contact', to: redirect('/#help')
 
   resource :help, only: %i[new create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,9 @@ Rails.application.routes.draw do
   direct :contact_form do
     { controller: 'welcome', action: 'show', anchor: 'help' }
   end
+  # legacy /contact links in PURLs should redirect to new contact form URL
+  get 'contact', to: redirect('/#help')
+
   resource :help, only: %i[new create]
   get 'print_terms_of_deposit', to: 'print#terms_of_deposit'
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3014 - add a redirect for old contact form URL to new one

## How was this change tested? 🤨

Localhost