### PR TITLE
actually fix the bug with globus deposit emails not going out

### DIFF
--- a/app/services/work_observer.rb
+++ b/app/services/work_observer.rb
@@ -43,7 +43,7 @@ class WorkObserver
             mailer.deposited_email
           end
     job.deliver_later
-    mailer.globus_deposited_email.deliver_later if work_version.globus?
+    mailer.globus_deposited_email.deliver_later if work_version.globus_endpoint && Settings.notify_admin_list
   end
 
   def self.after_rejected(work_version, _transition)

--- a/spec/models/work_version_state_machine_spec.rb
+++ b/spec/models/work_version_state_machine_spec.rb
@@ -289,8 +289,14 @@ RSpec.describe WorkVersion do
     end
 
     context 'when a deposit with globus' do
-      let(:work_version) { build(:work_version, :depositing, work:, upload_type: 'globus') }
+      let(:work_version) do
+        build(:work_version, :depositing, work:, upload_type: 'browser', globus_endpoint: '/some/globus/url')
+      end
       let(:collection) { create(:collection) }
+
+      before do
+        allow(Settings).to receive(:notify_admin_list).and_return(true)
+      end
 
       it 'transitions to deposited' do
         expect { work_version.deposit_complete! }


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3056 (for real this time).

This also reverts the change in #3057, which was a red herring (that setting was actually true in production anyway).

The problem with our code is that once we fetch the files from Globus, we switch the upload_type back to 'browser' and so when we run this observer on state change to deposited, the upload type is not 'globus' and we never send an email.  Instead we need to look for the presence of a 'globus_endpoint' URL, which indicates the user originally selected globus as the upload mechanism.  It is not 100% foolproof, as a user may have selected globus originally, received an endpoint, and then later changed their mind back to browser before depositing, but this is an edge case the only consequence of which is that the administrator will get the email about globus deposit when it actually wasn't.

An alternate apporach is to have a separate database column to track the upload type used and not change that as files are fetched.

See https://github.com/sul-dlss/happy-heron/blob/main/app/jobs/fetch_globus_job.rb#L25-L26

## How was this change tested? 🤨

Updated the spec


