### PR TITLE
Update logic so that auto generated citation is properly enabled when editing

### DIFF
--- a/app/javascript/controllers/auto_citation_controller.js
+++ b/app/javascript/controllers/auto_citation_controller.js
@@ -1,18 +1,21 @@
 import { Controller } from "@hotwired/stimulus";
 
+const PURL_PLACE_HOLDER = ":link will be inserted here automatically when available:"
+const DOI_PLACE_HOLDER = ":DOI will be inserted here automatically when available:"
+
 export default class extends Controller {
   static targets = ["titleField", "manual", "auto", "switch",
     "contributorFirst", "contributorLast", "contributorRole", "contributorOrg",
     "embargoYear", "embargo"];
 
   connect() {
-    this.purl = this.data.get("purl") || ":link will be inserted here automatically when available:" // Use a real purl on a persisted item or a placeholder
+    this.purl = this.data.get("purl") || PURL_PLACE_HOLDER // Use a real purl on a persisted item or a placeholder
     this.doi = this.data.get("doi") || ""
 
     this.updateDisplay()
 
-    // If the manualTarget matches the autoTarget or is blank, then display the auto.
-    const showAuto = this.manualTarget.value === '' || this.manualTarget.value === this.autoTarget.value
+    // If the manualTarget is blank or the autoTarget matches the citation, then display the auto.
+    const showAuto = this.enableAutoCitation()
     this.switchTarget.checked = showAuto
     this.displayDefault(showAuto)
   }
@@ -20,6 +23,19 @@ export default class extends Controller {
   // Populate the text area with the auto generated citation
   updateDisplay() {
     this.autoTarget.value = this.citation
+  }
+
+  enableAutoCitation() {
+    if (this.manualTarget.value === '') { // The initial value
+      return true
+    } else {
+      const manualValue = this.manualTarget.value.replace(PURL_PLACE_HOLDER, this.purl).replace(DOI_PLACE_HOLDER, this.doi)
+      if (manualValue === this.autoTarget.value) {
+        return true
+      }
+    }
+
+    return false
   }
 
   get citation() {


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3277 

This enables and disables the manual citation switch when editing items based on the citation value.

In the first 2 screenshots, you can see that I'm using the manual citation as the title in the citation is different than the title in the work. This disables the "auto" citation so that the manual edit is not lost.

![Screenshot 2023-07-19 at 4 34 29 PM](https://github.com/sul-dlss/happy-heron/assets/2294288/ad5540e8-46df-4479-acd1-7e1d045ec55e)
![Screenshot 2023-07-19 at 4 36 02 PM](https://github.com/sul-dlss/happy-heron/assets/2294288/7d335553-eced-4fd4-818f-be1b492c6f18)

When the citation matches the auto generated citation the switch is enabled properly:

![Screenshot 2023-07-19 at 4 37 46 PM](https://github.com/sul-dlss/happy-heron/assets/2294288/83491b8b-ecde-4580-9b36-f74337a35b8a)

# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



