### PR TITLE
Avoid race condition by moving job enqueuing out of state machine

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -183,7 +183,11 @@ class WorksController < ObjectsController
 
     # Instead of crazy conditional logic, constructing the event name and sending
     state_event = state_event_for(work_version)
-    work_version.send(state_event) if state_event
+    if state_event
+      work_version.send(state_event)
+      FetchGlobusJob.perform_later(work_version) if state_event.starts_with?("fetch_globus")
+      UnzipJob.perform_later(work_version) if state_event.starts_with?("unzip")
+    end
 
     return redirect_to next_step_review_work_path(work) if deposit_button_pushed? && work.collection.review_enabled?
     return redirect_to next_step_work_path(work) if deposit_button_pushed?

--- a/app/models/concerns/work_version_state_machine.rb
+++ b/app/models/concerns/work_version_state_machine.rb
@@ -26,12 +26,6 @@ module WorkVersionStateMachine
       after_transition on: :deposit_complete, do: WorkObserver.method(:after_deposit_complete)
       after_transition on: :deposit_complete, do: CollectionObserver.method(:item_deposited)
       after_transition on: :decommission, do: WorkObserver.method(:after_decommission)
-      after_transition on: :unzip, do: WorkObserver.method(:after_unzip)
-      after_transition on: :unzip_and_submit_for_review, do: WorkObserver.method(:after_unzip)
-      after_transition on: :unzip_and_begin_deposit, do: WorkObserver.method(:after_unzip)
-      after_transition on: :fetch_globus, do: WorkObserver.method(:after_fetch_globus)
-      after_transition on: :fetch_globus_and_submit_for_review, do: WorkObserver.method(:after_fetch_globus)
-      after_transition on: :fetch_globus_and_begin_deposit, do: WorkObserver.method(:after_fetch_globus)
 
       # check to see if there any globus related actions needed when transitioning to any draft state
       after_transition to: %i[first_draft version_draft],

--- a/app/services/work_observer.rb
+++ b/app/services/work_observer.rb
@@ -70,14 +70,6 @@ class WorkObserver
     end
   end
 
-  def self.after_unzip(work_version, _transition)
-    UnzipJob.perform_later(work_version)
-  end
-
-  def self.after_fetch_globus(work_version, _transition)
-    FetchGlobusJob.perform_later(work_version)
-  end
-
   def self.work_mailer(work_version)
     WorksMailer.with(user: work_version.work.owner, work_version:)
   end

--- a/spec/models/work_version_state_machine_spec.rb
+++ b/spec/models/work_version_state_machine_spec.rb
@@ -340,7 +340,6 @@ RSpec.describe WorkVersion do
       expect { work_version.unzip! }
         .to change(work_version, :state)
         .to("unzip_first_draft")
-        .and(have_enqueued_job(UnzipJob).with(work_version))
     end
   end
 
@@ -351,7 +350,6 @@ RSpec.describe WorkVersion do
       expect { work_version.unzip_and_submit_for_review! }
         .to change(work_version, :state)
         .to("unzip_pending_approval")
-        .and(have_enqueued_job(UnzipJob).with(work_version))
     end
   end
 
@@ -362,7 +360,6 @@ RSpec.describe WorkVersion do
       expect { work_version.unzip_and_begin_deposit! }
         .to change(work_version, :state)
         .to("unzip_depositing")
-        .and(have_enqueued_job(UnzipJob).with(work_version))
     end
   end
 
@@ -373,7 +370,6 @@ RSpec.describe WorkVersion do
       expect { work_version.fetch_globus! }
         .to change(work_version, :state)
         .to("fetch_globus_first_draft")
-        .and(have_enqueued_job(FetchGlobusJob).with(work_version))
     end
   end
 
@@ -384,7 +380,6 @@ RSpec.describe WorkVersion do
       expect { work_version.fetch_globus_and_submit_for_review! }
         .to change(work_version, :state)
         .to("fetch_globus_pending_approval")
-        .and(have_enqueued_job(FetchGlobusJob).with(work_version))
     end
   end
 
@@ -395,7 +390,6 @@ RSpec.describe WorkVersion do
       expect { work_version.fetch_globus_and_begin_deposit! }
         .to change(work_version, :state)
         .to("fetch_globus_depositing")
-        .and(have_enqueued_job(FetchGlobusJob).with(work_version))
     end
   end
 end


### PR DESCRIPTION
# Why was this change made? 🤔
Resolves #3071. Both FetchGlobusJob and UnzipJob, which send an event at the end, had been called from an `after_transition` callback. Moving that step out of the state machine, to the controller. 

# How was this change tested? 🤨
Unit tests and QA testing. 

# Does your change introduce accessibility violations? 🩺
No front-end changes

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



