### PR TITLE
Adds custom rights entry to the work and work display

### DIFF
--- a/app/components/popover_component.rb
+++ b/app/components/popover_component.rb
@@ -7,16 +7,17 @@
 #  <legend aria-describedby="popover-collection.depositors">Depositors</legend>
 #  <%= render PopoverComponent.new key: "collection.depositors" %>
 class PopoverComponent < ApplicationComponent
-  def initialize(key:, icon: "fa-solid fa-info-circle", scope: "tooltip")
+  def initialize(key:, icon: "fa-solid fa-info-circle", scope: "tooltip", custom_content: nil)
     @key = key
     @icon = icon
     @scope = scope
+    @custom_content = custom_content
   end
 
   attr_reader :icon, :scope, :key
 
   def text
-    t(@key, scope:)
+    @custom_content || t(@key, scope:)
   end
 
   def render?

--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -208,6 +208,10 @@
       <th class="col-3" scope="row">Terms of use</th>
       <td><%= Settings.access.use_and_reproduction_statement %></td>
     </tr>
+    <tr>
+      <th class="col-3" scope="row">Additional terms of use</th>
+      <td><%= rights %></td>
+    </tr>
     </tbody>
   </table>
 

--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -210,7 +210,7 @@
     </tr>
     <tr>
       <th class="col-3" scope="row">Additional terms of use</th>
-      <td><%= rights %></td>
+      <td><%= custom_rights %></td>
     </tr>
     </tbody>
   </table>

--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -13,9 +13,9 @@ module Works
 
     delegate :doi_option, to: :collection, prefix: true
 
-    delegate :work_type, :contact_emails, :abstract, :citation, :first_draft?,
-      :attached_files, :related_works, :related_links, :contributors, :authors,
-      :created_edtf, :published_edtf, :rejected?, :rights, :work, :version_description, to: :work_version
+    delegate :abstract, :attached_files, :authors, :citation, :contact_emails, :contributors,
+      :created_edtf, :custom_rights, :first_draft?, :published_edtf, :rejected?, :related_links,
+      :related_works, :version_description, :work, :work_type, to: :work_version
 
     def version
       return "1 - initial version" if first_draft?

--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -15,7 +15,7 @@ module Works
 
     delegate :work_type, :contact_emails, :abstract, :citation, :first_draft?,
       :attached_files, :related_works, :related_links, :contributors, :authors,
-      :created_edtf, :published_edtf, :rejected?, :work, :version_description, to: :work_version
+      :created_edtf, :published_edtf, :rejected?, :rights, :work, :version_description, to: :work_version
 
     def version
       return "1 - initial version" if first_draft?

--- a/app/components/works/license_component.html.erb
+++ b/app/components/works/license_component.html.erb
@@ -43,7 +43,7 @@
       <div class="col-sm-8">
         <% if collection.provided_custom_rights_statement %>
           <p><%= collection.provided_custom_rights_statement %></p>
-          <%= form.hidden_field :rights, value: "#{collection.provided_custom_rights_statement}" %>
+          <%= form.hidden_field :rights, value: collection.provided_custom_rights_statement %>
         <% else %>
           <%= form.text_area :rights, class: "form-control",
                 data: {action: "no-newlines#change", no_newlines_target: "input", controller: "no-newlines"} %>

--- a/app/components/works/license_component.html.erb
+++ b/app/components/works/license_component.html.erb
@@ -34,7 +34,7 @@
     <div class="row">
       <div class="col-sm-2">
         <%= form.label :custom_rights, "Additional terms of use", class: "col-form-label" %>
-        <%= render PopoverComponent.new key: "work.custom_rights" %>
+        <%= render PopoverComponent.new key: "work.custom_rights", custom_content: collection.custom_rights_statement_custom_instructions %>
       </div>
       <div class="col-sm-8">Enter additional terms of use not covered by your chosen license or the default terms shown above, which also display on th PURL page.</div>
     </div>

