### PR TITLE
Update globus upload text for clarity on file count/size

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -72,8 +72,10 @@
   <div class="form-check pt-3" data-complex-radio-target="selection">
     <%= form.radio_button :upload_type, "globus", class: "form-check-input", "data-file-uploads-target": "globusRadioButton", "data-deposit-button-target": "globusRadioButton",
           data: {action: "complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus"} %>
-    <%= form.label :upload_type_globus, "Upload one or more files (more than 10GB) which will be displayed as uploaded, including any file hierarchy.", class: "form-check-label fw-semibold" %>
+    <%= form.label :upload_type_globus, "Upload one or more files via Globus (fewer than 25,000 files and less than 4TB total) which will be displayed as uploaded, including any file hierarchy.", class: "form-check-label fw-semibold" %>
+
     <div data-file-uploads-target="globusUpload">
+      <p>Please notify us at <a href="mailto:sdr-contact@lists.stanford.edu">sdr-contact@lists.stanford.edu</a> if you are uploading 1TB or more of content.</p>
       <div class="container py-4">
         <div class="row g-3">
           <div class="col">


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3268 

![Screenshot 2023-07-20 at 11 01 19 AM](https://github.com/sul-dlss/happy-heron/assets/2294288/76c9b348-00ee-4219-95c6-2f3f6f068384)


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

I ran the site improve plug in against this change. There is a suggestion of an additional visual indicator (i.e. an icon) to improve the visibility of the link, but this is a minor change.

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



