### PR TITLE
add unique labels to remove buttons for contributors and keywords

### DIFF
--- a/app/components/works/contributor_row_component.rb
+++ b/app/components/works/contributor_row_component.rb
@@ -66,11 +66,19 @@ module Works
       form.object.class.method_defined?(:model) ? form.object.model : form.object
     end
 
+    def contributor_remove_label
+      "Remove #{contributor_name.empty? ? "blank contributor" : contributor_name}"
+    end
+
+    def contributor_name
+      "#{form.object.first_name} #{form.object.last_name}".strip
+    end
+
     def html_options_for_delete
       {
         type: "button",
         class: "btn btn-sm",
-        aria: {label: "Remove"},
+        aria: {label: contributor_remove_label},
         data: {}.tap do |data|
           actions = ["contributors#remove #{form_controller}#removeAssociation"]
           actions << "auto-citation#updateDisplay" if author?

--- a/app/components/works/contributor_row_component.rb
+++ b/app/components/works/contributor_row_component.rb
@@ -67,11 +67,11 @@ module Works
     end
 
     def contributor_remove_label
-      "Remove #{contributor_name.empty? ? "blank contributor" : contributor_name}"
+      "Remove #{contributor_name.blank? ? "blank #{model.class.name.downcase}" : contributor_name}"
     end
 
     def contributor_name
-      "#{form.object.first_name} #{form.object.last_name}".strip
+      model.full_name.blank? ? "#{model.first_name} #{model.last_name}".strip : model.full_name
     end
 
     def html_options_for_delete

--- a/app/components/works/keywords_row_component.html.erb
+++ b/app/components/works/keywords_row_component.html.erb
@@ -15,7 +15,7 @@
     </div>
   </div>
   <div class="col-sm-1">
-    <%= button_tag type: "button", class: "btn btn-sm", aria: {label: "Remove"},
+    <%= button_tag type: "button", class: "btn btn-sm", aria: {label: keyword_remove_label},
           data: {action: "click->nested-form#removeAssociation"} do %>
       <span class="fa-regular fa-trash-alt"></span>
     <% end %>

--- a/app/components/works/keywords_row_component.rb
+++ b/app/components/works/keywords_row_component.rb
@@ -9,6 +9,10 @@ module Works
 
     attr_reader :form
 
+    def keyword_remove_label
+      "Remove #{form.object.label || "blank keyword"}"
+    end
+
     def error?
       errors.present?
     end

--- a/spec/components/works/contributor_row_component_spec.rb
+++ b/spec/components/works/contributor_row_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Works::ContributorRowComponent do
     expect(rendered.css('button[aria-label="Move up"]')).to be_present
     expect(rendered.css('button[aria-label="Move down"]')).to be_present
     expect(rendered.css('input[name*="_destroy"]')).to be_present
-    expect(rendered.css('button[aria-label="Remove"]')).to be_present
+    expect(rendered.css('button[aria-label="Remove First1 Last1"]')).to be_present
   end
 
   context "when an author" do

--- a/spec/components/works/contributor_row_component_spec.rb
+++ b/spec/components/works/contributor_row_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Works::ContributorRowComponent do
     expect(rendered.css('button[aria-label="Move up"]')).to be_present
     expect(rendered.css('button[aria-label="Move down"]')).to be_present
     expect(rendered.css('input[name*="_destroy"]')).to be_present
-    expect(rendered.css('button[aria-label="Remove First1 Last1"]')).to be_present
+    expect(rendered.css("button[aria-label=\"Remove #{author.first_name} #{author.last_name}\"]")).to be_present
   end
 
   context "when an author" do


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3181 - make two generic delete button aira-labels (keywords and contributors) unique so users can tell what they are deleting.  The other trash can aria-labels all seem to be labelled appropriately as far as I can tell by searching through code.

For authors/contributors, aria-label for trash can will be:
- "Remove blank author" or "Remove blank contributor" for new rows (even if text added)
- "Remove [actual name]" if an existing row that was previously saved

For keywords, aria-label for trash can will be:
- "Remove blank keyword" for new rows (even if text added)
- "Remove [actual keyword]" if an existing row that was previously saved

# How was this change tested? 🤨

Localhost and CI
