### PR TITLE
Do not show more options when mixed material.

### DIFF
--- a/app/components/works/subtypes_component.html.erb
+++ b/app/components/works/subtypes_component.html.erb
@@ -38,9 +38,11 @@
     <% end %>
     </div>
 
-    <a href="#" class="more-options collapsed" data-action="more-types#toggleMoreTypes" data-more-types-target="moreTypesLink">
-      See more options
-    </a>
+    <% unless mixed_material_type? %>
+      <a href="#" class="more-options collapsed" data-action="more-types#toggleMoreTypes" data-more-types-target="moreTypesLink">
+        See more options
+      </a>
+    <% end %>
 
     <div class="mb-4 subtype-container" data-more-types-target="moreTypes" hidden>
       <% more_types.each do |more_type| %>


### PR DESCRIPTION
closes #3138

# Why was this change made? 🤔
Empty header is confusing.


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Local

![image](https://github.com/sul-dlss/happy-heron/assets/588335/55bd4eea-9556-4bed-9df5-f647838f3a65)



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



