### PR TITLE
Do not render globus instructions until globus endpoint is set.

### DIFF
--- a/app/components/works/globus_setup_component.html.erb
+++ b/app/components/works/globus_setup_component.html.erb
@@ -2,16 +2,26 @@
   <div class="row my-5 mx-2 alert alert-danger">
     <div class="col-12">
       <p><strong>How to complete your deposit using Globus:</strong></p>
-      <ol>
-        <li>If you are NOT transferring content from Oak, Sherlock, or Google Drive, you may need to perform some setup tasks, including installation of software. Check the appendices of our <%= link_to "instructions", "#{Settings.globus.help_doc_url}/edit", target: "_blank" %> for details.</li>
-          <ul>
-            <li>Be sure you have logged into Globus with your Stanford credentials!</li>
-          </ul>
-        <li>Go to this <%= link_to "shared folder at Globus", endpoint, target: "_blank" %> that we have created just for you and transfer your files there.</li>
-        <li>Return here and click the pencil icon above to edit your item.</li>
-        <li>Check the box in the "Add your files" section on the edit page to indicate that your files have finished transferring to Globus (transfer must be complete!).</li>
-        <li>Scroll to the bottom of the form and click "Deposit" to finish up now, or click "Save as draft" to finish later.</li>
-      </ol>
+      <% if placeholder? %>
+        <ol>
+          <li><span class="placeholder w-100"></span></li>
+          <li><span class="placeholder w-100"></span></li>
+          <li><span class="placeholder w-100"></span></li>
+          <li><span class="placeholder w-100"></span></li>
+          <li><span class="placeholder w-100"></span></li>
+        </ol>
+      <% else %>
+        <ol>
+          <li>If you are NOT transferring content from Oak, Sherlock, or Google Drive, you may need to perform some setup tasks, including installation of software. Check the appendices of our <%= link_to "instructions", "#{Settings.globus.help_doc_url}/edit", target: "_blank" %> for details.</li>
+            <ul>
+              <li>Be sure you have logged into Globus with your Stanford credentials!</li>
+            </ul>
+          <li>Go to this <%= link_to "shared folder at Globus", endpoint, target: "_blank" %> that we have created just for you and transfer your files there.</li>
+          <li>Return here and click the pencil icon above to edit your item.</li>
+          <li>Check the box in the "Add your files" section on the edit page to indicate that your files have finished transferring to Globus (transfer must be complete!).</li>
+          <li>Scroll to the bottom of the form and click "Deposit" to finish up now, or click "Save as draft" to finish later.</li>
+        </ol>
+      <% end %>
     </div>
   </div>
 <% else %>

--- a/app/components/works/globus_setup_component.rb
+++ b/app/components/works/globus_setup_component.rb
@@ -10,7 +10,11 @@ module Works
     attr_reader :work_version
 
     def render?
-      work_version.globus? && work_version.globus_endpoint
+      work_version.globus?
+    end
+
+    def placeholder?
+      work_version.globus_endpoint.blank?
     end
 
     def globus_user_valid?

--- a/app/components/works/globus_setup_component.rb
+++ b/app/components/works/globus_setup_component.rb
@@ -10,7 +10,7 @@ module Works
     attr_reader :work_version
 
     def render?
-      work_version.globus?
+      work_version.globus? && work_version.globus_endpoint
     end
 
     def globus_user_valid?

--- a/spec/components/works/globus_setup_component_spec.rb
+++ b/spec/components/works/globus_setup_component_spec.rb
@@ -26,14 +26,16 @@ RSpec.describe Works::GlobusSetupComponent, type: :component do
       it "renders the instructions with origin_id in globus link" do
         expect(rendered.to_html).to include "How to complete your deposit using Globus"
         expect(rendered.css("a").map { |node| node["href"] }).to include "https://app.globus.org/file-manager?&destination_id=endpoint_uuid&destination_path=/uploads/user/123/version1&origin_id=8b3a8b64-d4ab-4551-b37e-ca0092f769a7"
+        expect(rendered.css("li span.placeholder").length).to be_zero
       end
     end
 
     context "when globus endpoint not yet set" do
       let(:globus_endpoint) { nil }
 
-      it "does not render the instructions" do
-        expect(rendered.to_html).not_to include "How to complete your deposit using Globus"
+      it "renders the instructions with placeholders" do
+        expect(rendered.to_html).to include "How to complete your deposit using Globus"
+        expect(rendered.css("li span.placeholder").length).to be_positive
       end
     end
   end

--- a/spec/components/works/globus_setup_component_spec.rb
+++ b/spec/components/works/globus_setup_component_spec.rb
@@ -4,8 +4,9 @@ require "rails_helper"
 
 RSpec.describe Works::GlobusSetupComponent, type: :component do
   let(:rendered) { render_inline(described_class.new(work_version:)) }
-  let(:work_version) { build_stubbed(:work_version, state: "first_draft", upload_type: "globus", globus_endpoint: "user/123/version1", globus_origin:) }
+  let(:work_version) { build_stubbed(:work_version, state: "first_draft", upload_type: "globus", globus_endpoint: globus_endpoint, globus_origin:) }
   let(:globus_origin) { nil }
+  let(:globus_endpoint) { "user/123/version1" }
 
   context "when the globus user is valid" do
     before do
@@ -25,6 +26,14 @@ RSpec.describe Works::GlobusSetupComponent, type: :component do
       it "renders the instructions with origin_id in globus link" do
         expect(rendered.to_html).to include "How to complete your deposit using Globus"
         expect(rendered.css("a").map { |node| node["href"] }).to include "https://app.globus.org/file-manager?&destination_id=endpoint_uuid&destination_path=/uploads/user/123/version1&origin_id=8b3a8b64-d4ab-4551-b37e-ca0092f769a7"
+      end
+    end
+
+    context "when globus endpoint not yet set" do
+      let(:globus_endpoint) { nil }
+
+      it "does not render the instructions" do
+        expect(rendered.to_html).not_to include "How to complete your deposit using Globus"
       end
     end
   end


### PR DESCRIPTION
closes #3212

# Why was this change made? 🤔
User was getting an incomplete link.


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



