### PR TITLE
Adds rake task for getting Stanford users not in MAIS.

### DIFF
--- a/app/services/orcid_stanford_user_service.rb
+++ b/app/services/orcid_stanford_user_service.rb
@@ -1,0 +1,24 @@
+# Finds contributors that have an orcid id and a Stanford affiliation, but do not have an orcid in MAIS.
+class OrcidStanfordUserService
+  def self.execute
+    new.execute
+  end
+
+  def execute
+    orcid_ids = Affiliation.where("label ILIKE ?", "%Stanford University%").joins(:abstract_contributor).where.not(abstract_contributor: {orcid: nil}).pluck(:orcid).uniq
+    contributors = orcid_ids.map { |orcid_id| AbstractContributor.find_by(orcid: orcid_id) }
+    contributors.select do |contributor|
+      mais_orcid_client.fetch_orcid_user(orcidid: contributor.orcid).nil?
+    end
+  end
+
+  private
+
+  def mais_orcid_client
+    @mais_orcid_client ||= MaisOrcidClient.configure(
+      client_id: Settings.mais_orcid.client_id,
+      client_secret: Settings.mais_orcid.client_secret,
+      base_url: Settings.mais_orcid.base_url
+    )
+  end
+end

--- a/lib/tasks/orcid.rake
+++ b/lib/tasks/orcid.rake
@@ -10,4 +10,16 @@ namespace :orcid do
       end
     end
   end
+
+  desc "Returns Stanford users not found in MAIS"
+  task stanford_users: :environment do
+    contributors = OrcidStanfordUserService.execute
+    CSV.open("stanford_users.csv", "wb") do |csv|
+      csv << ["first name", "last name", "orcidid"]
+      contributors.each do |contributor|
+        csv << [contributor.first_name, contributor.last_name, contributor.orcid]
+        puts "#{contributor.first_name} #{contributor.last_name} => #{contributor.orcid}"
+      end
+    end
+  end
 end

--- a/spec/services/orcid_stanford_user_service_spec.rb
+++ b/spec/services/orcid_stanford_user_service_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrcidStanfordUserService do
+  # Contributor with stanford affiliation and orcid, not found in MAIS
+  let(:contributor) do
+    create(:person_author, orcid: "https://sandbox.orcid.org/0000-0003-3437-349X")
+  end
+  let(:client) { instance_double(MaisOrcidClient) }
+
+  before do
+    allow(MaisOrcidClient).to receive(:configure).and_return(client)
+
+    # For contributor with stanford affiliation and orcid, not found in MAIS
+    create(:affiliation, label: "stanford university", abstract_contributor: contributor)
+    allow(client).to receive(:fetch_orcid_user).with(orcidid: "https://sandbox.orcid.org/0000-0003-3437-349X").and_return(nil)
+
+    # Contributor with stanford affiliation and orcid, found in MAIS
+    contributor1 = create(:person_author, orcid: "https://sandbox.orcid.org/0000-0003-3437-1234")
+    create(:affiliation, label: "Stanford University", abstract_contributor: contributor1)
+    allow(client).to receive(:fetch_orcid_user).with(orcidid: "https://sandbox.orcid.org/0000-0003-3437-1234").and_return(instance_double(MaisOrcidClient::OrcidUser))
+
+    # Contributor with stanford affiliation, no orcid
+    contributor2 = create(:person_author)
+    create(:affiliation, label: "Stanford University", abstract_contributor: contributor2)
+
+    # Contributor with orcid, no stanford affiliation
+    create(:person_author, orcid: "https://sandbox.orcid.org/0000-0003-3437-5678")
+  end
+
+  it "returns contributors with stanford affiliation and orcid but not found in MAIS" do
+    expect(described_class.execute).to eq([contributor])
+  end
+end


### PR DESCRIPTION
closes #3154

# Why was this change made? 🤔



# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit, QA

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



