### PR TITLE
Disallow editing mid-globus.

### DIFF
--- a/app/views/works/_edit_button.html.erb
+++ b/app/views/works/_edit_button.html.erb
@@ -12,6 +12,8 @@
             aria: {label: edit_label} do %>
         <span class="fa-solid fa-pencil-alt" aria-hidden="true"></span>
       <% end %>
+    <% elsif work.head.fetching_globus_state? %>
+      <%# do not render %>
     <% else %>
       <%= link_to edit_work_path(work, anchor: anchor), aria: {label: edit_label} do %>
         <span class="fa-solid fa-pencil-alt" aria-hidden="true"></span>

--- a/spec/requests/work_edit_button_spec.rb
+++ b/spec/requests/work_edit_button_spec.rb
@@ -46,6 +46,19 @@ RSpec.describe "Link to edit a work" do
         expect(rendered).not_to have_selector('a[data-controller="popover"]')
       end
     end
+
+    context "when the work is pending globus" do
+      before do
+        work.head.update(state: "fetch_globus_version_draft")
+      end
+
+      it "draws an empty frame (we don't want this button to appear for each section on the view page)" do
+        get "/works/#{work.id}/edit_button?tag=details"
+        expect(response).to have_http_status(:ok)
+        expect(rendered).to have_selector("turbo-frame")
+        expect(rendered).not_to have_selector('a[data-controller="popover"]')
+      end
+    end
   end
 
   context "with a user who may not edit the object" do


### PR DESCRIPTION
closes #3081

# Why was this change made? 🤔
Prevent users from horking a work.


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

![image](https://github.com/sul-dlss/happy-heron/assets/588335/8888eb53-ada2-453f-a861-7b42609c3926)


# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



