### PR TITLE
Change globus endpoint permissions on deposit

### DIFF
--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -256,4 +256,8 @@ FactoryBot.define do
     globus_endpoint { "userid/workid/version1" }
     deposited
   end
+
+  trait :with_globus_endpoint_draft do
+    globus_endpoint { "userid/workid/version1" }
+  end
 end


### PR DESCRIPTION
# Why was this change made? 🤔

Resolves #3302 to change globus permissions to "r" when depositing starts. 

# How was this change tested? 🤨
Unit and stage deploy. Also ran globus integration test. 

If a user tries to rename or edit a file on the globus endpoint once the deposit job starts, they'll get a permission denied message. 

![Screenshot 2023-07-26 at 4 08 46 PM](https://github.com/sul-dlss/happy-heron/assets/1619369/ffcec590-4cb6-44c1-b297-42f9afabe31f)


![Screenshot 2023-07-26 at 4 07 50 PM](https://github.com/sul-dlss/happy-heron/assets/1619369/e613edcb-427f-46a3-b4cf-60a4468b82eb)

# Does your change introduce accessibility violations? 🩺
Does not touch front-end. 





