### PR TITLE
Update standard gems and require standard-custom

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,11 +4,14 @@ inherit_mode:
 
 require:
   - standard
+  - standard-custom
+  - standard-performance
+  - standard-rails
+  - rubocop-capybara
+  - rubocop-factory_bot
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
-  - rubocop-capybara
-  - rubocop-factory_bot
 
 inherit_gem:
   standard: config/base.yml

--- a/Gemfile
+++ b/Gemfile
@@ -15,14 +15,9 @@ group :development, :test do
   gem "rspec"
   gem "rspec_junit_formatter" # used by CircleCI
   gem "rspec-rails"
-  # NOTE: the `standard` way does not support using the rubocop CLI with
-  # extensions like standard-rails, so until that changes or we decide to switch
-  # to the standardrb CLI (which would need CI and editor support), we have to
-  # carry both this dependency and standard-rails.
-  gem "rubocop-rails", require: false
   gem "rubocop-rspec", require: false
   gem "simplecov", require: false
-  gem "standard", "< 1.30", require: false # TODO: 1.30.x breaks build as of 2023-07-10, unpin once a later release fixes this, or if suggested workaround is acceptable and fixes the issue, see https://github.com/standardrb/standard/issues/569
+  gem "standard", require: false
   gem "standard-rails", require: false
   gem "super_diff", require: false
   gem "webmock" # test calls to external QA lookup service for autocomplete

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -542,14 +542,15 @@ GEM
     sshkit (1.21.5)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    standard (1.29.0)
+    standard (1.30.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
       rubocop (~> 1.52.0)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.1.0)
-    standard-custom (1.0.1)
+    standard-custom (1.0.2)
       lint_roller (~> 1.0)
+      rubocop (~> 1.50)
     standard-performance (1.1.1)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.18.0)
@@ -671,7 +672,6 @@ DEPENDENCIES
   rspec
   rspec-rails
   rspec_junit_formatter
-  rubocop-rails
   rubocop-rspec
   rubyzip (~> 2.3)
   sdr-client (~> 2.0)
@@ -681,7 +681,7 @@ DEPENDENCIES
   sneakers (~> 2.11)
   spring
   spring-watcher-listen (~> 2.0.0)
-  standard (< 1.30)
+  standard
   standard-rails
   state_machines-activerecord
   state_machines-graphviz


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3244

This commit updates the standard gems and uses the new pattern for requiring standardrb plugins in the `require` section of the rubocop configuration.


# How was this change tested? 🤨

CI


# Does your change introduce accessibility violations? 🩺

No