--- a/app/components/works/license_component.html.erb
+++ b/app/components/works/license_component.html.erb
@@ -31,14 +31,17 @@
 
   <hr>
   <div class="row">
-    <div class="col-sm-2"><strong>Additional terms of use</strong></div>
+    <div class="col-sm-2">
+      <%= form.label :rights, "Additional terms of use", class: "col-form-label" %>
+      <%= render PopoverComponent.new key: "work.rights" %>
+    </div>
     <div class="col-sm-8">Enter additional terms of use not covered by your chosen license or the default terms shown above, which also display on th PURL page.</div>
   </div>
   <div class="row">
     <div class="col-sm-2"></div>
     <div class="col-sm-8">
-      <%= form.input :rights,
-            class: "form-textarea" %>
+      <%= form.text_area :rights, class: "form-control",
+            data: {action: "no-newlines#change", no_newlines_target: "input", controller: "no-newlines"} %>
     </div>
   </div>
 

--- a/app/components/works/license_component.html.erb
+++ b/app/components/works/license_component.html.erb
@@ -1,5 +1,5 @@
 <section id="license">
-  <header>Select a license *</header>
+  <header>License *</header>
   <% if user_can_set_license? %>
     <div class="mb-3 row">
       <div class="col-sm-2">
@@ -28,4 +28,18 @@
   <p style="font-style: italic; margin-left: 2.5rem;">
     <%= Settings.access.use_and_reproduction_statement %>
   </p>
+
+  <hr>
+  <div class="row">
+    <div class="col-sm-2"><strong>Additional terms of use</strong></div>
+    <div class="col-sm-8">Enter additional terms of use not covered by your chosen license or the default terms shown above, which also display on th PURL page.</div>
+  </div>
+  <div class="row">
+    <div class="col-sm-2"></div>
+    <div class="col-sm-8">
+      <%= form.input :rights,
+            class: "form-textarea" %>
+    </div>
+  </div>
+
 </section>

--- a/app/components/works/license_component.html.erb
+++ b/app/components/works/license_component.html.erb
@@ -33,8 +33,8 @@
     <hr>
     <div class="row">
       <div class="col-sm-2">
-        <%= form.label :rights, "Additional terms of use", class: "col-form-label" %>
-        <%= render PopoverComponent.new key: "work.rights" %>
+        <%= form.label :custom_rights, "Additional terms of use", class: "col-form-label" %>
+        <%= render PopoverComponent.new key: "work.custom_rights" %>
       </div>
       <div class="col-sm-8">Enter additional terms of use not covered by your chosen license or the default terms shown above, which also display on th PURL page.</div>
     </div>
@@ -43,9 +43,9 @@
       <div class="col-sm-8">
         <% if collection.provided_custom_rights_statement %>
           <p><%= collection.provided_custom_rights_statement %></p>
-          <%= form.hidden_field :rights, value: collection.provided_custom_rights_statement %>
+          <%= form.hidden_field :custom_rights, value: collection.provided_custom_rights_statement %>
         <% else %>
-          <%= form.text_area :rights, class: "form-control",
+          <%= form.text_area :custom_rights, class: "form-control",
                 data: {action: "no-newlines#change", no_newlines_target: "input", controller: "no-newlines"} %>
         <% end %>
       </div>

--- a/app/components/works/license_component.html.erb
+++ b/app/components/works/license_component.html.erb
@@ -29,20 +29,27 @@
     <%= Settings.access.use_and_reproduction_statement %>
   </p>
 
-  <hr>
-  <div class="row">
-    <div class="col-sm-2">
-      <%= form.label :rights, "Additional terms of use", class: "col-form-label" %>
-      <%= render PopoverComponent.new key: "work.rights" %>
+  <% if collection.allow_custom_rights_statement? %>
+    <hr>
+    <div class="row">
+      <div class="col-sm-2">
+        <%= form.label :rights, "Additional terms of use", class: "col-form-label" %>
+        <%= render PopoverComponent.new key: "work.rights" %>
+      </div>
+      <div class="col-sm-8">Enter additional terms of use not covered by your chosen license or the default terms shown above, which also display on th PURL page.</div>
     </div>
