### PR TITLE
do not alert HB for a purge

### DIFF
--- a/app/services/active_storage/service/sdr_service.rb
+++ b/app/services/active_storage/service/sdr_service.rb
@@ -23,6 +23,12 @@ module ActiveStorage
         # to be raised to HB either: https://app.honeybadger.io/projects/77112/faults/88770594
       end
 
+      def delete_prefixed(prefix)
+        # See comment for #delete above.  Called for images by ActiveSupport when #destroy is called
+        # on AttachedFile.  Also marked as a noop for the same reason.
+        # Would raise a NotImplementedError to HB: https://app.honeybadger.io/projects/77112/faults/94613200
+      end
+
       def self.encode_key(druid, version, filepath)
         [druid, version, filepath].join('/')
       end


### PR DESCRIPTION
## Why was this change made? 🤔

When purging objects that have images, we do not want ActiveStorage to do anything.  Currently we get an HB alert from a raise in the ActiveStorage stack, this just makes it a no-op, which we already have for the `#delete` method.  This `#delete_prefixed` method is also called for images by ActiveStorage and also needs a noop. It is the same change as was done for the globus service a couple months ago: https://github.com/sul-dlss/happy-heron/pull/2969/files

The HB alert: https://app.honeybadger.io/projects/77112/faults/88770594

## How was this change tested? 🤨

Existing CI