### PR TITLE
Add work owner as depositor to new collection

### DIFF
--- a/app/controllers/work_move_controller.rb
+++ b/app/controllers/work_move_controller.rb
@@ -30,6 +30,8 @@ class WorkMoveController < ApplicationController
       flash[:error] = I18n.t("work.flash.work_not_moved")
     else
       Work.transaction do
+        collection.depositors << work.owner unless collection.depositors.include?(work.owner)
+        collection.save!
         work.update!(collection:)
         work.events.create(user: current_user, event_type: "collection_moved",
           description: "Moved to \"#{collection.head.description}\" collection")


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3024

This commit allows the owner of a work that has been moved to a new collection to deposit to the collection.

# How was this change tested? 🤨

CI

# Does your change introduce accessibility violations? 🩺

No.
