### PR TITLE
allow admin user to edit message shown on home page/dashboard

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -22,7 +22,7 @@
         font-weight: normal;
       }
     }
-    
+
     .work-title {
       width: 28%;
     }
@@ -40,4 +40,23 @@
 ul.collections {
   list-style-type: none;
   padding-left: 0;
+}
+
+.page-content-message-dashboard-top {
+  font-size: 1.0rem;
+  font-style: italic;
+  text-align: center;
+
+  a {
+    text-decoration: underline;
+  }
+}
+
+.page-content-message-dashboard-bottom {
+  font-size: 0.9rem;
+  font-style: italic;
+
+  a {
+    text-decoration: underline;
+  }
 }

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -52,6 +52,10 @@ ul.collections {
   }
 }
 
+.yellow {
+  color: #FEC51D;
+}
+
 .page-content-message-dashboard-bottom {
   font-size: 0.9rem;
   font-style: italic;

--- a/app/assets/stylesheets/frontpage.scss
+++ b/app/assets/stylesheets/frontpage.scss
@@ -103,6 +103,10 @@
   }
 }
 
+.yellow {
+  color: #FEC51D;
+}
+
 .page-content-message {
   font-size: 1.1rem;
   font-style: italic;

--- a/app/assets/stylesheets/frontpage.scss
+++ b/app/assets/stylesheets/frontpage.scss
@@ -102,3 +102,13 @@
     margin-top: 2rem;
   }
 }
+
+.page-content-message {
+  font-size: 1.1rem;
+  font-style: italic;
+
+  a {
+    color: white;
+    text-decoration: underline;
+  }
+}

--- a/app/components/admin/navigation_component.rb
+++ b/app/components/admin/navigation_component.rb
@@ -9,7 +9,7 @@ module Admin
                                     ['Search for user', admin_users_path],
                                     ['Generate collection report', new_admin_collection_report_path],
                                     ['Generate item report', new_admin_work_report_path],
-                                    ['Edit home page message', admin_page_content_index_path]],
+                                    ['Edit page content', admin_page_content_index_path]],
                                    request.env['PATH_INFO'])
       select_tag 'path', options, class: 'form-select', onchange: 'window.location.href = this.value'
     end

--- a/app/components/admin/navigation_component.rb
+++ b/app/components/admin/navigation_component.rb
@@ -3,6 +3,12 @@
 module Admin
   # Displays the drop down navigation for the admin pages
   class NavigationComponent < ApplicationComponent
+    def initialize(selected: nil)
+      @selected = selected
+    end
+
+    attr_reader :selected
+
     def dropdown
       options = options_for_select([['Admin page', admin_path],
                                     ['Search for DRUID', admin_druid_searches_path],
@@ -10,7 +16,7 @@ module Admin
                                     ['Generate collection report', new_admin_collection_report_path],
                                     ['Generate item report', new_admin_work_report_path],
                                     ['Edit page content', admin_page_content_index_path]],
-                                   request.env['PATH_INFO'])
+                                   selected || request.env['PATH_INFO'])
       select_tag 'path', options, class: 'form-select', onchange: 'window.location.href = this.value'
     end
   end

--- a/app/components/admin/navigation_component.rb
+++ b/app/components/admin/navigation_component.rb
@@ -8,7 +8,8 @@ module Admin
                                     ['Search for DRUID', admin_druid_searches_path],
                                     ['Search for user', admin_users_path],
                                     ['Generate collection report', new_admin_collection_report_path],
-                                    ['Generate item report', new_admin_work_report_path]],
+                                    ['Generate item report', new_admin_work_report_path],
+                                    ['Edit home page message', admin_page_content_index_path]],
                                    request.env['PATH_INFO'])
       select_tag 'path', options, class: 'form-select', onchange: 'window.location.href = this.value'
     end

--- a/app/components/dashboard/page_content_component.html.erb
+++ b/app/components/dashboard/page_content_component.html.erb
@@ -1,0 +1,4 @@
+<div>
+    <p><%= page_content.value %></p>
+    <%= link_to 'Read me details', Settings.more_news_url %>
+</div>

