### PR TITLE
Add mapping of affiliations to cocina.

### DIFF
--- a/app/services/cocina_generator/description/affiliations_generator.rb
+++ b/app/services/cocina_generator/description/affiliations_generator.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module CocinaGenerator
+  module Description
+    # generates Cocina::Models::DescriptiveValue to be used by ContributorsGenerator
+    class AffiliationsGenerator
+      def self.generate(contributor:)
+        new(contributor:).generate
+      end
+
+      def initialize(contributor:)
+        @contributor = contributor
+      end
+
+      def generate
+        contributor.affiliations.map do |affiliation|
+          generate_affiliation(affiliation)
+        end
+      end
+
+      private
+
+      attr_reader :contributor
+
+      def generate_affiliation(affiliation)
+        params = if affiliation.department.present?
+          {
+            type: "affiliation",
+            structuredValue: [
+              generate_descriptive_value_by_label(affiliation),
+              {
+                value: affiliation.department
+              }
+            ]
+          }
+        else
+          {
+            type: "affiliation"
+          }.merge(generate_descriptive_value_by_label(affiliation))
+        end
+        Cocina::Models::DescriptiveValue.new(params)
+      end
+
+      def generate_descriptive_value_by_label(affiliation)
+        {
+          value: affiliation.label,
+          identifier: generate_identifier(affiliation)
+        }.compact
+      end
+
+      def generate_identifier(affiliation)
+        return nil if affiliation.uri.blank?
+        [
+          {
+            uri: affiliation.uri,
+            type: "ROR",
+            source: {
+              code: "ror"
+            }
+          }
+        ]
+      end
+    end
+  end
+end

--- a/app/services/cocina_generator/description/contributors_generator.rb
+++ b/app/services/cocina_generator/description/contributors_generator.rb
@@ -103,11 +103,10 @@ module CocinaGenerator
       end
 
       def notes(contributor)
-        return unless contributor.type == "Contributor"
-
-        [
-          Cocina::Models::DescriptiveValue.new(type: "citation status", value: "false")
-        ]
+        notes = []
+        notes << Cocina::Models::DescriptiveValue.new(type: "citation status", value: "false") if contributor.type == "Contributor"
+        notes.concat(AffiliationsGenerator.generate(contributor: contributor))
+        notes.presence
       end
 
       def marcrelator_role(role)

--- a/spec/factories/affiliations.rb
+++ b/spec/factories/affiliations.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :affiliation do
+    sequence(:label) { |n| "Affiliation #{n}" }
+
+    trait :with_ror do
+      sequence(:uri) { |n| "https://ror.org/#{n}" }
+    end
+
+    trait :with_department do
+      sequence(:department) { |n| "Department #{n}" }
+    end
+  end
+end