-    <div class="col-sm-8">Enter additional terms of use not covered by your chosen license or the default terms shown above, which also display on th PURL page.</div>
-  </div>
-  <div class="row">
-    <div class="col-sm-2"></div>
-    <div class="col-sm-8">
-      <%= form.text_area :rights, class: "form-control",
-            data: {action: "no-newlines#change", no_newlines_target: "input", controller: "no-newlines"} %>
+    <div class="row">
+      <div class="col-sm-2"></div>
+      <div class="col-sm-8">
+        <% if collection.provided_custom_rights_statement %>
+          <p><%= collection.provided_custom_rights_statement %></p>
+          <%= form.hidden_field :rights, value: "#{collection.provided_custom_rights_statement}" %>
+        <% else %>
+          <%= form.text_area :rights, class: "form-control",
+                data: {action: "no-newlines#change", no_newlines_target: "input", controller: "no-newlines"} %>
+        <% end %>
+      </div>
     </div>
-  </div>
+  <% end %>
 
 </section>

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -247,7 +247,7 @@ class WorksController < ObjectsController
         "created_range(4i)", "created_range(5i)", "created_range(6i)",
         "created_range(approx3)",
         :abstract, :citation_auto, :citation, :default_citation,
-        :access, :license, :version_description,
+        :access, :license, :rights, :version_description,
         :release, "embargo_date(1i)", "embargo_date(2i)", "embargo_date(3i)",
         :agree_to_terms, :assign_doi, :upload_type, :globus, :fetch_globus_files,
         :globus_origin, subtype: [], files: [],

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -247,7 +247,7 @@ class WorksController < ObjectsController
         "created_range(4i)", "created_range(5i)", "created_range(6i)",
         "created_range(approx3)",
         :abstract, :citation_auto, :citation, :default_citation,
-        :access, :license, :rights, :version_description,
+        :access, :license, :custom_rights, :version_description,
         :release, "embargo_date(1i)", "embargo_date(2i)", "embargo_date(3i)",
         :agree_to_terms, :assign_doi, :upload_type, :globus, :fetch_globus_files,
         :globus_origin, subtype: [], files: [],

--- a/app/forms/base_work_form.rb
+++ b/app/forms/base_work_form.rb
@@ -21,7 +21,7 @@ class BaseWorkForm < Reform::Form
   property :collection_id, on: :work
   property :access, on: :work_version
   property :license, on: :work_version
