### PR TITLE
Reconnect to database

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -550,6 +550,7 @@ PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
## Why was this change made? 🤔

We've observed that long running Globus `list_files()` operations can cause the database connection to be lost, and subsequent attempts to use the database fail. This change should cause connections to be re-established.

(hopefully) fixes #3019

## How was this change tested? 🤨

Unit tests

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


