### PR TITLE
Strip whitespace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ gem "sdr-client", "~> 2.0"
 gem "sidekiq", "~> 7.0"
 gem "sneakers", "~> 2.11" # rabbitMQ background processing
 gem "state_machines-activerecord"
+gem "strip_attributes"
 gem "turbo-rails", "~> 1.0"
 gem "view_component", "~> 2.56.2" # https://github.com/github/view_component/issues/1390
 gem "whenever", require: false # Work around https://github.com/javan/whenever/issues/831

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -566,6 +566,8 @@ GEM
     state_machines-graphviz (0.0.2)
       ruby-graphviz
       state_machines
+    strip_attributes (1.13.0)
+      activemodel (>= 3.0, < 8.0)
     super_diff (0.10.0)
       attr_extras (>= 6.2.4)
       diff-lcs
@@ -683,6 +685,7 @@ DEPENDENCIES
   standard-rails
   state_machines-activerecord
   state_machines-graphviz
+  strip_attributes
   super_diff
   turbo-rails (~> 1.0)
   view_component (~> 2.56.2)

--- a/app/models/abstract_contributor.rb
+++ b/app/models/abstract_contributor.rb
@@ -62,6 +62,8 @@ class AbstractContributor < ApplicationRecord
   validates :orcid, format: {with: Orcid::REGEX}, allow_nil: true, if: :person?
   validates :orcid, absence: true, unless: :person?
 
+  strip_attributes allow_empty: true, only: [:first_name, :last_name, :full_name]
+
   def self.grouped_roles(citable:)
     return GROUPED_ROLES if citable
 

--- a/app/models/collection_version.rb
+++ b/app/models/collection_version.rb
@@ -8,6 +8,8 @@ class CollectionVersion < ApplicationRecord
   has_many :contact_emails, as: :emailable, dependent: :destroy
   belongs_to :collection, touch: true
 
+  strip_attributes allow_empty: true, only: [:name, :description]
+
   after_update_commit -> { collection.broadcast_update }
 
   include CollectionVersionStateMachine

--- a/app/models/contact_email.rb
+++ b/app/models/contact_email.rb
@@ -3,4 +3,5 @@
 # Models an email in the database
 class ContactEmail < ApplicationRecord
   belongs_to :emailable, polymorphic: true
+  strip_attributes allow_empty: true, only: [:email]
 end

--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -3,4 +3,5 @@
 # Models keywords that describe a work
 class Keyword < ApplicationRecord
   belongs_to :work_version
+  strip_attributes allow_empty: true, only: [:uri, :label]
 end

--- a/app/models/related_link.rb
+++ b/app/models/related_link.rb
@@ -3,6 +3,6 @@
 # Models a URI that is related to a work
 class RelatedLink < ApplicationRecord
   belongs_to :linkable, polymorphic: true
-
   validates :url, presence: true
+  strip_attributes allow_empty: true, only: [:link_title, :url]
 end

--- a/app/models/related_work.rb
+++ b/app/models/related_work.rb
@@ -3,6 +3,6 @@
 # Models a citation of a work that is related to the deposited work.
 class RelatedWork < ApplicationRecord
   belongs_to :work_version
-
   validates :citation, presence: true
+  strip_attributes allow_empty: true, only: [:citation]
 end

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -30,6 +30,8 @@ class WorkVersion < ApplicationRecord
   validates :subtype, work_subtype: true
   validates :work_type, presence: true, work_type: true
 