--- a/app/components/dashboard/page_content_component.html.erb
+++ b/app/components/dashboard/page_content_component.html.erb
@@ -1,4 +1,3 @@
-<div>
-    <p><%= page_content.value %></p>
-    <%= link_to 'Read me details', Settings.more_news_url %>
+<div class="page-content-message-dashboard-<%=location%>">
+    <p><i class="fa-solid fa-star-of-life" style="color: #fedb4f;"></i> <%= page_content.value %> <%= link_to 'More >', Settings.more_news_url %></p>
 </div>

--- a/app/components/dashboard/page_content_component.html.erb
+++ b/app/components/dashboard/page_content_component.html.erb
@@ -1,3 +1,3 @@
 <div class="page-content-message-dashboard-<%=location%>">
-    <p><i class="fa-solid fa-star-of-life" style="color: #fedb4f;"></i> <%= page_content.value %> <%= link_to 'More >', Settings.more_news_url %></p>
+    <p><i class="fa-solid fa-asterisk" style="color: #FEC51D;"></i> <%= page_content.value %> <%= link_to page_content.link_text, page_content.link_url if page_content.link_visible %></p>
 </div>

--- a/app/components/dashboard/page_content_component.html.erb
+++ b/app/components/dashboard/page_content_component.html.erb
@@ -1,3 +1,3 @@
 <div class="page-content-message-dashboard-<%=location%>">
-    <p><i class="fa-solid fa-asterisk" style="color: #FEC51D;"></i> <%= page_content.value %> <%= link_to page_content.link_text, page_content.link_url if page_content.link_visible %></p>
+    <p><i class="fa-solid fa-asterisk yellow"></i> <%= page_content.value %> <%= link_to page_content.link_text, page_content.link_url if page_content.link_visible %></p>
 </div>

--- a/app/components/dashboard/page_content_component.rb
+++ b/app/components/dashboard/page_content_component.rb
@@ -3,11 +3,12 @@
 module Dashboard
   # Renders an optional user message on the dashboard page
   class PageContentComponent < ApplicationComponent
-    def initialize(page_content:)
+    def initialize(page_content:, location:)
       @page_content = page_content
+      @location = location
     end
 
-    attr_reader :page_content
+    attr_reader :page_content, :location
 
     def render?
       page_content.present? && page_content.visible

--- a/app/components/dashboard/page_content_component.rb
+++ b/app/components/dashboard/page_content_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Dashboard
+  # Renders an optional user message on the dashboard page
+  class PageContentComponent < ApplicationComponent
+    def initialize(page_content:)
+      @page_content = page_content
+    end
+
+    attr_reader :page_content
+
+    def render?
+      page_content.present? && page_content.visible
+    end
+  end
+end

--- a/app/components/page_content_component.html.erb
+++ b/app/components/page_content_component.html.erb
@@ -1,0 +1,4 @@
+<div>
+    <p><%= page_content.value %></p>
+    <%= link_to 'Read me details', Settings.more_news_url %>
+</div>

--- a/app/components/page_content_component.html.erb
+++ b/app/components/page_content_component.html.erb
@@ -1,3 +1,3 @@
 <div class="page-content-message">
-    <p><i class="fa-solid fa-star-of-life" style="color: #fedb4f;"></i> <%= page_content.value %> <%= link_to 'More >', Settings.more_news_url %></p>
+    <p><i class="fa-solid fa-asterisk" style="color: #FEC51D;"></i> <%= page_content.value %> <%= link_to page_content.link_text, page_content.link_url if page_content.link_visible %></p>
 </div>

--- a/app/components/page_content_component.html.erb
+++ b/app/components/page_content_component.html.erb
@@ -1,4 +1,3 @@
-<div>
-    <p><%= page_content.value %></p>
-    <%= link_to 'Read me details', Settings.more_news_url %>
+<div class="page-content-message">
+    <p><i class="fa-solid fa-star-of-life" style="color: #fedb4f;"></i> <%= page_content.value %> <%= link_to 'More >', Settings.more_news_url %></p>
 </div>

--- a/app/components/page_content_component.html.erb
+++ b/app/components/page_content_component.html.erb
@@ -1,3 +1,3 @@
 <div class="page-content-message">
