### PR TITLE
purl links should go to purl

### DIFF
--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -33,7 +33,7 @@
         <td>
           <% if purl %>
             <%= link_to purl, purl %>
-            <a class="copy-button" data-controller="copy" data-copy-clip-value="<%= purl %>" data-action="copy#copy" aria-label="Copy persistent link" href=""><span class="fa-solid fa-copy"></span></a>
+            <a class="copy-button" data-controller="copy" data-copy-clip-value="<%= purl %>" data-action="copy#copy" aria-label="Copy persistent link" href="<%= purl %>"><span class="fa-solid fa-copy"></span></a>
           <% else %>
             <em>Link will become available once the work has been deposited.</em>
           <% end %>

--- a/app/views/dashboards/_collection_summary_row.html.erb
+++ b/app/views/dashboards/_collection_summary_row.html.erb
@@ -10,7 +10,7 @@
   <td>
     <% if work.purl %>
       <%= link_to work.purl, work.purl %>
-      <a class="copy-button" data-controller="copy" data-copy-clip-value="<%= work.purl %>" data-action="copy#copy" aria-label="Copy persistent link to <%= WorkTitlePresenter.show(work.head) %>" href=""><span class="fa-solid fa-copy"></span></a>
+      <a class="copy-button" data-controller="copy" data-copy-clip-value="<%= work.purl %>" data-action="copy#copy" aria-label="Copy persistent link to <%= WorkTitlePresenter.show(work.head) %>" href="<%= work.purl %>"><span class="fa-solid fa-copy"></span></a>
     <% end %>
   </td>
   <td><%= render CitationComponent.new(work_version: work.head) %></td>


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3284 - opening the PURL link with a right-click should go to PURL.  I verified in Firefox that left click still does the copy as expected.

# How was this change tested? 🤨

Localhost