+  strip_attributes allow_empty: true, only: [:title, :abstract, :citation]
+
   scope :awaiting_review_by, lambda { |user|
     with_state(:pending_approval)
       .joins(:work)

--- a/spec/models/collection_version_spec.rb
+++ b/spec/models/collection_version_spec.rb
@@ -159,4 +159,23 @@ RSpec.describe CollectionVersion do
       end
     end
   end
+
+  context "when select attributes contain leading/trailing whitespace" do
+    let(:collection_version) do
+      create(
+        :collection_version,
+        name: " W3C ",
+        description: " W3C Documents ",
+        collection: build(:collection)
+      )
+    end
+
+    it "strips name" do
+      expect(collection_version.name).to eq("W3C")
+    end
+
+    it "strips description" do
+      expect(collection_version.description).to eq("W3C Documents")
+    end
+  end
 end

--- a/spec/models/contact_email_spec.rb
+++ b/spec/models/contact_email_spec.rb
@@ -14,4 +14,14 @@ RSpec.describe ContactEmail do
   it "belongs to a work" do
     expect(contact_email.emailable).to eq work
   end
+
+  context "when select attributes contain leading/trailing whitespace" do
+    let(:contact_email) do
+      create(:contact_email, email: " timbl@w3.org ", emailable: work)
+    end
+
+    it("strips email") do
+      expect(contact_email.email).to eq("timbl@w3.org")
+    end
+  end
 end

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -34,4 +34,27 @@ RSpec.describe Contributor do
       it { is_expected.to be_valid }
     end
   end
+
+  context "when select attributes contain leading/trailing whitespace" do
+    let(:contributor) do
+      create(
+        :person_contributor,
+        first_name: " Ted ",
+        last_name: " Nelson ",
+        full_name: " Ted Nelson "
+      )
+    end
+
+    it "strips first_name" do
+      expect(contributor.first_name).to eq("Ted")
+    end
+
+    it "strips last_name" do
+      expect(contributor.last_name).to eq("Nelson")
+    end
+
+    it "strips full_name" do
+      expect(contributor.full_name).to eq("Ted Nelson")
+    end
+  end
 end

--- a/spec/models/keyword_spec.rb
+++ b/spec/models/keyword_spec.rb
@@ -12,4 +12,24 @@ RSpec.describe Keyword do
   it "has a url" do
     expect(keyword.uri).to be_present
   end
+
+  context "when select attributes contain leading/trailing whitespace" do
+    let(:work_version) { build(:work_version) }
+    let(:keyword) do
+      create(
+        :keyword,
+        label: " World Wide Web ",
+        uri: " http://www.wikidata.org/entity/Q466 ",
+        work_version:
+      )
+    end
+
+    it "strips label" do
+      expect(keyword.label).to eq("World Wide Web")
+    end
+
+    it "strips uri" do
+      expect(keyword.uri).to eq("http://www.wikidata.org/entity/Q466")
+    end
+  end
 end

--- a/spec/models/related_link_spec.rb
+++ b/spec/models/related_link_spec.rb
@@ -18,4 +18,23 @@ RSpec.describe RelatedLink do
   it "belongs to a work" do
     expect(related_link.linkable).to eq work
   end
+
+  context "when select attributes contain leading/trailing whitespace" do
+    let(:related_link) do
+      create(
+        :related_link,
+        link_title: " The RTF file ",
+        url: " https://www.w3.org/History/1989/proposal.rtf ",
+        linkable: work
+      )
+    end
+
+    it "strips title" do
+      expect(related_link.link_title).to eq("The RTF file")
+    end
+
+    it "strips url" do
+      expect(related_link.url).to eq("https://www.w3.org/History/1989/proposal.rtf")
+    end
+  end
 end

--- a/spec/models/related_work_spec.rb
+++ b/spec/models/related_work_spec.rb
@@ -8,4 +8,14 @@ RSpec.describe RelatedWork do
   it "has a citation" do
     expect(related_work.citation).to be_present
   end
+
+  context "when select attributes contain leading/trailing whitespace" do
+    let(:related_work) do
+      create(:related_work, citation: " The RTF file generated from the above, with scalable drawings ")
+    end
+
+    it "strips citation" do
+      expect(related_work.citation).to eq("The RTF file generated from the above, with scalable drawings")
+    end
+  end
 end

--- a/spec/models/work_version_spec.rb
+++ b/spec/models/work_version_spec.rb
@@ -330,4 +330,27 @@ RSpec.describe WorkVersion do
       end
     end
   end
+
+  context "when select attributes contain leading/trailing whitespace" do
+    let(:work_version) do
+      create(
+        :work_version,
+        title: " Information Management: A Proposal ",
+        abstract: " This proposal concerns the management of general information about accelerators and experiments at CERN. It discusses the problems of loss of information about complex evolving systems and derives a solution based on a distributed hypertext system. ",
+        citation: " Berners-Lee, Tim (1998). Information Management: A Proposal, CERN. "
+      )
+    end
+
+    it "strips the title" do
+      expect(work_version.title).to eq("Information Management: A Proposal")
+    end
+
+    it "strips the abstract" do
+      expect(work_version.abstract).to eq("This proposal concerns the management of general information about accelerators and experiments at CERN. It discusses the problems of loss of information about complex evolving systems and derives a solution based on a distributed hypertext system.")
+    end
+
+    it "strips the citation" do
+      expect(work_version.citation).to eq("Berners-Lee, Tim (1998). Information Management: A Proposal, CERN.")
+    end
+  end
 end


### PR DESCRIPTION
# Why was this change made? 🤔

Adds the [strip-attributes](https://github.com/rmm5t/strip_attributes) gem to easily remove leading/trailing whitespace from designated model attributes.

I chose to configure strip-attributes to only strip specific identified attributes, and also turned off the auto-conversion of `""` to `nil` which broke some tests because the columns were `NOT NULL`.

Fixes #3207

# How was this change tested? 🤨

Local development instance and unit tests.

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

# Does your change introduce accessibility violations? 🩺

No
