### PR TITLE
fix accessibility for help form by adding namespace

### DIFF
--- a/app/views/helps/new.html.erb
+++ b/app/views/helps/new.html.erb
@@ -1,5 +1,5 @@
 <turbo-frame id="<%= params.fetch(:id, "help") %>">
-  <%= form_with(url: help_path(id: params[:id]), data: {controller: "help"}) do |form| %>
+  <%= form_with(url: help_path(id: params[:id]), data: {controller: "help"}, namespace: params[:id]) do |form| %>
     <strong><sup>*</sup>Required fields</strong>
     <div class="container-fluid">
       <div class="row">


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3118.

The first time user page uses the same form as the help link in the header (compare the background form with the help modal):

![image](https://github.com/sul-dlss/happy-heron/assets/96775/68bb04bb-5f9a-4008-aca0-d46dcbcfbbbe)



Adding a namespace to the [ActiveRecord::FormHelper](https://api.rubyonrails.org/v7.0.5.1/classes/ActionView/Helpers/FormHelper.html#method-i-form_with) call fixes the problem.

## After Change

![image](https://github.com/sul-dlss/happy-heron/assets/96775/9e6c66e1-9e02-44bd-b7c8-32757d4e891b)


## Before Change

![image](https://github.com/sul-dlss/happy-heron/assets/96775/6abd1eaa-47f4-4b34-bacd-8005112d1d43)


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


