### PR TITLE
Update contributor form layout

### DIFF
--- a/app/components/works/contributor_row_component.html.erb
+++ b/app/components/works/contributor_row_component.html.erb
@@ -1,17 +1,19 @@
 <div class="row inner-container contributor-row" data-controller="contributors" data-contributors-required-value="<%= author? %>">
   <% namespace = author? ? "author" : "contributor" %>
   <div class="col-md-11">
-    <div class="row">
-      <div class="col-md-3">
+    <div class="row" style="margin-bottom: 10px;">
+      <div class="col-md-2">
         <%= form.label :role_term, role_term_label, class: "form-label" %>
         <%= render PopoverComponent.new key: "work.role_term" %>
+      </div>
+      <div class="col-md-3">
         <%= select_role %>
       </div>
-      <div class="col-md-1">
-      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-2"></div>
       <div class="col" data-contributors-target="person">
         <fieldset>
-          <legend>Details</legend>
           <div class="form-check">
             <%= form.radio_button :with_orcid, "false", html_options_for_radio(true, !orcid?) %>
             <%= form.label :with_orcid, "Enter author name", value: "false", class: "form-check-label fw-semibold" %>


### PR DESCRIPTION
# Why was this change made? 🤔

Closes #3206 

Updates the contributor form as seen below:

<img width="1368" alt="Screenshot 2023-07-12 at 4 25 21 PM" src="https://github.com/sul-dlss/happy-heron/assets/2294288/3a2d4acd-000f-4f2d-b704-2673c524bd5d">

# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



