### PR TITLE
Do not show instructions when custom rights are provided

### DIFF
--- a/app/components/works/license_component.html.erb
+++ b/app/components/works/license_component.html.erb
@@ -34,9 +34,11 @@
     <div class="row">
       <div class="col-sm-2">
         <%= form.label :custom_rights, "Additional terms of use", class: "col-form-label" %>
-        <%= render PopoverComponent.new key: "work.custom_rights", custom_content: collection.custom_rights_statement_custom_instructions %>
+        <% unless collection.provided_custom_rights_statement %>
+          <%= render PopoverComponent.new key: "work.custom_rights", custom_content: collection.custom_rights_statement_custom_instructions %>
+        <% end %>
       </div>
-      <div class="col-sm-8">Enter additional terms of use not covered by your chosen license or the default terms shown above, which also display on th PURL page.</div>
+      <div class="col-sm-8">Enter additional terms of use not covered by your chosen license or the default terms shown above, which also display on the PURL page.</div>
     </div>
     <div class="row">
       <div class="col-sm-2"></div>


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3316 

The instructions are not displayed if a custom rights statement is provided.

![Screenshot 2023-07-28 at 12 25 51 PM](https://github.com/sul-dlss/happy-heron/assets/2294288/bf1e40f5-b229-4c7d-aea9-0940ef018b6c)


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



