### PR TITLE
Allows user to select globus origin.

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -79,42 +79,29 @@
           <div class="col">
             <div class="border border-dark h-100 p-2 bg-light">
               <p>STEP 1</p>
-              <p>Scroll to the bottom of this page and click "Save as draft."</p>
-              <p><em>You can finish filling out the form now or later.</em></p>
+              <p>If your files are located on Stanford Google Drive, Oak, or Sherlock, select where they are located below.</p>
+              <%= form.select :globus_origin, origin_options, {prompt: "Select..."}, {class: "form-select", "aria-label": "Origin for Globus deposit"} %>
             </div>
           </div>
           <div class="col">
             <div class="border border-dark h-100 p-2 bg-light">
               <p>STEP 2</p>
-              <p>Set up a Stanford Globus account, following these <%= link_to "instructions", "#{Settings.globus.help_doc_url}?pli=1#heading=h.ptdws4k1wnlz", target: :blank %>.</p>
-              <p><em>Skip to Step 3 if you already have a Stanford Globus account.</em></p>
+              <p>Scroll to the bottom of this page and click "Save as draft".</p>
+              <p>You can finish filling out this form later.</p>
             </div>
           </div>
           <div class="col">
             <div class="border border-dark h-100 p-2 bg-light">
               <p>STEP 3</p>
-              <p>Complete Globus setup (may require software installation) following these <%= link_to "instructions", "#{Settings.globus.help_doc_url}?pli=1#heading=h.3h6eldy9ndya", target: :blank %>.</p>
+              <p>Follow our <%= link_to "instructions", Settings.globus.help_doc_url.to_s, target: :blank %> to set up Globus (may require software installation).</p>
+              <p>Transfer your files to the location you'll see on your item page once you've saved this form.</p>
             </div>
           </div>
           <div class="col">
             <div class="border border-dark h-100 p-2 bg-light">
               <p>STEP 4</p>
-              <p>Return to your item at sdr.stanford.edu and click the button that says "Globus setup complete."</p>
-              <p><em>Don't see this button? Proceed to Step 5.</em></p>
-            </div>
-          </div>
-          <div class="col">
-            <div class="border border-dark h-100 p-2 bg-light">
-              <p>STEP 5</p>
-              <p>Check your email from "Globus Notifications."</p>
-              <p><em>Click the link in the email and follow these <%= link_to "instructions", "#{Settings.globus.help_doc_url}?pli=1#heading=h.n1tmzgcygoqj", target: :blank %> to complete your deposit.</em></p>
-            </div>
-          </div>
-          <div class="col">
-            <div class="border border-dark h-100 p-2 bg-light">
-              <p>STEP 6</p>
               <p>Return to this page and make sure the form is complete. Then click "Deposit."</p>
-              <p><em>This will move your files from Globus to the SDR.</em></p>
+              <p>This will move your files from Globus to SDR.</p>
             </div>
           </div>
         </div>

--- a/app/components/works/add_files_component.rb
+++ b/app/components/works/add_files_component.rb
@@ -29,5 +29,13 @@ module Works
       # Only show checkbox once a new work_version with a cleared out globus_endpoint has been created.
       !form.object.work_version.deposited? && form.object.work_version.globus_endpoint.present?
     end
+
+    def origin_options
+      [
+        ["Stanford Google Drive", "stanford_gdrive"],
+        ["Oak", "oak"],
+        ["Sherlock", "sherlock"]
+      ]
+    end
   end
 end

--- a/app/components/works/globus_setup_component.rb
+++ b/app/components/works/globus_setup_component.rb
@@ -30,7 +30,9 @@ module Works
     end
 
     def endpoint
