### PR TITLE
Mixin Live for streaming

### DIFF
--- a/app/controllers/preservation_controller.rb
+++ b/app/controllers/preservation_controller.rb
@@ -2,6 +2,8 @@
 
 # Downloads files from preservation
 class PreservationController < ApplicationController
+  include ActionController::Live # required for streaming
+
   before_action :authenticate_user!
   verify_authorized
 
@@ -18,6 +20,11 @@ class PreservationController < ApplicationController
       disposition: "attachment",
       filename: CGI.escape(attached_file.filename.to_s)
     )
+
+    # Not setting Last-Modified seems to trigger some caching logic in
+    # passenger standalone that causes memory to bloat.
+    # https://github.com/sul-dlss/happy-heron/issues/3310
+    response.headers["Last-Modified"] = Time.now.utc.rfc2822
 
     attached_file.file.download do |chunk|
       response.stream.write chunk


### PR DESCRIPTION
# Why was this change made? 🤔

[ActionController::Live](https://api.rubyonrails.org/classes/ActionController/Live.html) is needed for streaming responses. It also looks like setting `Last-Modified` on the HTTP response is needed to prevent passenger in standalone mode from reading the response into memory during caching.

Fixes #3310

# How was this change tested? 🤨

Downloading a 4GB file on h2-stage, and not seeing the server go up in 🔥 The downloaded file completes and the checksum matches what is on preservation.

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

# Does your change introduce accessibility violations? 🩺

No