-    <p><i class="fa-solid fa-asterisk" style="color: #FEC51D;"></i> <%= page_content.value %> <%= link_to page_content.link_text, page_content.link_url if page_content.link_visible %></p>
+    <p><i class="fa-solid fa-asterisk yellow"></i> <%= page_content.value %> <%= link_to page_content.link_text, page_content.link_url if page_content.link_visible %></p>
 </div>

--- a/app/components/page_content_component.rb
+++ b/app/components/page_content_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Renders an optional user message on the selected page
+class PageContentComponent < ApplicationComponent
+  def initialize(page_content:)
+    @page_content = page_content
+  end
+
+  attr_reader :page_content
+
+  def render?
+    page_content.present? && page_content.visible
+  end
+end

--- a/app/components/page_content_component.rb
+++ b/app/components/page_content_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Renders an optional user message on the selected page
+# Renders an optional user message on the home page
 class PageContentComponent < ApplicationComponent
   def initialize(page_content:)
     @page_content = page_content

--- a/app/controllers/admin/page_content_controller.rb
+++ b/app/controllers/admin/page_content_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Admin
+  # Generates work reports
+  class PageContentController < ApplicationController
+    before_action :authenticate_user!
+    verify_authorized
+
+    def index
+      authorize! :page_content
+      @page_content = PageContent.find_by(page: 'home')
+    end
+
+    # rubocop:disable Metrics/AbcSize
+    def update
+      authorize! :page_content
+
+      page_content = PageContent.find_by(page: 'home')
+      if page_content.update(page_content_params.merge(user: current_user))
+        flash[:success] = I18n.t('admin.page_content.success')
+      else
+        flash[:error] = "#{I18n.t('admin.page_content.error')}: #{page_content.errors.full_messages.join(', ')}"
+      end
+
+      redirect_to admin_page_content_index_path
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    private
+
+    def page_content_params
+      params.require(:page_content).permit(:value, :visible)
+    end
+  end
+end

--- a/app/controllers/admin/page_content_controller.rb
+++ b/app/controllers/admin/page_content_controller.rb
@@ -41,7 +41,7 @@ module Admin
     private
 
     def page_content_params
-      params.require(:page_content).permit(:value, :visible)
+      params.require(:page_content).permit(:value, :visible, :link_visible, :link_url, :link_text)
     end
   end
 end

--- a/app/controllers/admin/page_content_controller.rb
+++ b/app/controllers/admin/page_content_controller.rb
@@ -8,23 +8,35 @@ module Admin
 
     def index
       authorize! :page_content
-      @page_content = PageContent.find_by(page: 'home')
+
+      # NOTE: the user cannot create new pages, they are created manually in a migration
+      # or on the rails console.  The user can then edit them.
+      # As of April 2023, we only have one page in the database that can be edited, so just
+      # shortcut to that edit view.  If we create more pages in the future, remove
+      # this redirect, and this index page showing all available pages will be shown.
+      redirect_to edit_admin_page_content_path(PageContent.find_by(page: 'home'))
+
+      @page_contents = PageContent.all
     end
 
-    # rubocop:disable Metrics/AbcSize
+    def edit
+      authorize! :page_content
+
+      @page_content = PageContent.find(params[:id])
+    end
+
     def update
       authorize! :page_content
 
-      page_content = PageContent.find_by(page: 'home')
-      if page_content.update(page_content_params.merge(user: current_user))
-        flash[:success] = I18n.t('admin.page_content.success')
-      else
-        flash[:error] = "#{I18n.t('admin.page_content.error')}: #{page_content.errors.full_messages.join(', ')}"
-      end
+      @page_content = PageContent.find(params[:id])
 
-      redirect_to admin_page_content_index_path
+      if @page_content.update(page_content_params.merge(user: current_user))
+        flash[:success] = I18n.t('admin.page_content.success')
+        redirect_to admin_page_content_index_path
+      else
+        render action: 'edit', status: :unprocessable_entity
+      end
     end
