### PR TITLE
Editing item view globus instructions

### DIFF
--- a/app/components/works/globus_setup_component.html.erb
+++ b/app/components/works/globus_setup_component.html.erb
@@ -3,12 +3,12 @@
     <div class="col-12">
       <p><strong>How to complete your deposit using Globus:</strong></p>
       <ol>
-        <li>Follow these <%= link_to "these instructions", "#{Settings.globus.help_doc_url}/edit", target: "_blank" %> to set up Globus (may require
+        <li>Follow these <%= link_to "instructions", "#{Settings.globus.help_doc_url}/edit", target: "_blank" %> to set up Globus (may require
           software installation). Be sure you have logged into Globus with your Stanford credentials!</li>
-        <li>Go to <%= link_to "this folder at Globus", endpoint, target: "_blank" %> that we have created just for you and transfer your files there.</li>
-        <li>Then return here and click the pencil icon above to edit your draft.</li>
-        <li>Check the box in the "Add your files" section on the edit page to indicate you have uploaded your files to Globus.</li>
-        <li>Scroll to the bottom of the form and click "Save as draft" to return later to complete your deposit, or click "Deposit" to complete your deposit now.</li>
+        <li>Go to this <%= link_to "shared folder at Globus", endpoint, target: "_blank" %> that we have created just for you and transfer your files there.</li>
+        <li>Return here and click the pencil icon above to edit your item.</li>
+        <li>Check the box in the "Add your files" section on the edit page to indicate that your files have finished transferring to Globus (transfer must be complete!).</li>
+        <li>Scroll to the bottom of the form and click "Deposit" to finish up now, or click "Save as draft" to finish later.</li>
       </ol>
     </div>
   </div>


### PR DESCRIPTION
# Why was this change made? 🤔
Fixing instructions text to match mock-ups. @amyehodge.
(Mockup: https://projects.invisionapp.com/share/YQ132HXFX2GR#/screens/472346509_Globus_Auto_Account)

Note that the mockup has bullets and this is numbered (as originally). Should it switch to bullets?

![Screenshot 2023-06-30 at 1 49 43 PM](https://github.com/sul-dlss/happy-heron/assets/1619369/85480e36-79e1-46b3-b69c-7c5c2429790d)


# How was this change tested? 🤨
Unit / local deployment

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺
No

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



