### PR TITLE
Remove rack multipart total part limit

### DIFF
--- a/config/initializers/rack_multipart_limit.rb
+++ b/config/initializers/rack_multipart_limit.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Allow uploading many files at a time: https://github.com/sul-dlss/happy-heron/issues/3051
+Rack::Utils.multipart_total_part_limit = 0


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3051

This commit configures the Rack multi-part total part limit such that there is no limit. Note that this Rack exception was only recently added (March 2023), so for most of the lifetime of H2, it effectively had a limit of 0. This Rack exception is meant to prevent a CVE which could "allow an attacker to craft requests that can ... cause multipart parsing to take longer than expected," so the severity does not seem to rise to that of a denial of service.

## How was this change tested? 🤨

CI
