### PR TITLE
Stop pinning reform-rails to pick up patch in 0.2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,9 +73,7 @@ gem 'redis', '~> 4.0'
 # TODO: Deal with this
 # pinned because 2.6.0 broke the build: [Reform] Your :populator did not return a Reform::Form instance for `authors`.
 gem 'reform', '~> 2.5.0'
-# TODO: Deal with this
-# pinned because 0.2.4 broke the build: https://github.com/trailblazer/reform-rails/issues/99
-gem 'reform-rails', '~> 0.2.0', '< 0.2.4'
+gem 'reform-rails'
 gem 'rubyzip', '~> 2.3'
 gem 'sdr-client', '~> 2.0'
 gem 'sidekiq', '~> 7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -392,7 +392,7 @@ GEM
       disposable (>= 0.4.2, < 0.5.0)
       representable (>= 2.4.0, < 3.1.0)
       uber (< 0.2.0)
-    reform-rails (0.2.3)
+    reform-rails (0.2.5)
       activemodel (>= 5.0)
       reform (>= 2.3.1, < 3.0.0)
     regexp_parser (2.8.0)
@@ -603,7 +603,7 @@ DEPENDENCIES
   rails (~> 7.0.1)
   redis (~> 4.0)
   reform (~> 2.5.0)
-  reform-rails (~> 0.2.0, < 0.2.4)
+  reform-rails
   rspec
   rspec-rails
   rspec_junit_formatter


### PR DESCRIPTION
## Why was this change made? 🤔

Keep pace with reform-rails releases now that bug found in 0.2.4 was patched.

## How was this change tested? 🤨

CI
