### PR TITLE
Remove unnecessary requires in rubocop task

### DIFF
--- a/lib/tasks/linters.rake
+++ b/lib/tasks/linters.rake
@@ -2,14 +2,7 @@
 
 begin
   require "rubocop/rake_task"
-  RuboCop::RakeTask.new do |task|
-    task.requires << "standard"
-    task.requires << "rubocop-performance"
-    task.requires << "rubocop-rails"
-    task.requires << "rubocop-rspec"
-    task.requires << "rubocop-capybara"
-    task.requires << "rubocop-factory_bot"
-  end
+  RuboCop::RakeTask.new
 rescue LoadError
   task rubocop: :environment do
     abort "Please install the rubocop gem to run rubocop."


### PR DESCRIPTION
# Why was this change made? 🤔

AFAICT, these requires are unnecessary, as they duplicate what is already listed in the Rubocop configuration. Also, none of our other codebases do this so it is clearly an outlier.

# How was this change tested? 🤨

- [ ] CI
- [ ] Ran `rake rubocop` task before and after the change to verify no behavior differences.

# Does your change introduce accessibility violations? 🩺

Nope
