### PR TITLE
Deposit form complies with WCAG A/AA accessibility levels

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -15,7 +15,7 @@
       <div data-controller="dropzone" data-dropzone-max-file-size="10000" data-dropzone-previews-container=".dropzone-files-previews">
         <fieldset>
           <div class="dropzone dropzone-default" data-dropzone-target="container">
-            <%= form.file_field :files, multiple: true, direct_upload: true,
+            <%= form.file_field :files, multiple: true, direct_upload: true, namespace: "flat_list",
                   data: {dropzone_target: "input"} %>
             <div class="dz-message needsclick text-secondary">
               <p>Drop files here</p>
@@ -49,7 +49,7 @@
            data-dropzone-previews-container=".dropzone-zip-previews">
         <fieldset>
           <div class="dropzone dropzone-default" data-dropzone-target="container">
-            <%= form.file_field :files, multiple: false, direct_upload: true,
+            <%= form.file_field :files, multiple: false, direct_upload: true, namespace: "zip",
                   data: {dropzone_target: "input"} %>
             <div class="dz-message needsclick text-secondary">
               <p>Drop zip file here</p>

--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -15,7 +15,7 @@
       <div data-controller="dropzone" data-dropzone-max-file-size="10000" data-dropzone-previews-container=".dropzone-files-previews">
         <fieldset>
           <div class="dropzone dropzone-default" data-dropzone-target="container">
-            <%= form.file_field :files, multiple: true, direct_upload: true, namespace: "flat_list",
+            <%= form.file_field :files, multiple: true, direct_upload: true, namespace: "flat_list", "aria-label": "Upload files",
                   data: {dropzone_target: "input"} %>
             <div class="dz-message needsclick text-secondary">
               <p>Drop files here</p>
@@ -49,7 +49,7 @@
            data-dropzone-previews-container=".dropzone-zip-previews">
         <fieldset>
           <div class="dropzone dropzone-default" data-dropzone-target="container">
-            <%= form.file_field :files, multiple: false, direct_upload: true, namespace: "zip",
+            <%= form.file_field :files, multiple: false, direct_upload: true, namespace: "zip", "aria-label": "Upload files",
                   data: {dropzone_target: "input"} %>
             <div class="dz-message needsclick text-secondary">
               <p>Drop zip file here</p>

--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -1,4 +1,5 @@
 <div class="row inner-container contributor-row" data-controller="contributors" data-contributors-required-value="<%= author? %>">
+  <% namespace = author? ? "author" : "contributor" %>
   <div class="col-md-11">
     <div class="row">
       <div class="col-md-3">
@@ -39,23 +40,24 @@
             <%= form.label :with_orcid, "Enter ORCID iD", value: "true", class: "form-check-label fw-semibold" %>
           </div>
           <div class="row person-identifier-row" data-contributors-target="personOrcid">
+            <% text_field_id_prefix = "work_#{namespace}_orcid_#{form.options[:child_index]}_" %>
             <div class="col">
               <%= form.label :orcid, orcid_label, class: "form-label" %>
               <%= render PopoverComponent.new key: "work.orcid" %>
-              <%= form.text_field :orcid, class: "form-control", required: author?, data: {contributors_target: "orcid", action: "contributors#lookupOrcid"} %>
-              <div class="invalid-feedback" data-contributors-target="orcidFeedback">You must provide an ORCID iD</div>
+              <%= form.text_field :orcid, class: "form-control", required: author?, id: "#{text_field_id_prefix}id", data: {contributors_target: "orcid", action: "contributors#lookupOrcid"} %>
+              <div class="invalid-feedback" data-contributors-target="orcidFeedback">You must provide an ORCID ID</div>
               <div data-contributors-target="personOrcidName">
                 <div class="form-text" data-contributors-target="orcidDisplayName"></div>
                 <div class="row">
                   <div class="col-md-5">
                     <%= form.label :first_name, first_name_label, class: "form-label" %>
                     <%= render PopoverComponent.new key: "work.orcid_name" %>
