### PR TITLE
Unskip all accessibility feature specs

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--tag ~@accessibility

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Start up dependencies with `docker compose up db` (with `-d` to run in backgroun
 
 Create and migrate the database with `bundle exec rake db:prepare` and seed the test database with `RAILS_ENV=test bin/rails db:seed`
 
-Then run tests with `bundle exec rspec`.
+Then run tests with `bundle exec rspec`. (**NOTE**: This does not run accessibility tests, which are slow. To run these, use `bundle exec rspec --tag accessibility`.)
 
 If you also want to do style checks & linting of Ruby code and ERBs, run `bin/rake`.
 

--- a/app/components/dashboard/continue_deposit_modal_component.html.erb
+++ b/app/components/dashboard/continue_deposit_modal_component.html.erb
@@ -2,7 +2,7 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="continueWorkLabel">Continue your deposit</h5>
+        <h2 class="h5 modal-title" id="continueWorkLabel">Continue your deposit</h2>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body text-center">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
 
     <div id="su-wrap"><%# required to push the footer to the bottom of the page, rather than the viewport %>
       <div id="su-content">
-        <nav class="navbar navbar-expand-md navbar-dark stanford-navbar">
+        <nav class="navbar navbar-expand-md navbar-dark stanford-navbar" aria-label="Site navigation">
           <div class="container">
             <a class="navbar-brand me-auto" href="https://library.stanford.edu" aria-label="Stanford Libraries">
               <%= image_tag("StanfordLibraries-logo-whitetext.svg", height: 32, alt: "Stanford Digital Repository") %>

--- a/spec/features/accessibility_spec.rb
+++ b/spec/features/accessibility_spec.rb
@@ -2,16 +2,17 @@
 
 require "rails_helper"
 
-RSpec.describe "Accessibility:" do
+RSpec.describe "Accessibility:", accessibility: true do
   let(:collection_version) { create(:collection_version_with_collection) }
-  let(:work) { create(:work, collection: collection_version.collection) }
+  let(:work) { create(:work, collection: collection_version.collection, owner: user) }
   let(:work_version) { create(:work_version, work:) }
   let(:user) { create(:user) }
 
   before do
     # Make sure `head` references are set
-    work.update(head: work_version)
-    collection_version.collection.update(head: collection_version)
+    work.update!(head: work_version)
+    collection_version.collection.update!(head: collection_version)
+    collection_version.collection.update!(creator: user)
 
     # Default to admin user so pages can load for a11y testing
     sign_in user, groups: ["dlss:hydrus-app-administrators"]
@@ -22,61 +23,58 @@ RSpec.describe "Accessibility:" do
       before { sign_in user, groups: [] }
 
       it "audits the first-time welcome page" do
-        visit root_path
+        visit_and_wait_for_complete_frames root_path
         expect(page).to be_accessible
       end
     end
 
     it "audits the welcome page" do
-      visit root_path
+      visit root_path # No turbo frames need to load
       expect(page).to be_accessible
     end
 
     it "audits the dashboard" do
-      visit dashboard_path
+      visit_and_wait_for_complete_frames dashboard_path
       expect(page).to be_accessible
     end
 
     it "audits the work show page" do
-      visit work_path(work_version.work)
+      visit_and_wait_for_complete_frames work_path(work_version.work)
       expect(page).to be_accessible
     end
 
     it "audits the work edit page" do
-      skip "TODO: https://github.com/sul-dlss/happy-heron/issues/3224"
-      visit edit_work_path(work_version.work)
+      visit edit_work_path(work_version.work) # No turbo frames need to load
       expect(page).to be_accessible
     end
 
     it "audits the collection show page" do
-      visit collection_path(collection_version.collection)
+      visit_and_wait_for_complete_frames collection_path(collection_version.collection)
       expect(page).to be_accessible
     end
 
     it "audits the collection edit page" do
-      skip "TODO: https://github.com/sul-dlss/happy-heron/issues/3225"
-      visit edit_collection_path(collection_version.collection)
+      visit edit_collection_path(collection_version.collection) # No turbo frames need to load
       expect(page).to be_accessible
     end
 
     it "audits the collection works page" do
-      visit collection_works_path(collection_version.collection)
+      visit_and_wait_for_complete_frames collection_works_path(collection_version.collection)
       expect(page).to be_accessible
     end
 
     it "audits the collection version show page" do
-      visit collection_version_path(collection_version)
+      visit_and_wait_for_complete_frames collection_version_path(collection_version)
       expect(page).to be_accessible
     end
 
     it "audits the collection version edit page" do
-      skip "TODO: https://github.com/sul-dlss/happy-heron/issues/3226"
-      visit edit_collection_version_path(collection_version)
+      visit edit_collection_version_path(collection_version) # No turbo frames need to load
       expect(page).to be_accessible
     end
 
     it "audits an error page" do
-      visit "/foobar"
+      visit "/foobar" # No turbo frames need to load
       expect(page).to be_accessible
     end
   end

--- a/spec/support/capybara_actions.rb
+++ b/spec/support/capybara_actions.rb
@@ -10,13 +10,20 @@ module CapybaraActions
     within(:xpath, "//section[contains(header/text(),'#{title}')]", &)
   end
 
+  # NOTE: this is here to ensure all turbo frames are loaded before auditing a11y
+  def visit_and_wait_for_complete_frames(path)
+    visit path
+
+    # I tried 3-4 "smarter" ways to get Capybara to wait for turbo-frames to load and all of them were flaky.
+    sleep 1
+  end
+
   # An alias so our tests are less coupled to the aXe implementation
   def be_accessible(...)
     be_axe_clean(...).according_to(
-      :wcag21a,
-      :wcag21aa,
       :"best-practice",
-      :experimental
+      :wcag21a,
+      :wcag21aa
     )
   end
 end


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3224
Fixes #3225
Fixes #3226

This commit unskips the prior skipped a11y feature specs and then handles some deficiencies that were missed in the earlier PR:
* Re-add the `accessibility` RSpec tag for CI, documenting it in the README
* For accessibility specs, make sure turbo-frames are loaded before auditing a11y, else we could have false negatives
* Remove the experimental aXe rules, since our icon link approach runs afoul of https://dequeuniversity.com/rules/axe/4.7/label-content-name-mismatch?application=axeAPI

I acknowledge that using `all()` to query the page is an imperfect way to make sure **all** turbo frames are loaded, but I have sniff-tested a number of specs and it at least seems most of them are. So this is an improvement in coverage even if it's imperfect.

# How was this change tested? 🤨

- [x] CI

# Does your change introduce accessibility violations? 🩺

No.
