### PR TITLE
Further reducing allowed location size to avoid cookie overflow

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,7 +73,7 @@ class ApplicationController < ActionController::Base
     store_location_for(:user, request.fullpath)
   end
 
-  MAX_LOCATION_SIZE = ActionDispatch::Cookies::MAX_COOKIE_SIZE / 2
+  MAX_LOCATION_SIZE = ActionDispatch::Cookies::MAX_COOKIE_SIZE / 3
 
   # This overrides devise so that we always check that we have enough space in the cookie
   # to store the full location.


### PR DESCRIPTION
## Why was this change made? 🤔
There are a few pages in H2 that are visible without authenticating, including the terms page (https://sdr.stanford.edu/terms). If an automated bot sends a long list of query params in a request while not authenticated, the URL gets put in the `request.fullpath`. This can trigger a cookie overflow if it's too long. See: https://app.honeybadger.io/projects/77112/faults/96779132

The error could also be triggered if a session times out while a user has a page open with a lot of params in a GET request, but we POST forms in H2. Since it seems highly unlikely that a legitimate user would be sending a lot of query params in a GET request during normal usage, this should primarily affect bots. 

We already tried to mitigate 500 errors by lowering the acceptable length of the location before declining to store it. This reduces it a little more. 

## How was this change tested? 🤨
Deployed to QA and tested. The URL used in the request that triggered the HB error will not cause a cookie overflow now. User gets the SDR home page and can log in. 

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


