### PR TITLE
Address unpermitted params across various controller interactions

### DIFF
--- a/app/controllers/first_draft_collections_controller.rb
+++ b/app/controllers/first_draft_collections_controller.rb
@@ -25,7 +25,6 @@ class FirstDraftCollectionsController < ObjectsController
 
     collection_version = collection.collection_versions.first # this is a first draft and should only have one version
     @form = CreateCollectionForm.new(collection_version:, collection:)
-    # @form = CollectionSettingsForm.new(collection)
     @form.prepopulate!
   end
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -232,27 +232,28 @@ class WorksController < ObjectsController
   end
 
   def work_params
-    top_level = params.require(:work)
-    top_level.permit(:title, :work_type,
-      "published(1i)", "published(2i)", "published(3i)",
-      :created_type,
-      "created(1i)", "created(2i)", "created(3i)", "created(approx0)",
-      "created_range(1i)", "created_range(2i)", "created_range(3i)",
-      "created_range(approx0)",
-      "created_range(4i)", "created_range(5i)", "created_range(6i)",
-      "created_range(approx3)",
-      :abstract, :citation_auto, :citation, :default_citation,
-      :access, :license, :version_description,
-      :release, "embargo_date(1i)", "embargo_date(2i)", "embargo_date(3i)",
-      :agree_to_terms, :assign_doi, :upload_type, :globus, :fetch_globus_files,
-      :globus_origin, subtype: [],
-      attached_files_attributes: %i[_destroy id label hide file path],
-      authors_attributes: %i[_destroy id full_name first_name last_name role_term weight orcid],
-      contributors_attributes: %i[_destroy id full_name first_name last_name role_term weight orcid],
-      contact_emails_attributes: %i[_destroy id email],
-      keywords_attributes: %i[_destroy id label uri cocina_type],
-      related_works_attributes: %i[_destroy id citation],
-      related_links_attributes: %i[_destroy id link_title url])
+    params
+      .require(:work)
+      .permit(:title, :work_type,
+        "published(1i)", "published(2i)", "published(3i)",
+        :created_type,
+        "created(1i)", "created(2i)", "created(3i)", "created(approx0)",
+        "created_range(1i)", "created_range(2i)", "created_range(3i)",
+        "created_range(approx0)",
+        "created_range(4i)", "created_range(5i)", "created_range(6i)",
+        "created_range(approx3)",
+        :abstract, :citation_auto, :citation, :default_citation,
+        :access, :license, :version_description,
+        :release, "embargo_date(1i)", "embargo_date(2i)", "embargo_date(3i)",
+        :agree_to_terms, :assign_doi, :upload_type, :globus, :fetch_globus_files,
+        :globus_origin, subtype: [], files: [],
+        attached_files_attributes: %i[_destroy id label hide file path],
+        authors_attributes: %i[_destroy id full_name first_name last_name role_term weight orcid with_orcid],
+        contributors_attributes: %i[_destroy id full_name first_name last_name role_term weight orcid with_orcid],
+        contact_emails_attributes: %i[_destroy id email],
+        keywords_attributes: %i[_destroy id label uri cocina_type],
+        related_works_attributes: %i[_destroy id citation],
+        related_links_attributes: %i[_destroy id link_title url])
   end
 
   def validate_work_types!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,6 +5,10 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Raise when request includes unpermitted params to help find errors in
+  # dev/test (default value is `nil`, which is used in production)
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,6 +12,10 @@ Rails.application.configure do
   require "test_shibboleth_headers"
   config.middleware.use TestShibbolethHeaders
 
+  # Raise when request includes unpermitted params to help find errors in
+  # dev/test (default value is `nil`, which is used in production)
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   # Turn false under Spring and add config.action_view.cache_template_loading = true.
   config.cache_classes = true
 

--- a/spec/requests/create_collection_spec.rb
+++ b/spec/requests/create_collection_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe "Create a collection" do
       context "when collection fails to save" do
         let(:collection_params) do
           {
-            visibility: "world"
+            release_option: "non-existent-value"
           }
         end
 

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -190,6 +190,7 @@ RSpec.describe "Create a new work" do
 
         let(:work_params) do
           attributes_for(:work_version)
+            .except(:published_at, :state) # Unpermitted params
             .merge(:authors_attributes => authors,
               :attached_files_attributes => files,
               :contact_emails_attributes => contact_emails,
@@ -645,9 +646,9 @@ RSpec.describe "Create a new work" do
             license: "CC0-1.0",
             upload_type: "browser",
             release: "embargo",
-            "embargo(1i)": "2030",
-            "embargo(2i)": "09",
-            "embargo(3i)": "01"
+            "embargo_date(1i)": "2030",
+            "embargo_date(2i)": "09",
+            "embargo_date(3i)": "01"
           }
         end
 

--- a/spec/requests/edit_collection_spec.rb
+++ b/spec/requests/edit_collection_spec.rb
@@ -34,8 +34,6 @@ RSpec.describe "Updating an existing collection" do
       context "when collection saves" do
         let(:collection_params) do
           {
-            name: "My Test Collection",
-            description: "This is a very good collection.",
             access: "world",
             required_license: "CC0-1.0",
             doi_option: "depositor-selects",
@@ -47,14 +45,8 @@ RSpec.describe "Updating an existing collection" do
               "9995" => {"sunetid" => "giancarlo", "_destroy" => "false"},
               "9994" => {"sunetid" => "zhengyi", "_destroy" => "false"}
             },
-            email_depositors_status_changed: true,
-            contact_emails_attributes: {}
-          }.tap do |param|
-            collection_version.contact_emails.each_with_object(param[:contact_emails_attributes])
-              .with_index do |(author, attrs), index|
-              attrs[index.to_s] = {"_destroy" => "false", "id" => author.id, "email" => "bob@foo.io"}
-            end
-          end
+            email_depositors_status_changed: true
+          }
         end
 
         context "when an existing collection is updated" do


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3191

This commit adds `with_orcid` as a permitted parameter for works in the `WorksController`. As part of this work, configure the app to raise on unpermitted params in the test and dev envs, so we can better flag these before they get to production going forward, and then deal with all the failing tests that causes.

# How was this change tested? 🤨

CI

# Does your change introduce accessibility violations? 🩺

No.
