### PR TITLE
Allow nil titles when integration test setting is true

### DIFF
--- a/app/jobs/globus_setup_job.rb
+++ b/app/jobs/globus_setup_job.rb
@@ -76,7 +76,7 @@ class GlobusSetupJob < ApplicationJob
   end
 
   def integration_test_work_version?(work_version)
-    integration_test_mode? && work_version.title.ends_with?("Integration Test")
+    integration_test_mode? && work_version.title&.ends_with?("Integration Test")
   end
 
   def integration_endpoint


### PR DESCRIPTION
# Why was this change made? 🤔

On QA and stage, if you start a globus deposit with an empty title, this error is raised: https://app.honeybadger.io/projects/77112/faults/97250692

# How was this change tested? 🤨
Unit and QA

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



