### PR TITLE
Hiding globus deposit disabled message once box checked

### DIFF
--- a/app/javascript/controllers/deposit_button_controller.js
+++ b/app/javascript/controllers/deposit_button_controller.js
@@ -8,7 +8,7 @@ export default class extends Controller {
   }
 
   updateDepositButtonStatus(_event) {
-    this.globusMessageTarget.hidden = !this.globusRadioButtonTarget.checked
+    this.globusMessageTarget.hidden = !this.globusRadioButtonTarget.checked || this.globusCheckboxTarget.checked
     this.depositButtonTarget.disabled = this.globusRadioButtonTarget.checked && (!this.hasGlobusCheckboxTarget || !this.globusCheckboxTarget.checked)
   }
 }

--- a/cypress/spec/create_work_version.cy.js
+++ b/cypress/spec/create_work_version.cy.js
@@ -101,5 +101,8 @@ describe('Create work version', () => {
 
       // deposit button should be enabled
       cy.get('input.btn[value="Deposit"]', {force: true}).should('be.enabled')
+
+      // globus-specific message is not present
+      cy.contains('Deposit is disabled until file transfer is complete.').should('not.be.visible')
     })
 })


### PR DESCRIPTION
# Why was this change made? 🤔
Resolves #3246.

Once the "Check this box once all your files have completed uploading to Globus." box is checked, the "deposit is disabled" message will be hidden.

![Screenshot 2023-07-18 at 10 57 17 AM](https://github.com/sul-dlss/happy-heron/assets/1619369/db0700bc-afd4-46af-81a9-675e94b7476c)

# How was this change tested? 🤨
Unit, added to cypress spec.

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

# Does your change introduce accessibility violations? 🩺
No new issues.



