### PR TITLE
Stop auto-requiring whenever gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,5 +81,5 @@ gem 'sneakers', '~> 2.11' # rabbitMQ background processing
 gem 'state_machines-activerecord'
 gem 'turbo-rails', '~> 1.0'
 gem 'view_component', '~> 2.56.2' # https://github.com/github/view_component/issues/1390
-gem 'whenever'
+gem 'whenever', require: false # Work around https://github.com/javan/whenever/issues/831
 gem 'zipline', '~> 1.4'


### PR DESCRIPTION
## Why was this change made? 🤔

This commits works around a bug in the whenever gem that has begun crashing the Rails console when doing auto-complete under Ruby 3.2: https://github.com/javan/whenever/issues/831

We shouldn't need the whenever gem required outside of the Capistrano deploy anyway.

## How was this change tested? 🤨

CI & QA