-  property :rights, on: :work_version
+  property :custom_rights, on: :work_version
   property :agree_to_terms, on: :work_version
   property :created_type, virtual: true, prepopulator: (proc do |*|
     self.created_type = created_edtf.is_a?(EDTF::Interval) ? "range" : "single" unless created_type

--- a/app/forms/base_work_form.rb
+++ b/app/forms/base_work_form.rb
@@ -21,6 +21,7 @@ class BaseWorkForm < Reform::Form
   property :collection_id, on: :work
   property :access, on: :work_version
   property :license, on: :work_version
+  property :rights, on: :work_version
   property :agree_to_terms, on: :work_version
   property :created_type, virtual: true, prepopulator: (proc do |*|
     self.created_type = created_edtf.is_a?(EDTF::Interval) ? "range" : "single" unless created_type

--- a/app/services/cocina_generator/access_generator.rb
+++ b/app/services/cocina_generator/access_generator.rb
@@ -44,7 +44,7 @@ module CocinaGenerator
     end
 
     def rights_statement
-      [work_version.rights, Settings.access.use_and_reproduction_statement].compact.join(". ")
+      [work_version.custom_rights, Settings.access.use_and_reproduction_statement].compact.join(". ")
     end
   end
 end

--- a/app/services/cocina_generator/access_generator.rb
+++ b/app/services/cocina_generator/access_generator.rb
@@ -44,7 +44,7 @@ module CocinaGenerator
     end
 
     def rights_statement
-      [work_version.rights, Settings.access.use_and_reproduction_statement].compact.join(". ") 
+      [work_version.rights, Settings.access.use_and_reproduction_statement].compact.join(". ")
     end
   end
 end

--- a/app/services/cocina_generator/access_generator.rb
+++ b/app/services/cocina_generator/access_generator.rb
@@ -39,8 +39,12 @@ module CocinaGenerator
     def base_access
       {
         license: License.find(work_version.license).uri.presence,
-        useAndReproductionStatement: Settings.access.use_and_reproduction_statement
+        useAndReproductionStatement: rights_statement
       }.compact
+    end
+
+    def rights_statement
+      [work_version.rights, Settings.access.use_and_reproduction_statement].compact.join(". ") 
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,6 +138,7 @@ en:
       related_link: This section allows you to provide links to other web pages that are related to your deposit. These links will display on the persistent URL (PURL) page for your deposit and on the Stanford Libraries' catalog record. Enter the text to be displayed on the page in the "Link text" box. This entire text will be hyperlinked to the URL you enter in the "URL" box. Examples of content you might consider linking to are lab, institute, or project pages; GitHub repositories for the current version of software code; or funder websites.
       license: A license helps others who access your content to understand what you are allowing them to do with your work and under what conditions.  Click on "Get help selecting a license" for assistance with the license options presented here.
       locked: This deposit can no longer be edited in this application. If you need to make changes to this deposit, please use the Help link at the top of this page to contact us.
+      rights: For open access articles, use this section for required publisher's statement. For other deposits, use this section to describe other terms of use not covered by the license you select below. This section does not constitute a formal Data Use Agreement.
   hints:
     collection:
       review_enabled: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,7 +138,7 @@ en:
       related_link: This section allows you to provide links to other web pages that are related to your deposit. These links will display on the persistent URL (PURL) page for your deposit and on the Stanford Libraries' catalog record. Enter the text to be displayed on the page in the "Link text" box. This entire text will be hyperlinked to the URL you enter in the "URL" box. Examples of content you might consider linking to are lab, institute, or project pages; GitHub repositories for the current version of software code; or funder websites.
       license: A license helps others who access your content to understand what you are allowing them to do with your work and under what conditions.  Click on "Get help selecting a license" for assistance with the license options presented here.
       locked: This deposit can no longer be edited in this application. If you need to make changes to this deposit, please use the Help link at the top of this page to contact us.
-      rights: For open access articles, use this section for required publisher's statement. For other deposits, use this section to describe other terms of use not covered by the license you select below. This section does not constitute a formal Data Use Agreement.
+      custom_rights: For open access articles, use this section for required publisher's statement. For other deposits, use this section to describe other terms of use not covered by the license you select below. This section does not constitute a formal Data Use Agreement.
   hints:
     collection:
       review_enabled: >

--- a/db/migrate/20230726172521_add_rights_to_work_version.rb
+++ b/db/migrate/20230726172521_add_rights_to_work_version.rb
@@ -1,0 +1,5 @@
+class AddRightsToWorkVersion < ActiveRecord::Migration[7.0]
+  def change
+    add_column :work_versions, :rights, :string
+  end
+end

--- a/db/migrate/20230726172521_add_rights_to_work_version.rb
+++ b/db/migrate/20230726172521_add_rights_to_work_version.rb
@@ -1,5 +1,5 @@
 class AddRightsToWorkVersion < ActiveRecord::Migration[7.0]
   def change
-    add_column :work_versions, :rights, :string
+    add_column :work_versions, :custom_rights, :string
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -664,7 +664,8 @@ CREATE TABLE public.work_versions (
     published_at timestamp(6) without time zone,
     upload_type character varying,
     globus_endpoint character varying,
-    globus_origin character varying
+    globus_origin character varying,
+    rights character varying
 );
 
 
@@ -1478,6 +1479,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230420204926'),
 ('20230627053607'),
 ('20230629154913'),
-('20230705222153');
+('20230705222153'),
+('20230726172521');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -665,7 +665,7 @@ CREATE TABLE public.work_versions (
     upload_type character varying,
     globus_endpoint character varying,
     globus_origin character varying,
-    rights character varying
+    custom_rights character varying
 );
 
 

--- a/spec/components/popover_component_spec.rb
+++ b/spec/components/popover_component_spec.rb
@@ -36,4 +36,12 @@ RSpec.describe PopoverComponent, type: :component do
       expect(rendered.to_html).to eq ""
     end
   end
+
+  context "when custom content is provided" do
+    let(:rendered) { render_inline(described_class.new(key: "work.creation_date", custom_content: "This is some custom content.")) }
+
+    it "renders the component" do
+      expect(rendered.css("a").first["data-bs-content"]).to eq "This is some custom content."
+    end
+  end
 end

--- a/spec/components/works/form_component_spec.rb
+++ b/spec/components/works/form_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Works::FormComponent do
     allow(controller).to receive(:allowed_to?).and_return(true)
   end
 
-  context 'when the collection does not allow a custom rights statement' do
+  context "when the collection does not allow a custom rights statement" do
     let(:collection) { build_stubbed(:collection, :depositor_selects_access, id: 7) }
 
     it "renders the component" do
@@ -31,10 +31,10 @@ RSpec.describe Works::FormComponent do
         .not_to include("What's changing?")
       expect(rendered.to_html)
         .not_to include("Additional terms of use")
-      end
+    end
   end
 
-  context 'when the collection allows a custom rights statement' do
+  context "when the collection allows a custom rights statement" do
     let(:collection) { build_stubbed(:collection, :depositor_selects_access, :with_custom_rights_from_depositor, id: 7) }
 
     it "renders the component" do
@@ -53,7 +53,7 @@ RSpec.describe Works::FormComponent do
     end
   end
 
-  context 'when the collection provides a custom rights statement' do
+  context "when the collection provides a custom rights statement" do
     let(:collection) { build_stubbed(:collection, :depositor_selects_access, :with_custom_rights_from_collection, id: 7) }
 
     it "renders the component" do

--- a/spec/components/works/form_component_spec.rb
+++ b/spec/components/works/form_component_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Works::FormComponent do
         "Enter dates related to your deposit",
         "Describe your deposit",
         "Settings for release date and download access",
-        "Select a license",
+        "License",
         "auto-citation unsaved-changes deposit-button")
     expect(rendered.to_html)
       .not_to include("What's changing?")

--- a/spec/components/works/form_component_spec.rb
+++ b/spec/components/works/form_component_spec.rb
@@ -5,7 +5,6 @@ require "rails_helper"
 RSpec.describe Works::FormComponent do
   let(:component) { described_class.new(work_form:) }
   let(:form) { ActionView::Helpers::FormBuilder.new(nil, work_form, controller.view_context, {}) }
-  let(:collection) { build_stubbed(:collection, :depositor_selects_access, id: 7) }
   let(:work) { build_stubbed(:work, collection:) }
   let(:work_version) { build_stubbed(:work_version, work:) }
   let(:work_form) { WorkForm.new(work_version:, work:) }
@@ -15,17 +14,62 @@ RSpec.describe Works::FormComponent do
     allow(controller).to receive(:allowed_to?).and_return(true)
   end
 
-  it "renders the component" do
-    expect(rendered.to_html)
-      .to include("Deposit", "Save as draft", "Add your files",
-        "Title of deposit and contact information",
-        "List authors and contributors",
-        "Enter dates related to your deposit",
-        "Describe your deposit",
-        "Settings for release date and download access",
-        "License",
-        "auto-citation unsaved-changes deposit-button")
-    expect(rendered.to_html)
-      .not_to include("What's changing?")
+  context 'when the collection does not allow a custom rights statement' do
+    let(:collection) { build_stubbed(:collection, :depositor_selects_access, id: 7) }
+
+    it "renders the component" do
+      expect(rendered.to_html)
+        .to include("Deposit", "Save as draft", "Add your files",
+          "Title of deposit and contact information",
+          "List authors and contributors",
+          "Enter dates related to your deposit",
+          "Describe your deposit",
+          "Settings for release date and download access",
+          "License",
+          "auto-citation unsaved-changes deposit-button")
+      expect(rendered.to_html)
+        .not_to include("What's changing?")
+      expect(rendered.to_html)
+        .not_to include("Additional terms of use")
+      end
+  end
+
+  context 'when the collection allows a custom rights statement' do
+    let(:collection) { build_stubbed(:collection, :depositor_selects_access, :with_custom_rights_from_depositor, id: 7) }
+
+    it "renders the component" do
+      expect(rendered.to_html)
+        .to include("Deposit", "Save as draft", "Add your files",
+          "Title of deposit and contact information",
+          "List authors and contributors",
+          "Enter dates related to your deposit",
+          "Describe your deposit",
+          "Settings for release date and download access",
+          "License",
+          "Additional terms of use",
+          "auto-citation unsaved-changes deposit-button")
+      expect(rendered.to_html)
+        .not_to include("What's changing?")
+    end
+  end
+
+  context 'when the collection provides a custom rights statement' do
+    let(:collection) { build_stubbed(:collection, :depositor_selects_access, :with_custom_rights_from_collection, id: 7) }
+
+    it "renders the component" do
+      expect(rendered.to_html)
+        .to include("Deposit", "Save as draft", "Add your files",
+          "Title of deposit and contact information",
+          "List authors and contributors",
+          "Enter dates related to your deposit",
+          "Describe your deposit",
+          "Settings for release date and download access",
+          "License",
+          "Additional terms of use",
+          "An addendum to the built in terms of use",
+          "auto-citation unsaved-changes deposit-button")
+      expect(rendered.to_html)
+        .not_to include("What's changing?")
+    end
   end
 end

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -258,6 +258,6 @@ FactoryBot.define do
   end
 
   trait :with_custom_rights_statement do
-    rights { "An addendum to the built in terms of use" }
+    custom_rights { "An addendum to the built in terms of use" }
   end
 end

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -256,4 +256,8 @@ FactoryBot.define do
     globus_endpoint { "userid/workid/version1" }
     deposited
   end
+
+  trait :with_custom_rights_statement do
+    rights { "An addendum to the built in terms of use" }
+  end
 end

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe "Create a new work" do
               :related_links_attributes => related_links,
               :default_citation => false,
               :license => "PDDL-1.0",
-              :rights => "An addendum to the built in terms of use",
+              :custom_rights => "An addendum to the built in terms of use",
               "published(1i)" => "2020", "published(2i)" => "2", "published(3i)" => "14",
               :created_type => "range",
               "created(1i)" => "2020", "created(2i)" => "2", "created(3i)" => "14",
@@ -232,7 +232,7 @@ RSpec.describe "Create a new work" do
           expect(work_version.related_links.size).to eq 2
           expect(work_version.citation).to eq "test citation"
           expect(work_version.license).to eq "PDDL-1.0"
-          expect(work_version.rights).to eq "An addendum to the built in terms of use"
+          expect(work_version.custom_rights).to eq "An addendum to the built in terms of use"
           expect(work_version.published_edtf.to_edtf).to eq "2020-02-14"
           expect(work_version.created_edtf.to_s).to eq "2020-03-04/2020-10-31"
           expect(work_version.embargo_date).to eq Date.parse("#{embargo_year}-04-04")

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Create a new work" do
 
       context "when a collection allows embargo and a license but restricts access and with all fields provided" do
         let(:collection) do
-          create(:collection, depositors: [user], release_option: "depositor-selects")
+          create(:collection, :with_custom_rights_from_collection, depositors: [user], release_option: "depositor-selects")
         end
 
         let(:authors) do
@@ -200,6 +200,7 @@ RSpec.describe "Create a new work" do
               :related_links_attributes => related_links,
               :default_citation => false,
               :license => "PDDL-1.0",
+              :rights => "An addendum to the built in terms of use",
               "published(1i)" => "2020", "published(2i)" => "2", "published(3i)" => "14",
               :created_type => "range",
               "created(1i)" => "2020", "created(2i)" => "2", "created(3i)" => "14",
@@ -231,6 +232,7 @@ RSpec.describe "Create a new work" do
           expect(work_version.related_links.size).to eq 2
           expect(work_version.citation).to eq "test citation"
           expect(work_version.license).to eq "PDDL-1.0"
+          expect(work_version.rights).to eq "An addendum to the built in terms of use"
           expect(work_version.published_edtf.to_edtf).to eq "2020-02-14"
           expect(work_version.created_edtf.to_s).to eq "2020-03-04/2020-10-31"
           expect(work_version.embargo_date).to eq Date.parse("#{embargo_year}-04-04")

--- a/spec/services/cocina_generator/access_generator_spec.rb
+++ b/spec/services/cocina_generator/access_generator_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe CocinaGenerator::AccessGenerator do
     end
   end
 
-  context "when access is world" do
+  context "when access is world and custom rights are provided" do
     let(:work_version) { build(:work_version, :with_custom_rights_statement) }
 
     it "generates the model" do

--- a/spec/services/cocina_generator/access_generator_spec.rb
+++ b/spec/services/cocina_generator/access_generator_spec.rb
@@ -63,4 +63,15 @@ RSpec.describe CocinaGenerator::AccessGenerator do
         useAndReproductionStatement: Settings.access.use_and_reproduction_statement)
     end
   end
