### PR TITLE
globus_endpoint_created mail message updated

### DIFF
--- a/app/views/works_mailer/globus_endpoint_created.html.erb
+++ b/app/views/works_mailer/globus_endpoint_created.html.erb
@@ -1,9 +1,10 @@
 <p>Dear <%= @user.first_name %>,</p>
 
-<p>You should have received an email from "Globus Notification" with a link to the location we created for you to transfer your files.</p>
+<p>You have initiated a deposit to the SDR using Globus. Here's what you need to do to complete it:</p>
 
 <ol>
-  <li>Please transfer your files to the above location in Globus using these <%= link_to "instructions", "#{Settings.globus.help_doc_url}?pli=1#heading=h.n1tmzgcygoqj" %>.</li>
+  <li>Follow these <%= link_to "instructions", "#{Settings.globus.help_doc_url}?pli=1#heading=h.3h6eldy9ndya" %> to set up Globus (may require software installation). Be sure you have logged into Globus with your Stanford credentials!</li>
+  <li>Go to this <%= link_to "shared folder at Globus", Works::GlobusSetupComponent.new(work_version: @work_version).endpoint %> that we have created just for you and transfer your files there.</li>
   <li><%= link_to "Return to your item", work_url(@work) %> at sdr.stanford.edu and click the pencil icon to edit your draft.</li>
   <li>Check the box in the "Add your files" section to indicate that you have uploaded your files to Globus.</li>
   <li>Scroll to the bottom and click "Save as draft" to finish your deposit later, or click "Deposit" to complete your deposit.</li>

--- a/spec/mailers/works_mailer_spec.rb
+++ b/spec/mailers/works_mailer_spec.rb
@@ -318,7 +318,9 @@ RSpec.describe WorksMailer do
 
     it "renders body" do
       expect(mail.body).to include "Dear #{a_user.first_name},"
-      expect(mail.body).to include "Please transfer your files to the above location in Globus"
+      expect(mail.body).to include "Be sure you have logged into Globus with your Stanford credentials!"
+      expect(mail.body).to include "#{Works::GlobusSetupComponent.new(work_version: work_version).endpoint.gsub("&", "&amp;")}\">shared folder at Globus</a> that we have created just for you and transfer your files there."
+      expect(mail.body).to include Works::GlobusSetupComponent.new(work_version: work_version).endpoint.gsub("&", "&amp;")
     end
   end
 


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3049.

Updates email to globus users for new, improved workflow.

@amyehodge does this need PO approval?

@lwrubel if this is needed for other endpoints (Oak, etc.) ... then I assume there will be separate tickets.

# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



