### PR TITLE
add work version search admin function

### DIFF
--- a/app/components/admin/navigation_component.rb
+++ b/app/components/admin/navigation_component.rb
@@ -12,6 +12,7 @@ module Admin
     def dropdown
       options = options_for_select([['Admin page', admin_path],
                                     ['Search for DRUID', admin_druid_searches_path],
+                                    ['Search for Work Version', admin_work_version_searches_path],
                                     ['Search for user', admin_users_path],
                                     ['Generate collection report', new_admin_collection_report_path],
                                     ['Generate item report', new_admin_work_report_path],

--- a/app/controllers/admin/work_version_searches_controller.rb
+++ b/app/controllers/admin/work_version_searches_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Admin
+  # Search by work_version and view a work
+  class WorkVersionSearchesController < ApplicationController
+    include Dry::Monads[:result]
+
+    before_action :authenticate_user!
+    verify_authorized
+
+    def index
+      authorize! :work_version_search
+      return unless params[:query]
+
+      result = lookup_work_version(params[:query])
+      return @failure = true if result.failure?
+
+      item = result.value!
+      redirect_to item
+    end
+
+    private
+
+    def lookup_work_version(work_version_id)
+      item = WorkVersion.find_by(id: work_version_id)
+      return Failure(:not_found) unless item
+
+      Success(item.work)
+    end
+  end
+end

--- a/app/policies/work_version_search_policy.rb
+++ b/app/policies/work_version_search_policy.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Defines who is authorized to see the work version search (admin page)
+class WorkVersionSearchPolicy < ApplicationPolicy
+  def index?
+    administrator?
+  end
+end

--- a/app/views/admin/work_version_searches/index.html.erb
+++ b/app/views/admin/work_version_searches/index.html.erb
@@ -1,0 +1,20 @@
+<% content_for :breadcrumbs do %>
+  <%= render BreadcrumbNavComponent.new(admin: true, breadcrumbs: [ { title: 'Search for Work Version' } ])%>
+<% end %>
+<main id="content">
+  <div class="container" id="dashboard">
+    <h1>Search for Work Version</h1>
+
+    <%= render Admin::NavigationComponent.new %>
+
+    <%= form_with url: admin_work_version_searches_path, method: :get, class: 'col-md-4 mt-3' do |form| %>
+        <%= form.label :query, "Enter Work Version ID" %>
+        <%= form.search_field :query, class: 'form-control' %>
+        <%= form.submit "Search", class: 'btn btn-primary my-3' %>
+    <% end %>
+
+    <% if @failure %>
+        <span class="text-danger">Work version not found. Please try searching for another Work Version ID or try again if you think this is an error.</span>
+    <% end %>
+  </div>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :druid_searches, only: :index
+    resources :work_version_searches, only: :index
     resources :users, only: :index
     resources :page_content, only: %i[index edit update]
     resources :collection_reports, only: %i[new create]

--- a/spec/features/admin/druid_search_spec.rb
+++ b/spec/features/admin/druid_search_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Searching for a DRUID', js: true do
+  let(:user) { create(:user) }
+
+  context 'when user is not an application admin' do
+    before do
+      sign_in user
+    end
+
+    it 'is forbidden' do
+      visit admin_druid_searches_path
+      expect(page).to have_content 'You are not authorized to perform the requested action'
+    end
+  end
+
+  context 'when druid is not found' do
+    before do
+      sign_in user, groups: ['dlss:hydrus-app-administrators']
+    end
+
+    it 'shows error' do
+      visit admin_druid_searches_path
+
+      fill_in 'Enter DRUID', with: 'oops'
+      click_button 'Search'
+
+      expect(page).to have_content 'DRUID not found.'
+    end
+  end
+
+  context 'when druid is found' do
+    let(:work_version) { create(:work_version_with_work_and_collection, state: 'deposited') }
+    let(:work) { work_version.work }
+    let(:druid) { 'druid:bc123df4567' }
+
+    before do
+      sign_in user, groups: ['dlss:hydrus-app-administrators']
+      work.update(druid:)
+    end
+
+    it 'redirects to work' do
+      visit admin_druid_searches_path
+
+      fill_in 'Enter DRUID', with: work.druid
+      click_button 'Search'
+      expect(page).to have_current_path work_path(work_version.work), ignore_query: true
+    end
+  end
+end

--- a/spec/features/admin/work_version_search_spec.rb
+++ b/spec/features/admin/work_version_search_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Searching for a work version', js: true do
+  let(:user) { create(:user) }
+
+  context 'when user is not an application admin' do
+    before do
+      sign_in user
+    end
+
+    it 'is forbidden' do
+      visit admin_work_version_searches_path
+      expect(page).to have_content 'You are not authorized to perform the requested action'
+    end
+  end
+
+  context 'when work_version is not found' do
+    before do
+      sign_in user, groups: ['dlss:hydrus-app-administrators']
+    end
+
+    it 'shows error' do
+      visit admin_work_version_searches_path
+
+      fill_in 'Enter Work Version ID', with: 'oops'
+      click_button 'Search'
+
+      expect(page).to have_content 'Work version not found.'
+    end
+  end
+
+  context 'when work_version is found' do
+    let(:work_version) { create(:work_version_with_work_and_collection, state: 'deposited') }
+
+    before do
+      sign_in user, groups: ['dlss:hydrus-app-administrators']
+    end
+
+    it 'redirects to work' do
+      visit admin_work_version_searches_path
+
+      fill_in 'Enter Work Version ID', with: work_version.id
+      click_button 'Search'
+      expect(page).to have_current_path work_path(work_version.work), ignore_query: true
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3059 - add admin function to search for work by work_version (useful for admins since HB messages frequently mention work_version IDs, but the app itself uses work ids in the URL

## How was this change tested? 🤨

Localhost, new spec (also added a spec for the druid search feature i borrowed code from, since it didn't have one)