-    # rubocop:enable Metrics/AbcSize
 
     private
 

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -10,6 +10,7 @@ class DashboardsController < ApplicationController
 
     authorize! :dashboard
     @presenter = build_presenter
+    @page_content = PageContent.find_by(page: 'home')
   end
 
   private

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -3,6 +3,7 @@
 # The endpoint for the landing page
 class WelcomeController < ApplicationController
   def show
+    @page_content = PageContent.find_by(page: 'home')
     return render :first_time if user_signed_in? && !allowed_to?(:show?, :dashboard)
   end
 end

--- a/app/models/page_content.rb
+++ b/app/models/page_content.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Optional text to display on home page/dashboard, as edited by an Admin user
+class PageContent < ApplicationRecord
+  validates :value, length: { maximum: 30 }
+end

--- a/app/models/page_content.rb
+++ b/app/models/page_content.rb
@@ -3,4 +3,6 @@
 # Optional text to display on home page/dashboard, as edited by an Admin user
 class PageContent < ApplicationRecord
   validates :value, length: { maximum: 1000 }
+  validates :link_text, length: { minimum: 5, maximum: 100 }, if: :link_visible
+  validates :link_url, format: URI::DEFAULT_PARSER.make_regexp(%w[http https]), if: :link_visible
 end

--- a/app/models/page_content.rb
+++ b/app/models/page_content.rb
@@ -2,5 +2,5 @@
 
 # Optional text to display on home page/dashboard, as edited by an Admin user
 class PageContent < ApplicationRecord
-  validates :value, length: { maximum: 30 }
+  validates :value, length: { maximum: 1000 }
 end

--- a/app/policies/page_content_policy.rb
+++ b/app/policies/page_content_policy.rb
@@ -2,11 +2,10 @@
 
 # Defines who is authorized to see the page content update (admin page)
 class PageContentPolicy < ApplicationPolicy
-  def index?
-    administrator?
-  end
+  alias_rule :update?, to: :index?
+  alias_rule :edit?, to: :index?
 
-  def update?
+  def index?
     administrator?
   end
 end

--- a/app/policies/page_content_policy.rb
+++ b/app/policies/page_content_policy.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Defines who is authorized to see the page content update (admin page)
+class PageContentPolicy < ApplicationPolicy
+  def index?
+    administrator?
+  end
+
+  def update?
+    administrator?
+  end
+end

--- a/app/views/admin/page_content/edit.html.erb
+++ b/app/views/admin/page_content/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="container" id="dashboard">
     <h1>Edit Page Content - <%= @page_content.page %></h1>
 
-    <%= render Admin::NavigationComponent.new %>
+    <%= render Admin::NavigationComponent.new(selected: admin_page_content_index_path) %>
 
     <%= form_for [:admin, @page_content], class: 'col-md-4 mt-3' do |form| %>
        <% if @page_content.errors.any? %>

--- a/app/views/admin/page_content/edit.html.erb
+++ b/app/views/admin/page_content/edit.html.erb
@@ -19,10 +19,19 @@
         <% end %>
         <p>Last edited: <em><%= @page_content.updated_at.to_formatted_s(:long) %></em></p>
         <p>Edited by: <em><%= @page_content.user %></em></p>
-        <%= form.text_area :value, class: 'form-control' %>
         <div class="form-check">
             <%= form.check_box :visible %>
             <%= form.label :visible, "Visible to user" %>
+        </div>
+        <%= form.label :value, "Message" %>
+        <%= form.text_area :value, class: 'form-control' %>
+        <%= form.label :link_text, "Link Text" %>
+        <%= form.text_field :link_text, size: 30, class: 'form-control' %>
+        <%= form.label :link_url, "Link URL" %>
+        <%= form.text_field :link_url, size: 30, class: 'form-control' %>
+        <div class="form-check">
+            <%= form.check_box :link_visible %>
+            <%= form.label :link_visible, "Show link" %>
         </div>
         <%= form.submit "Save", class: 'btn btn-primary my-3' %>
     <% end %>

