### PR TITLE
_collection_summary_row.html.erb: make link text more meaningful

### DIFF
--- a/app/views/dashboards/_collection_summary_row.html.erb
+++ b/app/views/dashboards/_collection_summary_row.html.erb
@@ -10,7 +10,7 @@
   <td>
     <% if work.purl %>
       <%= link_to work.purl, work.purl %>
-      <a class="copy-button" data-controller="copy" data-copy-clip-value="<%= work.purl %>" data-action="copy#copy" aria-label="Copy persistent link" href=""><span class="fa-solid fa-copy"></span></a>
+      <a class="copy-button" data-controller="copy" data-copy-clip-value="<%= work.purl %>" data-action="copy#copy" aria-label="Copy persistent link to <%= WorkTitlePresenter.show(work.head) %>" href=""><span class="fa-solid fa-copy"></span></a>
     <% end %>
   </td>
   <td><%= render CitationComponent.new(work_version: work.head) %></td>

--- a/spec/components/dashboard/collection_component_spec.rb
+++ b/spec/components/dashboard/collection_component_spec.rb
@@ -122,5 +122,9 @@ RSpec.describe Dashboard::CollectionComponent, type: :component do
     it "renders a link to purl" do
       expect(rendered.css("a").map { |node| node["href"] }).to include "https://purl.stanford.edu/yq268qt4607"
     end
+
+    it "renders a copy link button with a unique aria-label" do
+      expect(rendered.css("a").map { |node| node["aria-label"] }).to include "Copy persistent link to #{WorkTitlePresenter.show(work.head)}"
+    end
   end
 end


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3190 

Per suggestion from SODA report:  "The aria-label can be used to include the deposit name, which is what is being done for the edit links in the Actions column."

## After this fix

![image](https://github.com/sul-dlss/happy-heron/assets/96775/c8bb828b-49e6-4c28-a5c9-664470994161)

![image](https://github.com/sul-dlss/happy-heron/assets/96775/bbf898bf-1c1b-4648-b247-5538ba48716a)

![image](https://github.com/sul-dlss/happy-heron/assets/96775/cd354692-d493-4150-8f31-8d8a818df99f)


## Before this fix

![image](https://github.com/sul-dlss/happy-heron/assets/96775/f5e0ac94-7287-4201-bbf4-45dc81a25078)

![image](https://github.com/sul-dlss/happy-heron/assets/96775/70168b00-5320-40b6-bcee-04936127b90c)

![image](https://github.com/sul-dlss/happy-heron/assets/96775/19c8f40f-b159-4ea9-b814-a9716b29a7a2)

# How was this change tested? 🤨

wrote a spec, plus ran SiteImprove, WAVE and axe tool

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

No.

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



