### PR TITLE
Update autosuggest for stimulus-autosuggest 3.

### DIFF
--- a/app/components/works/keywords_row_component.html.erb
+++ b/app/components/works/keywords_row_component.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-3 row plain-container g-0 keyword-row">
   <div class="col-sm-6">
     <%= form.label :label, "Keyword", class: "col-form-label visually-hidden" %>
-    <div data-controller="keywords autocomplete autocomplete-edit" data-autocomplete-url-value="/autocomplete" data-autocomplete-min-length-value="3" class="dropdown">
+    <div data-controller="keywords autocomplete autocomplete-edit" data-autocomplete-url-value="/autocomplete" data-autocomplete-min-length-value="3" class="dropdown" role="combobox">
       <%= form.text_field :label, {class: "form-control#{"is-invalid" if error?}", required: true, "data-autocomplete-target": "input", "data-autocomplete-edit-target": "input",
                 "data-keywords-target": "input"} %>
       <!-- This input is populated by autocomplete controller.-->
@@ -9,7 +9,7 @@
       <input type="hidden" data-autocomplete-target="hidden" data-autocomplete-edit-target="value" data-action="autocomplete-edit#change">
       <%= form.hidden_field :uri, {required: true, "data-autocomplete-edit-target": "uri"} %>
       <%= form.hidden_field :cocina_type, {required: true, "data-autocomplete-edit-target": "type"} %>
-      <ul class="show dropdown-menu" data-autocomplete-target="results"></ul>
+      <ul class="list-group" data-autocomplete-target="results"></ul>
       <div class="invalid-feedback">At least one keyword is required. Each keyword must be unique.</div>
     </div>
   </div>

--- a/app/views/autocomplete/show.html.erb
+++ b/app/views/autocomplete/show.html.erb
@@ -1,3 +1,3 @@
 <% @suggestions.each_with_index.map do |suggestion, i| %>
-  <li class="dropdown-item" role="option" data-autocomplete-value="<%= suggestion.values.first %>" data-autocomplete-label="<%= suggestion.keys.first %>"><%= html_escape(suggestion.keys.first) %></li>
+  <li class="list-group-item" role="option" data-autocomplete-value="<%= suggestion.values.first %>" data-autocomplete-label="<%= suggestion.keys.first %>"><%= html_escape(suggestion.keys.first) %></li>
 <% end %>

--- a/spec/requests/autocomplete_spec.rb
+++ b/spec/requests/autocomplete_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe "Autocomplete Controller" do
     suggestions.each do |suggestion|
       actual_suggestion = suggestion.keys.first
       uri = suggestion.values.first
-      li_element_html = '<li class="dropdown-item" role="option" ' \
+      li_element_html = '<li class="list-group-item" role="option" ' \
                         "data-autocomplete-value=\"#{uri}\" data-autocomplete-label=\"#{actual_suggestion}\">" \
                         "#{ERB::Util.html_escape(actual_suggestion)}</li>"
       expect(response.body).to include(li_element_html)


### PR DESCRIPTION
closes #3139

# Why was this change made? 🤔
So it looks correct.


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

<img width="753" alt="image" src="https://github.com/sul-dlss/happy-heron/assets/588335/27e62a91-445d-419e-a337-cfd6e7392038">

<img width="776" alt="image" src="https://github.com/sul-dlss/happy-heron/assets/588335/6cbedeca-fc24-4f33-8ab1-a93322b79696">



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