+
+  context "when access is world" do
+    let(:work_version) { build(:work_version, :with_custom_rights_statement) }
+
+    it "generates the model" do
+      expect(model).to eq(view: "world",
+        download: "world",
+        license: license_uri,
+        useAndReproductionStatement: "An addendum to the built in terms of use. #{Settings.access.use_and_reproduction_statement}")
+    end
+  end
 end


### PR DESCRIPTION
# Why was this change made? 🤔

Closes #3094 as part of #3271

This adds the ability to add custom rights statement to a work, or use the one provided by the collection (if provided)

When provided in the collection:
![Screenshot 2023-07-26 at 3 36 56 PM](https://github.com/sul-dlss/happy-heron/assets/2294288/50dc3c7a-5b23-4311-affd-722928caf004)

It's displayed in the entry form for a work:
![Screenshot 2023-07-26 at 3 37 08 PM](https://github.com/sul-dlss/happy-heron/assets/2294288/39393656-9549-4a92-a619-85b7a003f65e)

When allowed and not provided, entry is allowed:
![Screenshot 2023-07-26 at 3 37 29 PM](https://github.com/sul-dlss/happy-heron/assets/2294288/9ca942b8-6583-4b2a-aab7-986940bf7ea4)

Displayed on the work page:
![Screenshot 2023-07-26 at 3 37 45 PM](https://github.com/sul-dlss/happy-heron/assets/2294288/d22e3f4d-c459-4d9d-91ed-e09df4927c95)

Note that any custom rights statement is pre-pended to the `useAndReproductionStatement` in cocina per https://stanfordlib.slack.com/archives/C69UZCJ8M/p1690408613716939?thread_ts=1690408431.344109&cid=C69UZCJ8M

Custom instructions are used for the tooltip if provided:
![Screenshot 2023-07-27 at 10 08 48 AM](https://github.com/sul-dlss/happy-heron/assets/2294288/61e51f9b-979e-4380-9aa2-17c6072fa0e5)


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



