### PR TITLE
Discard GlobusSetupJob for deserialization error.

### DIFF
--- a/app/jobs/globus_setup_job.rb
+++ b/app/jobs/globus_setup_job.rb
@@ -4,6 +4,8 @@
 class GlobusSetupJob < ApplicationJob
   queue_as :default
 
+  discard_on ActiveJob::DeserializationError
+
   # rubocop:disable Metrics/AbcSize
   def perform(work_version)
     druid = work_version.work.druid # may be nil


### PR DESCRIPTION
closes ~~#3050~~ #3060

## Why was this change made? 🤔
Avoid retrying jobs that will never succeed.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