-                    <%= form.text_field :first_name, html_options("contributorFirst", contributors_target: "orcidFirstName", disabled: !orcid?) %>
+                    <%= form.text_field :first_name, html_options("contributorFirst",contributors_target: "orcidFirstName", disabled: !orcid?).merge(id: "#{text_field_id_prefix}first_name") %>
                     <div class="invalid-feedback">You must provide a first name</div>
                   </div>
                   <div class="col-md-6">
                     <%= form.label :last_name, last_name_label, class: "form-label" %>
-                    <%= form.text_field :last_name, html_options("contributorLast", contributors_target: "orcidLastName", disabled: !orcid?) %>
+                    <%= form.text_field :last_name, html_options("contributorLast", contributors_target: "orcidLastName", disabled: !orcid?).merge(id: "#{text_field_id_prefix}last_name") %>
                     <div class="invalid-feedback">You must provide a last name</div>
                   </div>
                 </div>

--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -37,12 +37,12 @@
 
           <div class="form-check">
             <%= form.radio_button :with_orcid, "true", html_options_for_radio(false, orcid?) %>
-            <%= form.label :with_orcid, "Enter ORCID iD", value: "true", class: "form-check-label fw-semibold" %>
+            <%= form.label :with_orcid, "Enter ORCID ID", value: "true", class: "form-check-label fw-semibold" %>
           </div>
           <div class="row person-identifier-row" data-contributors-target="personOrcid">
             <% text_field_id_prefix = "work_#{namespace}_orcid_#{form.options[:child_index]}_" %>
             <div class="col">
-              <%= form.label :orcid, orcid_label, class: "form-label" %>
+              <%= form.label :orcid, orcid_label, for: "#{text_field_id_prefix}id", class: "form-label" %>
               <%= render PopoverComponent.new key: "work.orcid" %>
               <%= form.text_field :orcid, class: "form-control", required: author?, id: "#{text_field_id_prefix}id", data: {contributors_target: "orcid", action: "contributors#lookupOrcid"} %>
               <div class="invalid-feedback" data-contributors-target="orcidFeedback">You must provide an ORCID ID</div>
@@ -50,13 +50,13 @@
                 <div class="form-text" data-contributors-target="orcidDisplayName"></div>
                 <div class="row">
                   <div class="col-md-5">
-                    <%= form.label :first_name, first_name_label, class: "form-label" %>
+                    <%= form.label :first_name, first_name_label, for: "#{text_field_id_prefix}first_name", class: "form-label" %>
                     <%= render PopoverComponent.new key: "work.orcid_name" %>
                     <%= form.text_field :first_name, html_options("contributorFirst",contributors_target: "orcidFirstName", disabled: !orcid?).merge(id: "#{text_field_id_prefix}first_name") %>
                     <div class="invalid-feedback">You must provide a first name</div>
                   </div>
                   <div class="col-md-6">
-                    <%= form.label :last_name, last_name_label, class: "form-label" %>
+                    <%= form.label :last_name, last_name_label, for: "#{text_field_id_prefix}last_name", class: "form-label" %>
                     <%= form.text_field :last_name, html_options("contributorLast", contributors_target: "orcidLastName", disabled: !orcid?).merge(id: "#{text_field_id_prefix}last_name") %>
                     <div class="invalid-feedback">You must provide a last name</div>
                   </div>

--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -37,7 +37,7 @@
 
           <div class="form-check">
             <%= form.radio_button :with_orcid, "true", html_options_for_radio(false, orcid?) %>
-            <%= form.label :with_orcid, "Enter ORCID ID", value: "true", class: "form-check-label fw-semibold" %>
+            <%= form.label :with_orcid, "Enter ORCID iD", value: "true", class: "form-check-label fw-semibold" %>
           </div>
           <div class="row person-identifier-row" data-contributors-target="personOrcid">
             <% text_field_id_prefix = "work_#{namespace}_orcid_#{form.options[:child_index]}_" %>
@@ -45,14 +45,14 @@
               <%= form.label :orcid, orcid_label, for: "#{text_field_id_prefix}id", class: "form-label" %>
               <%= render PopoverComponent.new key: "work.orcid" %>
               <%= form.text_field :orcid, class: "form-control", required: author?, id: "#{text_field_id_prefix}id", data: {contributors_target: "orcid", action: "contributors#lookupOrcid"} %>