--- a/spec/services/cocina_generator/description/affiliations_generator_spec.rb
+++ b/spec/services/cocina_generator/description/affiliations_generator_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CocinaGenerator::Description::AffiliationsGenerator do
+  subject(:cocina_model) { described_class.generate(contributor:) }
+
+  let(:contributor) { build(:person_contributor, affiliations: affiliations) }
+
+  let(:cocina_props) { cocina_model.map(&:to_h) }
+
+  context "with affiliation with label" do
+    let(:affiliations) { [build(:affiliation, label: "Stanford University")] }
+
+    it "creates Cocina::Models::Contributor" do
+      expect(cocina_props).to eq(
+        [
+          Cocina::Models::DescriptiveValue.new({
+            type: "affiliation",
+            value: "Stanford University"
+          }).to_h
+
+        ]
+      )
+    end
+  end
+
+  context "with affiliation with label and ROR" do
+    let(:affiliations) { [build(:affiliation, label: "Stanford University", uri: "https://ror.org/00f54p054")] }
+
+    it "creates Cocina::Models::Contributor" do
+      expect(cocina_props).to eq(
+        [
+          Cocina::Models::DescriptiveValue.new({
+            type: "affiliation",
+            value: "Stanford University",
+            identifier: [
+              {
+                uri: "https://ror.org/00f54p054",
+                type: "ROR",
+                source: {
+                  code: "ror"
+                }
+              }
+            ]
+          }).to_h
+
+        ]
+      )
+    end
+  end
+
+  context "with affiliation with label and department" do
+    let(:affiliations) { [build(:affiliation, label: "Stanford University", department: "Stanford Libraries")] }
+
+    it "creates Cocina::Models::Contributor" do
+      expect(cocina_props).to eq(
+        [
+          Cocina::Models::DescriptiveValue.new({
+            type: "affiliation",
+            structuredValue: [
+              {
+                value: "Stanford University"
+              },
+              {
+                value: "Stanford Libraries"
+              }
+            ]
+          }).to_h
+
+        ]
+      )
+    end
+  end
+
+  context "with affiliation with label, ROR, and department" do
+    let(:affiliations) { [build(:affiliation, label: "Stanford University", uri: "https://ror.org/00f54p054", department: "Stanford Libraries")] }
+
+    it "creates Cocina::Models::Contributor" do
+      expect(cocina_props).to eq(
+        [
+          Cocina::Models::DescriptiveValue.new({
+            type: "affiliation",
+            structuredValue: [
+              {
+                value: "Stanford University",
+                identifier: [
+                  {
+                    uri: "https://ror.org/00f54p054",
+                    type: "ROR",
+                    source: {
+                      code: "ror"
+                    }
+                  }
+                ]
+              },
+              {
+                value: "Stanford Libraries"
+              }
+            ]
+          }).to_h
+
+        ]
+      )
+    end
+  end
+
+  context "with multiple affiliations" do
+    let(:affiliations) do
+      [
+        build(:affiliation, label: "Stanford University", uri: "https://ror.org/00f54p054", department: "Woods Institute for the Environment"),
+        build(:affiliation, label: "Stanford Medicine", uri: "https://ror.org/03mtd9a03")
+
+      ]
+    end
+
+    it "creates Cocina::Models::Contributor" do
+      expect(cocina_props).to eq(
+        [
+          Cocina::Models::DescriptiveValue.new({
+            type: "affiliation",
+            structuredValue: [
+              {
+                value: "Stanford University",
+                identifier: [
+                  {
+                    uri: "https://ror.org/00f54p054",
+                    type: "ROR",
+                    source: {
+                      code: "ror"
+                    }
+                  }
+                ]
+              },
+              {
+                value: "Woods Institute for the Environment"
+              }
+            ]
+          }).to_h,
+          Cocina::Models::DescriptiveValue.new({
+            type: "affiliation",
+            value: "Stanford Medicine",
+            identifier: [
+              {
+                uri: "https://ror.org/03mtd9a03",
+                type: "ROR",
+                source: {
+                  code: "ror"
+                }
+              }
+            ]
+          }).to_h
+
+        ]
+      )
+    end
+  end
+end

--- a/spec/services/cocina_generator/description/contributors_generator_spec.rb
+++ b/spec/services/cocina_generator/description/contributors_generator_spec.rb
@@ -1107,4 +1107,56 @@ RSpec.describe CocinaGenerator::Description::ContributorsGenerator do
       end
     end
   end
+
+  context "with contributor with affiliation" do
+    let(:affiliation) { build(:affiliation, label: "Stanford University") }
+    let(:contributor) { build(:person_contributor, orcid: "https://orcid.org/0000-0000-0000-0000", affiliations: [affiliation]) }
+    let(:work_version) { build(:work_version, contributors: [contributor]) }
+
+    it "creates Cocina::Models::Contributor" do
+      expect(cocina_props).to eq(
+        [
+          Cocina::Models::Contributor.new({
+            name: [
+              {
+                structuredValue: [
+                  {
+                    value: contributor.first_name,
+                    type: "forename"
+                  },
+                  {
+                    value: contributor.last_name,
+                    type: "surname"
+                  }
+                ]
+              }
+            ],
+            type: "person",
+            status: "primary",
+            role: [contributing_author_role],
+            identifier: [
+              {
+                value: "0000-0000-0000-0000",
+                type: "ORCID",
+                source: {
+                  uri: "https://orcid.org"
+                }
+              }
+            ],
+            note: [
+              {
+                type: "citation status",
+                value: "false"
+              },
+              {
+                type: "affiliation",
+                value: "Stanford University"
+              }
+
+            ]
+          }).to_h
+        ]
+      )
+    end
+  end
 end


### PR DESCRIPTION
closes #3201

# Why was this change made? 🤔
So that affiliations are deposited in SDR.


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