-      "https://app.globus.org/file-manager?&destination_id=#{Settings.globus.transfer_endpoint_id}&destination_path=#{Settings.globus.uploads_directory}#{work_version.globus_endpoint}"
+      url = "https://app.globus.org/file-manager?&destination_id=#{Settings.globus.transfer_endpoint_id}&destination_path=#{Settings.globus.uploads_directory}#{work_version.globus_endpoint}"
+      url += "&origin_id=#{Settings.globus.origins[work_version.globus_origin]}" if work_version.globus_origin
+      url
     end
   end
 end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -245,7 +245,7 @@ class WorksController < ObjectsController
       :access, :license, :version_description,
       :release, "embargo_date(1i)", "embargo_date(2i)", "embargo_date(3i)",
       :agree_to_terms, :assign_doi, :upload_type, :globus, :fetch_globus_files,
-      subtype: [],
+      :globus_origin, subtype: [],
       attached_files_attributes: %i[_destroy id label hide file path],
       authors_attributes: %i[_destroy id full_name first_name last_name role_term weight orcid],
       contributors_attributes: %i[_destroy id full_name first_name last_name role_term weight orcid],

--- a/app/forms/draft_work_form.rb
+++ b/app/forms/draft_work_form.rb
@@ -33,6 +33,7 @@ class DraftWorkForm < Reform::Form
   property :embargo_date, embargo_date: true, on: :work_version
   property :assign_doi, on: :work, type: Dry::Types["params.nil"] | Dry::Types["params.bool"]
   property :upload_type, on: :work_version
+  property :globus_origin, on: :work_version
   property :fetch_globus_files, virtual: true, type: Dry::Types["params.nil"] | Dry::Types["params.bool"]
 
   validates_with EmbargoDateParts,

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -51,6 +51,12 @@ class WorkVersion < ApplicationRecord
     zipfile: "zipfile"
   }
 
+  enum globus_origin: {
+    stanford_gdrive: "stanford_gdrive",
+    oak: "oak",
+    sherlock: "sherlock"
+  }
+
   LINK_TEXT = ":link will be inserted here automatically when available:"
   DOI_TEXT = ":DOI will be inserted here automatically when available:"
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,6 +17,10 @@ globus:
   test_user_valid: true # if test_mode=true, simulates the globus user is valid
   integration_mode: false # set to true for integration test
   integration_endpoint: 'integration_test/work388/version1'
+  origins:
+    stanford_gdrive: e1c8858b-d5aa-4e36-b97e-95913047ec2b
+    oak: 8b3a8b64-d4ab-4551-b37e-ca0092f769a7
+    sherlock: 6881ae2e-db26-11e5-9772-22000b9da45e
 
 accountws:
   pem_file: /etc/pki/tls/certs/sul-h2-qa.stanford.edu.pem