-              <div class="invalid-feedback" data-contributors-target="orcidFeedback">You must provide an ORCID ID</div>
+              <div class="invalid-feedback" data-contributors-target="orcidFeedback">You must provide an ORCID iD</div>
               <div data-contributors-target="personOrcidName">
                 <div class="form-text" data-contributors-target="orcidDisplayName"></div>
                 <div class="row">
                   <div class="col-md-5">
                     <%= form.label :first_name, first_name_label, for: "#{text_field_id_prefix}first_name", class: "form-label" %>
                     <%= render PopoverComponent.new key: "work.orcid_name" %>
-                    <%= form.text_field :first_name, html_options("contributorFirst",contributors_target: "orcidFirstName", disabled: !orcid?).merge(id: "#{text_field_id_prefix}first_name") %>
+                    <%= form.text_field :first_name, html_options("contributorFirst", contributors_target: "orcidFirstName", disabled: !orcid?).merge(id: "#{text_field_id_prefix}first_name") %>
                     <div class="invalid-feedback">You must provide a first name</div>
                   </div>
                   <div class="col-md-6">

--- a/app/components/works/keywords_row_component.html.erb
+++ b/app/components/works/keywords_row_component.html.erb
@@ -7,7 +7,7 @@
                 "data-keywords-target": "input"} %>
       <!-- This input is populated by autocomplete controller.-->
       <!-- That triggers the autocomplete-edit controller, which populates the uri and cocina type inputs. -->
-      <input type="hidden" data-autocomplete-target="hidden" data-autocomplete-edit-target="value" data-action="autocomplete-edit#change" aria-label="autocomplete" >
+      <input type="hidden" data-autocomplete-target="hidden" data-autocomplete-edit-target="value" data-action="autocomplete-edit#change" aria-label="autocomplete">
       <%= form.hidden_field :uri, {required: true, "aria-label": "#{unique_field_id}_uri", "data-autocomplete-edit-target": "uri"} %>
       <%= form.hidden_field :cocina_type, {required: true, "aria-label": "#{unique_field_id}_cocina_type", "data-autocomplete-edit-target": "type"} %>
       <ul class="list-group" data-autocomplete-target="results"></ul>

--- a/app/components/works/keywords_row_component.html.erb
+++ b/app/components/works/keywords_row_component.html.erb
@@ -1,14 +1,15 @@
 <div class="mb-3 row plain-container g-0 keyword-row">
   <div class="col-sm-6">