--- a/app/views/admin/page_content/edit.html.erb
+++ b/app/views/admin/page_content/edit.html.erb
@@ -1,0 +1,31 @@
+<% content_for :breadcrumbs do %>
+  <%= render BreadcrumbNavComponent.new(admin: true, breadcrumbs: [ { title: 'Edit page content' } ])%>
+<% end %>
+<main id="content">
+  <div class="container" id="dashboard">
+    <h1>Edit Page Content - <%= @page_content.page %></h1>
+
+    <%= render Admin::NavigationComponent.new %>
+
+    <%= form_for [:admin, @page_content], class: 'col-md-4 mt-3' do |form| %>
+       <% if @page_content.errors.any? %>
+            <div class="alert alert-danger" role="alert">
+                <ul>
+                <% @page_content.errors.full_messages.each do |msg| %>
+                    <li><%= msg %></li>
+                <% end %>
+                </ul>
+            </div>
+        <% end %>
+        <p>Last edited: <em><%= @page_content.updated_at.to_formatted_s(:long) %></em></p>
+        <p>Edited by: <em><%= @page_content.user %></em></p>
+        <%= form.text_area :value, class: 'form-control' %>
+        <div class="form-check">
+            <%= form.check_box :visible %>
+            <%= form.label :visible, "Visible to user" %>
+        </div>
+        <%= form.submit "Save", class: 'btn btn-primary my-3' %>
+    <% end %>
+
+  </div>
+</main>

--- a/app/views/admin/page_content/index.html.erb
+++ b/app/views/admin/page_content/index.html.erb
@@ -1,21 +1,17 @@
 <% content_for :breadcrumbs do %>
-  <%= render BreadcrumbNavComponent.new(admin: true, breadcrumbs: [ { title: 'Edit Home Page Message' } ])%>
+  <%= render BreadcrumbNavComponent.new(admin: true, breadcrumbs: [ { title: 'Edit page content' } ])%>
 <% end %>
 <main id="content">
   <div class="container" id="dashboard">
-    <h1>Edit Home Page Message</h1>
+    <h1>Edit Page Content</h1>
 
     <%= render Admin::NavigationComponent.new %>
 
-    <%= form_with model: [:admin, @page_content], class: 'col-md-4 mt-3' do |form| %>
-        <p>Last edited on <em><%= @page_content.updated_at.to_formatted_s(:long) %></em> by <em><%= @page_content.user %></em></p>
-        <%= form.label :value, "Text" %>
-        <%= form.text_area :value, class: 'form-control' %>
-        <div class="form-check">
-            <%= form.check_box :visible %>
-            <%= form.label :visible, "Visible to user" %>
-        </div>
-        <%= form.submit "Save", class: 'btn btn-primary my-3' %>
+    <h3>Pages to edit</h3>
+    <ul>
+    <% @page_contents.each do |page_content| %>
+        <li><%= link_to page_content.page, edit_admin_page_content_path(page_content) %>
     <% end %>
+    </ul>
   </div>
 </main>

--- a/app/views/admin/page_content/index.html.erb
+++ b/app/views/admin/page_content/index.html.erb
@@ -1,0 +1,21 @@
+<% content_for :breadcrumbs do %>
+  <%= render BreadcrumbNavComponent.new(admin: true, breadcrumbs: [ { title: 'Edit Home Page Message' } ])%>
+<% end %>
+<main id="content">
+  <div class="container" id="dashboard">
+    <h1>Edit Home Page Message</h1>
+
+    <%= render Admin::NavigationComponent.new %>
+
+    <%= form_with model: [:admin, @page_content], class: 'col-md-4 mt-3' do |form| %>
+        <p>Last edited on <em><%= @page_content.updated_at.to_formatted_s(:long) %></em> by <em><%= @page_content.user %></em></p>
+        <%= form.label :value, "Text" %>
+        <%= form.text_area :value, class: 'form-control' %>
+        <div class="form-check">
+            <%= form.check_box :visible %>
+            <%= form.label :visible, "Visible to user" %>
+        </div>
+        <%= form.submit "Save", class: 'btn btn-primary my-3' %>
+    <% end %>
+  </div>
+</main>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -3,8 +3,7 @@
 <% end %>
 <main class="mb-3 mb-md-5" id="content">
   <div class="container px-4 px-md-3" id="dashboard" data-controller="work-type">