--- a/db/migrate/20230629154913_add_globus_origin_to_work_versions.rb
+++ b/db/migrate/20230629154913_add_globus_origin_to_work_versions.rb
@@ -1,0 +1,5 @@
+class AddGlobusOriginToWorkVersions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :work_versions, :globus_origin, :string, null: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,6 +10,13 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: public; Type: SCHEMA; Schema: -; Owner: -
+--
+
+-- *not* creating schema, since initdb creates it
+
+
+--
 -- Name: work_access; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -254,13 +261,13 @@ CREATE TABLE public.collections (
     access character varying,
     required_license character varying,
     default_license character varying,
-    email_when_participants_changed boolean,
+    email_when_participants_changed boolean DEFAULT true NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     creator_id bigint NOT NULL,
     druid character varying,
-    email_depositors_status_changed boolean,
-    review_enabled boolean DEFAULT false,
+    email_depositors_status_changed boolean DEFAULT true NOT NULL,
+    review_enabled boolean DEFAULT false NOT NULL,
     license_option character varying DEFAULT 'required'::character varying NOT NULL,
     head_id bigint,
     doi_option character varying DEFAULT 'yes'::character varying
@@ -626,7 +633,8 @@ CREATE TABLE public.work_versions (
     version_description character varying,
     published_at timestamp(6) without time zone,
     upload_type character varying,
-    globus_endpoint character varying
+    globus_endpoint character varying,
+    globus_origin character varying
 );
 
 
@@ -1407,6 +1415,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221201204010'),
 ('20221206194032'),
 ('20221213211305'),
-('20230420204926');
+('20230420204926'),
+('20230629154913');
 
 

--- a/spec/components/works/add_files_component_spec.rb
+++ b/spec/components/works/add_files_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Works::AddFilesComponent do
 
   context "when globus section" do
     it "shows the globus upload option" do
-      expect(rendered.to_html).to include("Set up a Stanford Globus account")
+      expect(rendered.to_html).to include("If your files are located on")
       expect(rendered.to_html).not_to include("Check this box once all your files have been uploaded to Globus.")
     end
   end

--- a/spec/components/works/globus_setup_component_spec.rb
+++ b/spec/components/works/globus_setup_component_spec.rb
@@ -4,16 +4,28 @@ require "rails_helper"
 
 RSpec.describe Works::GlobusSetupComponent, type: :component do
   let(:rendered) { render_inline(described_class.new(work_version:)) }
-  let(:work_version) { build_stubbed(:work_version, state: "first_draft", upload_type: "globus", globus_endpoint: "user/123/version1") }
+  let(:work_version) { build_stubbed(:work_version, state: "first_draft", upload_type: "globus", globus_endpoint: "user/123/version1", globus_origin:) }
+  let(:globus_origin) { nil }
 
   context "when the globus user is valid" do
     before do
       allow(GlobusClient).to receive(:user_valid?).and_return(true)
     end
 
-    it "renders the instructions" do
-      expect(rendered.to_html).to include "How to complete your deposit using Globus"
-      expect(rendered.css("a").map { |node| node["href"] }).to include "https://app.globus.org/file-manager?&destination_id=endpoint_uuid&destination_path=/uploads/user/123/version1"
+    context "when no globus origin is set" do
+      it "renders the instructions" do
+        expect(rendered.to_html).to include "How to complete your deposit using Globus"
+        expect(rendered.css("a").map { |node| node["href"] }).to include "https://app.globus.org/file-manager?&destination_id=endpoint_uuid&destination_path=/uploads/user/123/version1"
+      end
+    end
+
+    context "when globus origin is set" do
+      let(:globus_origin) { "oak" }
+
+      it "renders the instructions with origin_id in globus link" do
+        expect(rendered.to_html).to include "How to complete your deposit using Globus"
+        expect(rendered.css("a").map { |node| node["href"] }).to include "https://app.globus.org/file-manager?&destination_id=endpoint_uuid&destination_path=/uploads/user/123/version1&origin_id=8b3a8b64-d4ab-4551-b37e-ca0092f769a7"
+      end
     end
   end
 

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
     version_description { "initial version" }
     published_at { Time.zone.parse("2019-01-01") }
     upload_type { "browser" }
+    globus_origin { nil }
     work
 
     factory :valid_work_version do

--- a/spec/requests/edit_work_spec.rb
+++ b/spec/requests/edit_work_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe "Updating an existing work" do
             work_type: "text",
             abstract: "test abstract",
             upload_type:,
+            globus_origin:,
             fetch_globus_files:,
             attached_files_attributes: {
               "0" => {"label" => "two", "_destroy" => "", "hide" => "0", "id" => work_version.attached_files.first.id}
@@ -89,6 +90,7 @@ RSpec.describe "Updating an existing work" do
 
         let(:upload_type) { "browser" }
         let(:fetch_globus_files) { "false" }
+        let(:globus_origin) { "" }
 
         before do
           create(:attached_file, :with_file, work_version:)
@@ -171,11 +173,13 @@ RSpec.describe "Updating an existing work" do
           let(:work_version) { create(:work_version, :version_draft, :with_required_associations, work:) }
           let(:upload_type) { "globus" }
           let(:fetch_globus_files) { "true" }
+          let(:globus_origin) { "oak" }
 
           context "when saving draft" do
             it "redirects to the work page and starts fetching globus" do
               patch "/works/#{work.id}", params: {work: work_params, commit: "Save as draft"}
               expect(work.reload.head).to be_fetch_globus_version_draft
+              expect(work.head).to be_oak
               expect(response).to redirect_to(work)
             end
           end


### PR DESCRIPTION
closes #3022

# Why was this change made? 🤔



# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