-    <%= form.label :label, "Keyword", class: "col-form-label visually-hidden" %>
-    <div data-controller="keywords autocomplete autocomplete-edit" data-autocomplete-url-value="/autocomplete" data-autocomplete-min-length-value="3" class="dropdown" role="combobox">
-      <%= form.text_field :label, {class: "form-control#{"is-invalid" if error?}", required: true, "data-autocomplete-target": "input", "data-autocomplete-edit-target": "input",
+    <% unique_field_id = "work_keywords_attributes_#{form.options[:child_index]}" %>
+    <div data-controller="keywords autocomplete autocomplete-edit" data-autocomplete-url-value="/autocomplete" data-autocomplete-min-length-value="3" aria-label="autocomplete group" class="dropdown" role="combobox" aria-expanded="false">
+      <%= form.label :label, "Keyword", for: unique_field_id, class: "col-form-label visually-hidden" %>
+      <%= form.text_field :label, {class: "form-control#{"is-invalid" if error?}", required: true, id: unique_field_id, "data-autocomplete-target": "input", "data-autocomplete-edit-target": "input",
                 "data-keywords-target": "input"} %>
       <!-- This input is populated by autocomplete controller.-->
       <!-- That triggers the autocomplete-edit controller, which populates the uri and cocina type inputs. -->
-      <input type="hidden" data-autocomplete-target="hidden" data-autocomplete-edit-target="value" data-action="autocomplete-edit#change">
-      <%= form.hidden_field :uri, {required: true, "data-autocomplete-edit-target": "uri"} %>
-      <%= form.hidden_field :cocina_type, {required: true, "data-autocomplete-edit-target": "type"} %>
+      <input type="hidden" data-autocomplete-target="hidden" data-autocomplete-edit-target="value" data-action="autocomplete-edit#change" aria-label="autocomplete" >
+      <%= form.hidden_field :uri, {required: true, "aria-label": "#{unique_field_id}_uri", "data-autocomplete-edit-target": "uri"} %>
+      <%= form.hidden_field :cocina_type, {required: true, "aria-label": "#{unique_field_id}_cocina_type", "data-autocomplete-edit-target": "type"} %>
       <ul class="list-group" data-autocomplete-target="results"></ul>
       <div class="invalid-feedback">At least one keyword is required. Each keyword must be unique.</div>
     </div>

--- a/app/javascript/controllers/dropzone_controller.js
+++ b/app/javascript/controllers/dropzone_controller.js
@@ -38,13 +38,13 @@ export default class extends Controller {
     const filepath = this.dirPath ? `${this.dirPath}/${fileName}` : fileName
     const fileNameNodes = Array.from(document.querySelectorAll('[data-dropzone-path]'))
 
-    const filepaths = fileNameNodes.map(fileNameNode => {      
+    const filepaths = fileNameNodes.map(fileNameNode => {
         const path = fileNameNode.getAttribute('data-dropzone-path')
         const filename = fileNameNode.innerText.trim()
 
         const item = fileNameNode.closest('.dz-complete')
         if(item && item.querySelector("input[name*='_destroy']").value == 1) return null
-    
+
         return path ? `${path}/${filename}` : filename
     })
 
@@ -94,11 +94,11 @@ export default class extends Controller {
   }
 
   bindEvents() {
-    this.dropZone.on("addedfile", file => {      
-      setTimeout(() => {        
+    this.dropZone.on("addedfile", file => {
+      setTimeout(() => {
         file.accepted && createDirectUploadController(this, file).start();
         this.fileCount++
-        this.enableSubmission()        
+        this.enableSubmission()
         if (this.checkForDuplicates(file.name)) {
           this.dropZone.emit("error", file, 'Duplicate file');
         }
@@ -240,6 +240,7 @@ class DirectUploadController {
     input.type = "hidden";
     input.classList.add('hidden-file')
     input.name = `work[attached_files_attributes][${this.count}][file]`
+    input.setAttribute("aria-label", "hidden file");
     this.file.previewElement.appendChild(input);
     return input;
   }
@@ -247,8 +248,9 @@ class DirectUploadController {
   createHiddenPathInput() {
     const input = document.createElement("input")
     input.type = "hidden"
-    input.name = `work[attached_files_attributes][${this.count}][path]`    
+    input.name = `work[attached_files_attributes][${this.count}][path]`
     input.value = this.source.dirPath ? `${this.source.dirPath}/${this.file.name}` : this.file.name
+    input.setAttribute("aria-label", "hidden path");
     this.file.previewElement.appendChild(input)
   }
 


### PR DESCRIPTION
# Why was this change made? 🤔

Closes #3149

Addressed all A and AA accessibility problems that I could find with SiteImprove, WAVE and Axe plugins.  Note that Axe found no violations in the original.

# Before

![image](https://github.com/sul-dlss/happy-heron/assets/96775/aac98637-9e29-4626-8d3c-a249f31bff43)

![image](https://github.com/sul-dlss/happy-heron/assets/96775/7e62e408-3c51-47dd-9b66-11a5d86e83bb)

# After 

![image](https://github.com/sul-dlss/happy-heron/assets/96775/02a5375b-3cf1-4051-ae71-6d714857b8b9)

- ^^ note that the remaining all need design help

![image](https://github.com/sul-dlss/happy-heron/assets/96775/db0bc687-99a8-4742-9399-50981bd1fbd6)

- ^^ I was unable to figure out the hidden fields causing the 4 errors still indicated by Wave, so I'm declaring this PR an excellent first cut.


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



