### PR TITLE
Updating unzipping note.

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -43,7 +43,7 @@
           data: {action: "complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus", file_uploads_target: "zipRadioButton"} %>
     <%= form.label :upload_type_zipfile, "Upload a single zip file (less than 10GB) which will be unzipped, including any file hierarchy.", class: "form-check-label fw-semibold" %>
     <div id="zip-files-panel" data-file-uploads-target="zipUpload">
-      <p>Viewers will see the file hierarchy and be able to download individual files.</p>
+      <p>Viewers will see the file hierarchy and be able to download individual files. Unzipping may take several minutes if your zip file contains a large number of individual files.</p>
       <div data-controller="dropzone" data-dropzone-max-file-size="10000" data-dropzone-max-files="1"
            data-dropzone-accepted-files=".zip" data-dropzone-clickable=".dz-zip-clickable"
            data-dropzone-previews-container=".dropzone-zip-previews">


### PR DESCRIPTION
# Why was this change made? 🤔

Resolves #3220. 

![Screenshot 2023-07-11 at 12 22 26 PM](https://github.com/sul-dlss/happy-heron/assets/1619369/420c8b56-e5e3-4ec5-beb3-7540b3e4cb3a)

# How was this change tested? 🤨
Unit

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺
No

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



