### PR TITLE
ensure move/up down button targets only contributor row elements

### DIFF
--- a/app/javascript/controllers/ordered_nested_form_controller.js
+++ b/app/javascript/controllers/ordered_nested_form_controller.js
@@ -33,7 +33,7 @@ export default class extends NestedFormController {
 
   moveUp(event) {
     const item = this.getItemForButton(event.target)
-    const previous = item.previousElementSibling
+    const previous = this.getPreviousSibling(item, 'div.contributor-row')
     previous.remove()
     item.insertAdjacentElement('afterend', previous)
     this.renumber()
@@ -41,7 +41,7 @@ export default class extends NestedFormController {
 
   moveDown(event) {
     const item = this.getItemForButton(event.target)
-    const next = item.nextElementSibling
+    const next = this.getNextSibling(item, 'div.contributor-row')
     next.remove()
     item.insertAdjacentElement('beforebegin', next)
     this.renumber()
@@ -61,4 +61,39 @@ export default class extends NestedFormController {
     const allRows = this.element.querySelectorAll(this.selectorValue)
     return Array.from(allRows).filter((item) => item.querySelector("input[name*='_destroy']").value != "1")
   }
+
+  // These methods help us find the next or previous element that also match a given selector.
+  // This allows us to better target a specific element of interest.
+  getNextSibling(elem, selector) {
+    // Get the next sibling element
+    // this is native JS: https://developer.mozilla.org/en-US/docs/Web/API/Element/nextElementSibling
+    var sibling = elem.nextElementSibling
+
+    // If there's no selector, return the sibling
+    if (!selector) return sibling
+
+    // If the sibling matches our selector, use it
+    // If not, jump to the next sibling and continue the loop
+    while (sibling) {
+      if (sibling.matches(selector)) return sibling
+      sibling = sibling.nextElementSibling
+    }
+  }
+
+  getPreviousSibling(elem, selector) {
+    // Get the previous sibling element
+    // this is native JS: https://developer.mozilla.org/en-US/docs/Web/API/Element/previousElementSibling
+    var sibling = elem.previousElementSibling
+
+    // If there's no selector, return the sibling
+    if (!selector) return sibling
+
+    // If the sibling matches our selector, use it
+    // If not, jump to the previous sibling and continue the loop
+    while (sibling) {
+      if (sibling.matches(selector)) return sibling
+      sibling = sibling.previousElementSibling
+    }
+  }
+
 }


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3306 

Moving authors up and down on the item work page with the arrows (next to the trash icon) sometimes doesn't work as expected, particularly after adding a brand new blank author.  I believe the issue is that the use of `nextElementSibling` and `previousElementSibling` to find the `<div>` row to move up and down doesn't always work as expected.  If you insepct the HTML of the page after adding a new author, you will see some hidden form elements like this:

`<input autocomplete="off" type="hidden" value="10" name="work[authors_attributes][0][id]" id="work_authors_attributes_0_id">`

These are inserted into the DOM technically as siblings to the `<div>` rows we care about, and so the JS methods find them instead of the divs.  You can see this happening by addling `console.log` statements to inspect the elements found when using the up and down arrows.  Pressing the up and down arrows repeatedly will eventually work after cycling through all of the hidden fields being selected.

The fix is to better target the previous/next siblings by also adding a selector.  This requires custom JS methods, added here.


# How was this change tested? 🤨

Localhost

# Does your change introduce accessibility violations? 🩺

No