### PR TITLE
Improve performance of collection deposits page

### DIFF
--- a/app/components/collections/work_row_component.html.erb
+++ b/app/components/collections/work_row_component.html.erb
@@ -7,7 +7,7 @@
   <td><%= work.owner.sunetid %></td>
   <td><%= render Works::StateDisplayComponent.new(work_version: work_version) %></td>
   <td><%= render LocalTimeComponent.new(datetime: work.updated_at, show_time: false) %></td>
-  <td><%= attached_files.count %></td>
+  <td><%= attached_files.size %></td>
   <td><%= size %></td>
   <td><%= link_to work.purl, work.purl if work.purl %></td>
   <td><%= render CitationComponent.new(work_version: work_version) %></td>

--- a/app/components/collections/work_row_component.rb
+++ b/app/components/collections/work_row_component.rb
@@ -13,7 +13,14 @@ module Collections
 
     # Returns the size of the attached files
     def size
-      number_to_human_size(attached_files.sum(&:byte_size))
+      # Note: This direct SQL query avoids excessive queries for large objects,
+      # Otherwise multiple queries to ActiveRecord are performed for each file
+      # to get it's size.
+      number_to_human_size(AttachedFile.where(work_version_id: work_version.id) \
+                           .joins("INNER JOIN active_storage_attachments on active_storage_attachments.record_id = attached_files.id")
+                           .joins("INNER JOIN active_storage_blobs on active_storage_attachments.blob_id = active_storage_blobs.id")
+                           .where("active_storage_attachments.record_type" => "AttachedFile")
+                           .sum("byte_size"))
     end
 
     delegate :work, :attached_files, to: :work_version


### PR DESCRIPTION
# Why was this change made? 🤔

Closes #3218 

These 2 changes improve the performance of how we are fetching the data displayed on the collection deposits page. The main change shows a direct SQL query to avoid preforming multiple queries per file to get the size (this becomes incredibly inefficient with a large number of files). The direct query improves the result time that was several minutes into a second or less.

# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



