### PR TITLE
Use assign doi to determine if collection can be moved.

### DIFF
--- a/app/services/check_move_work_service.rb
+++ b/app/services/check_move_work_service.rb
@@ -38,7 +38,7 @@ class CheckMoveWorkService
   end
 
   def missing_doi?
-    !work.doi && collection.doi_option == "yes"
+    !work.assign_doi && collection.doi_option == "yes"
   end
 
   def compatible_license?

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     owner { association(:user) }
     head { nil }
     created_at { Time.zone.parse("2007-02-10 15:30:45") }
+    assign_doi { false }
     collection
   end
 
@@ -14,6 +15,7 @@ FactoryBot.define do
   end
 
   trait :with_doi do
+    assign_doi { true }
     doi { "10.25740/hs561fr1234" }
   end
 

--- a/spec/jobs/assign_pid_job_spec.rb
+++ b/spec/jobs/assign_pid_job_spec.rb
@@ -58,8 +58,13 @@ RSpec.describe AssignPidJob do
           contains: []
         })
     end
-    let(:work) { create(:work_version_with_work, :reserving_purl, collection:).work }
+    let(:work_version) { create(:work_version, :reserving_purl, work: work) }
+    let(:work) { create(:work, collection: collection, assign_doi: true) }
     let(:collection) { create(:collection_version_with_collection).collection }
+
+    before do
+      work.update(head: work_version)
+    end
 
     it "updates the druid" do
       described_class.new.work(message)

--- a/spec/services/check_move_work_service_spec.rb
+++ b/spec/services/check_move_work_service_spec.rb
@@ -62,16 +62,16 @@ RSpec.describe CheckMoveWorkService do
     end
   end
 
-  context "when DOI is required but work does not have a DOI" do
-    let(:work) { build(:work) }
+  context "when DOI is required but work is not assigned DOI" do
+    let(:work) { build(:work, assign_doi: false) }
 
     it "returns an error" do
       expect(errors).to eq ["Depositor of the item chose not to get a DOI but the collection requires DOI assignment."]
     end
   end
 
-  context "when DOI is not required and work does not have a DOI" do
-    let(:work) { build(:work) }
+  context "when DOI is not required and work is not assigned a DOI" do
+    let(:work) { build(:work, assign_doi: false) }
 
     before do
       collection.doi_option = "depositor-selects"

--- a/spec/services/work_version_event_description_builder_spec.rb
+++ b/spec/services/work_version_event_description_builder_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe WorkVersionEventDescriptionBuilder do
 
   let(:collection) { build(:collection, :depositor_selects_access, :depositor_selects_release_date) }
   let(:work_version) do
-    create(:work_version_with_work, :with_no_subtype, collection:, attached_files:, state:, version: 1)
+    create(:work_version, :with_no_subtype, :with_keywords, attached_files:, state:, version: 1, work: work)
   end
-  let(:work) { work_version.work }
+  let(:work) { build(:work, assign_doi: true, collection: collection) }
   let(:form) { DraftWorkForm.new(work_version:, work:) }
   let(:attached_files) { [] }
   let(:filename) { "xml.svg" }


### PR DESCRIPTION
closes #3253

# Why was this change made? 🤔
So that the collection for a work can be changed prior to a deposit when a DOI is required.


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



