### PR TITLE
Update zip upload text to include warning

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -41,9 +41,10 @@
   <div class="form-check pt-3" data-complex-radio-target="selection">
     <%= form.radio_button :upload_type, "zipfile", class: "form-check-input",
           data: {action: "complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus", file_uploads_target: "zipRadioButton"} %>
-    <%= form.label :upload_type_zipfile, "Upload a single zip file (less than 10GB) which will be unzipped, including any file hierarchy.", class: "form-check-label fw-semibold" %>
+    <%= form.label :upload_type_zipfile, "Upload a single zip file (containing fewer than 25,000 files and less than 10GB total), which will be unzipped, including any hierarchy.", class: "form-check-label fw-semibold" %>
     <div id="zip-files-panel" data-file-uploads-target="zipUpload">
       <p>Viewers will see the file hierarchy and be able to download individual files. Unzipping may take several minutes if your zip file contains a large number of individual files.</p>
+      <p><strong>Warning:</strong> this file upload option will automatically replace all existing files on your item with the content in the new zip file.</p>
       <div data-controller="dropzone" data-dropzone-max-file-size="10000" data-dropzone-max-files="1"
            data-dropzone-accepted-files=".zip" data-dropzone-clickable=".dz-zip-clickable"
            data-dropzone-previews-container=".dropzone-zip-previews">


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3267 

![Screenshot 2023-07-20 at 2 08 37 PM](https://github.com/sul-dlss/happy-heron/assets/2294288/e8f90edd-b782-4c88-b931-c0f4849abd7c)



# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

No related warnings when running the siteimprove plugin.

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