-    <%= render PageContentComponent.new(page_content: @page_content) %>
-
+    <%= render Dashboard::PageContentComponent.new(page_content: @page_content) %>
     <%= render Dashboard::ContinueDepositModalComponent.new(presenter: @presenter) %>
     <%= render Dashboard::ProfileButtonComponent.new %>
     <%= render Dashboard::AdminButtonComponent.new %>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 <main class="mb-3 mb-md-5" id="content">
   <div class="container px-4 px-md-3" id="dashboard" data-controller="work-type">
-    <%= render Dashboard::PageContentComponent.new(page_content: @page_content) %>
+    <%= render Dashboard::PageContentComponent.new(page_content: @page_content, location: :top) %>
     <%= render Dashboard::ContinueDepositModalComponent.new(presenter: @presenter) %>
     <%= render Dashboard::ProfileButtonComponent.new %>
     <%= render Dashboard::AdminButtonComponent.new %>
@@ -27,6 +27,7 @@
 
       <%= render Works::PurlReservationModalComponent.new %>
       <%= render CitationModalComponent.new %>
+      <%= render Dashboard::PageContentComponent.new(page_content: @page_content, location: :bottom) %>
     </section>
     <%= link_to('Don\'t see an appropriate collection?', '#contactUsModal',
                             data: {

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -3,6 +3,8 @@
 <% end %>
 <main class="mb-3 mb-md-5" id="content">
   <div class="container px-4 px-md-3" id="dashboard" data-controller="work-type">
+    <%= render PageContentComponent.new(page_content: @page_content) %>
+
     <%= render Dashboard::ContinueDepositModalComponent.new(presenter: @presenter) %>
     <%= render Dashboard::ProfileButtonComponent.new %>
     <%= render Dashboard::AdminButtonComponent.new %>

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -8,9 +8,7 @@
     </div>
     <p class="fs-4">Long term preservation of scholarly works at Stanford</p>
     <div class="text-center text-md-left way-down">
-
       <%= render PageContentComponent.new(page_content: @page_content) %>
-
       <h2>Go to the SDR Dashboard</h2>
       <h3 class="mb-4">to create or manage deposits</h3>
       <%= link_to dashboard_path, class: 'btn btn-primary btn-xl mb-3 mr-md-3' do %>

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -8,12 +8,12 @@
     </div>
     <p class="fs-4">Long term preservation of scholarly works at Stanford</p>
     <div class="text-center text-md-left way-down">
-      <%= render PageContentComponent.new(page_content: @page_content) %>
       <h2>Go to the SDR Dashboard</h2>
       <h3 class="mb-4">to create or manage deposits</h3>
       <%= link_to dashboard_path, class: 'btn btn-primary btn-xl mb-3 mr-md-3' do %>
         <span class="me-5">Enter here</span><span class="fa-solid fa-arrow-right ml-2" aria-hidden="true"></span>
       <% end %>
+      <%= render PageContentComponent.new(page_content: @page_content) %>
     </div>
     <a href="#photo-credit" class="credit">Photo credit<sup>*</sup></a>
   </div>

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -8,6 +8,9 @@
     </div>
     <p class="fs-4">Long term preservation of scholarly works at Stanford</p>
     <div class="text-center text-md-left way-down">
+
+      <%= render PageContentComponent.new(page_content: @page_content) %>
+
       <h2>Go to the SDR Dashboard</h2>
       <h3 class="mb-4">to create or manage deposits</h3>
       <%= link_to dashboard_path, class: 'btn btn-primary btn-xl mb-3 mr-md-3' do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,3 +211,7 @@ en:
     decommissioned: The collection has been permanently removed
     assigned_new_owner: An item is assigned a new owner
     item_deleted: An item is deleted
+  admin:
+    page_content:
+      success: 'Home page message updated'
+      error: 'Home page message could not be saved'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :druid_searches, only: :index
     resources :users, only: :index
-    resources :page_content, only: %i[index update]
+    resources :page_content, only: %i[index edit update]
     resources :collection_reports, only: %i[new create]
     resources :work_reports, only: %i[new create]
     resources :locked_items, only: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :druid_searches, only: :index
     resources :users, only: :index
+    resources :page_content, only: %i[index update]
     resources :collection_reports, only: %i[new create]
     resources :work_reports, only: %i[new create]
     resources :locked_items, only: :index

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -69,7 +69,6 @@ purl_url: https://purl.stanford.edu
 terms_url: https://library.stanford.edu/research/stanford-digital-repository/documentation/sdr-terms-deposit
 sdr_url: https://library.stanford.edu/research/stanford-digital-repository
 newsletter_url: https://stanford.us20.list-manage.com/subscribe?u=139e1b2d3df8f8cacd77c8160&id=4f4148a871
-more_news_url: https://library.stanford.edu/research/stanford-digital-repository # added to home page display message
 
 host: ~
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -69,6 +69,7 @@ purl_url: https://purl.stanford.edu
 terms_url: https://library.stanford.edu/research/stanford-digital-repository/documentation/sdr-terms-deposit
 sdr_url: https://library.stanford.edu/research/stanford-digital-repository
 newsletter_url: https://stanford.us20.list-manage.com/subscribe?u=139e1b2d3df8f8cacd77c8160&id=4f4148a871
+more_news_url: https://library.stanford.edu/research/stanford-digital-repository # added to home page display message
 
 host: ~
 

--- a/db/migrate/20230420204926_create_page_contents.rb
+++ b/db/migrate/20230420204926_create_page_contents.rb
@@ -1,0 +1,14 @@
+class CreatePageContents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :page_contents do |t|
+      t.string :page, null: false, default: 'home'
+      t.text :value, default: ''
+      t.boolean :visible, default: false
+      t.string :user
+
+      t.timestamps
+    end
+
+    PageContent.create(page: 'home', visible: false)
+  end
+end

--- a/db/migrate/20230420204926_create_page_contents.rb
+++ b/db/migrate/20230420204926_create_page_contents.rb
@@ -1,14 +1,17 @@
 class CreatePageContents < ActiveRecord::Migration[7.0]
   def change
     create_table :page_contents do |t|
-      t.string :page, null: false, default: 'home'
+      t.string :page, null: false
       t.text :value, default: ''
       t.boolean :visible, default: false
+      t.boolean :link_visible, default: false
+      t.string :link_text, default: ''
+      t.string :link_url, default: ''
       t.string :user
 
       t.timestamps
     end
 
-    PageContent.create(page: 'home', visible: false)
+    PageContent.create(page: 'home')
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -443,6 +443,40 @@ CREATE TABLE public.managers (
 
 
 --
+-- Name: page_contents; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.page_contents (
+    id bigint NOT NULL,
+    page character varying DEFAULT 'home'::character varying NOT NULL,
+    value text DEFAULT ''::text,
+    visible boolean DEFAULT false,
+    "user" character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: page_contents_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.page_contents_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: page_contents_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.page_contents_id_seq OWNED BY public.page_contents.id;
+
+
+--
 -- Name: related_links; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -728,6 +762,13 @@ ALTER TABLE ONLY public.mail_preferences ALTER COLUMN id SET DEFAULT nextval('pu
 
 
 --
+-- Name: page_contents id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.page_contents ALTER COLUMN id SET DEFAULT nextval('public.page_contents_id_seq'::regclass);
+
+
+--
 -- Name: related_links id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -856,6 +897,14 @@ ALTER TABLE ONLY public.keywords
 
 ALTER TABLE ONLY public.mail_preferences
     ADD CONSTRAINT mail_preferences_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: page_contents page_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.page_contents
+    ADD CONSTRAINT page_contents_pkey PRIMARY KEY (id);
 
 
 --
@@ -1354,6 +1403,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221117233130'),
 ('20221201204010'),
 ('20221206194032'),
-('20221213211305');
+('20221213211305'),
+('20230420204926');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -448,9 +448,12 @@ CREATE TABLE public.managers (
 
 CREATE TABLE public.page_contents (
     id bigint NOT NULL,
-    page character varying DEFAULT 'home'::character varying NOT NULL,
+    page character varying NOT NULL,
     value text DEFAULT ''::text,
     visible boolean DEFAULT false,
+    link_visible boolean DEFAULT false,
+    link_text character varying DEFAULT ''::character varying,
+    link_url character varying DEFAULT ''::character varying,
     "user" character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL

--- a/spec/factories/page_content.rb
+++ b/spec/factories/page_content.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'faker'
+
+FactoryBot.define do
+  factory :page_content do
+    page { 'home' }
+    value { "#{Faker::Food.spice} #{Faker::Food.ingredient}" }
+    visible { true }
+  end
+end

--- a/spec/features/admin/page_content_spec.rb
+++ b/spec/features/admin/page_content_spec.rb
@@ -65,6 +65,9 @@ RSpec.describe 'Edit page contents', js: true do
 
       visit root_path
       expect(page).not_to have_content(page_content.value)
+
+      visit dashboard_path
+      expect(page).not_to have_content(page_content.value)
     end
   end
 end

--- a/spec/features/admin/page_content_spec.rb
+++ b/spec/features/admin/page_content_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Edit page contents', js: true do
+  let(:user) { create(:user) }
+  let(:page_content) { PageContent.last }
+
+  before { create(:page_content) }
+
+  context 'when user is not an application admin' do
+    before do
+      sign_in user, groups: ['dlss:hydrus-app-collection-creators']
+    end
+
+    it 'is forbidden to edit' do
+      visit admin_page_content_index_path
+      expect(page).to have_content 'You are not authorized to perform the requested action'
+    end
+
+    it 'shows the text on the home page' do
+      visit root_path
+      expect(page).to have_content page_content.value
+    end
+
+    it 'shows the text on the dashboard page' do
+      visit dashboard_path
+      expect(page).to have_content page_content.value
+    end
+  end
+
+  context 'when user is an application admin' do
+    let(:new_text) { 'Some new stuff is pretty cool!' }
+
+    before do
+      sign_in user, groups: ['dlss:hydrus-app-administrators']
+    end
+
+    it 'shows the edit index page' do
+      visit admin_page_content_index_path
+
+      expect(page).to have_content 'Edit Page Content'
+    end
+
+    it 'allows the user to edit the text' do
+      visit edit_admin_page_content_path(page_content)
+
+      fill_in 'page_content_value', with: new_text
+      check 'page_content_visible'
+      click_button 'Save'
+
+      expect(page).to have_content 'Home page message updated'
+
+      visit root_path
+      expect(page).to have_content(new_text)
+    end
+
+    it 'allows the user to hide the text' do
+      visit edit_admin_page_content_path(page_content)
+
+      uncheck 'page_content_visible'
+      click_button 'Save'
+
+      expect(page).to have_content 'Home page message updated'
+
+      visit root_path
+      expect(page).not_to have_content(page_content.value)
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3052 - new admin option to admins can easily edit text and link shown on home page and dashboard page

Waiting on:
- [x] design for how to show on home page
- [x] design for how to show on dashboard page
- [x] ~~link for more info to update in settings~~ made this editable so we don't need to wait for it

Note: the database design will allow for this same basic principle to be used on other pages as well, but for now it's all just hard-coded to use a single page ('home') which is shown on both the dashboard and the home page.  We still have two separate components for display, however, since the design will be different on the home page and the dashboard page.

Design provided by Astrid: https://projects.invisionapp.com/share/ER1387CAQNS5#/screens/473002124?browse

**As implemented in this PR:**

![Screen Shot 2023-04-24 at 10 12 18 AM](https://user-images.githubusercontent.com/47137/234068517-aa18570f-ad63-4e65-82d8-46b8ba81f581.png)

![Screen Shot 2023-04-24 at 10 14 11 AM](https://user-images.githubusercontent.com/47137/234069147-4c700c47-26d3-42c6-9058-5fa9bdbde495.png)

 

**Admin UI:**

![Screen Shot 2023-04-25 at 10 08 13 AM](https://user-images.githubusercontent.com/47137/234351408-b7c94559-722e-40b8-a65f-cacd918daa07.png)



## How was this change tested? 🤨

Localhost and new spec