### PR TITLE
send an email when a user completes a globus deposit

### DIFF
--- a/app/services/work_observer.rb
+++ b/app/services/work_observer.rb
@@ -43,7 +43,7 @@ class WorkObserver
             mailer.deposited_email
           end
     job.deliver_later
-    mailer.globus_deposited_email.deliver_later if work_version.globus? && Settings.notify_admin_list
+    mailer.globus_deposited_email.deliver_later if work_version.globus?
   end
 
   def self.after_rejected(work_version, _transition)

--- a/spec/models/work_version_state_machine_spec.rb
+++ b/spec/models/work_version_state_machine_spec.rb
@@ -292,10 +292,6 @@ RSpec.describe WorkVersion do
       let(:work_version) { build(:work_version, :depositing, work:, upload_type: 'globus') }
       let(:collection) { create(:collection) }
 
-      before do
-        allow(Settings).to receive(:notify_admin_list).and_return(true)
-      end
-
       it 'transitions to deposited' do
         expect { work_version.deposit_complete! }
           .to change(work_version, :state)


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3056 - send emails to admin when a user completes a globus email (instead of making it conditional on this setting, which also affects first draft collection email notification)

## How was this change tested? 🤨

Existing specs