### PR TITLE
Fix collection show custom rights instructions

### DIFF
--- a/app/components/collections/edit_terms_of_use_component.html.erb
+++ b/app/components/collections/edit_terms_of_use_component.html.erb
@@ -59,7 +59,7 @@
                   <%= form.radio_button :custom_rights_instructions_source_option, "default_instructions", checked: (custom_rights_instructions_source_option == "default_instructions"), class: "form-check-input" %>
                   <%= form.label :custom_rights_instructions_source_option_default_instructions, "Yes, display the following instructions", class: "form-check-label" %>
                   <p class="terms-of-use">
-                    <%= Settings.access.default_instructions_for_custom_use_statement %>
+                    <%= t("collection.depositor_custom_rights_instructions") %>
                   </p>
                 </div>
                 <div class="form-check<%= " is-invalid" if error? %>">

--- a/app/components/collections/terms_of_use_component.html.erb
+++ b/app/components/collections/terms_of_use_component.html.erb
@@ -11,6 +11,16 @@
       <th class="col-3">Terms of use</th>
       <td><%= I18n.t(:terms_of_use) %></td>
     </tr>
+    <tr>
+      <th class="col-3">Additional terms of use</th>
+      <td><%= collection_custom_rights_summary %></td>
+    </tr>
+    <% if allow_custom_rights_statement? && custom_rights_statement_source_option == "entered_by_depositor" %>
+      <tr>
+        <th class="col-3">Instructions</th>
+        <td><%= effective_custom_rights_instructions %></td>
+      </tr>
+    <% end %>
     <% if user_can_set_license? %>
       <tr>
         <th class="col-3">Default license (depositor selects)</th>
@@ -22,9 +32,5 @@
         <td><%= required_license %></td>
       </tr>
     <% end %>
-    <tr>
-      <th class="col-3">Additional terms of use</th>
-      <td><%= collection_custom_rights_summary %></td>
-    </tr>
   </tbody>
 </table>

--- a/app/components/collections/terms_of_use_component.rb
+++ b/app/components/collections/terms_of_use_component.rb
@@ -14,12 +14,12 @@ module Collections
       :required_license, :user_can_set_license?, to: :collection
 
     def collection_custom_rights_summary
-      return "Additional terms of use are disabled for this collection" unless allow_custom_rights_statement?
+      return "No" unless allow_custom_rights_statement?
 
       if custom_rights_statement_source_option == "provided_by_collection"
-        "\"#{provided_custom_rights_statement}\""
+        provided_custom_rights_statement
       else
-        "The depositor is allowed to enter their own terms. They will be presented with the following instructions: \"#{effective_custom_rights_instructions}\""
+        "Allow user to enter"
       end
     end
   end

--- a/app/components/popover_component.rb
+++ b/app/components/popover_component.rb
@@ -14,13 +14,13 @@ class PopoverComponent < ApplicationComponent
     @custom_content = custom_content
   end
 
-  attr_reader :icon, :scope, :key
+  attr_reader :custom_content, :icon, :scope, :key
 
   def text
-    @custom_content || t(@key, scope:)
+    custom_content || t(key, scope:)
   end
 
   def render?
-    I18n.exists?("#{scope}.#{@key}")
+    I18n.exists?("#{scope}.#{key}")
   end
 end

--- a/app/components/works/license_component.html.erb
+++ b/app/components/works/license_component.html.erb
@@ -34,11 +34,13 @@
     <div class="row">
       <div class="col-sm-2">
         <%= form.label :custom_rights, "Additional terms of use", class: "col-form-label" %>
-        <% unless collection.provided_custom_rights_statement %>
-          <%= render PopoverComponent.new key: "work.custom_rights", custom_content: collection.custom_rights_statement_custom_instructions %>
+        <% if custom_rights_statement_source_option == "entered_by_depositor" %>
+          <%= render PopoverComponent.new key: "work.custom_rights_from_depositor" %>
         <% end %>
       </div>
-      <div class="col-sm-8">Enter additional terms of use not covered by your chosen license or the default terms shown above, which also display on the PURL page.</div>
+      <% if custom_rights_statement_source_option == "entered_by_depositor" %>
+        <div class="col-sm-8"><%= effective_custom_rights_instructions %></div>
+      <% end %>
     </div>
     <div class="row">
       <div class="col-sm-2"></div>

--- a/app/components/works/license_component.rb
+++ b/app/components/works/license_component.rb
@@ -21,7 +21,7 @@ module Works
       reform.model.fetch(:work_version).license || collection.default_license
     end
 
-    delegate :user_can_set_license?, to: :collection
+    delegate :custom_rights_statement_source_option, :effective_custom_rights_instructions, :user_can_set_license?, to: :collection
 
     def license_from_collection
       License.label_for(collection.required_license)

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -108,13 +108,13 @@ class Collection < ApplicationRecord
 
   def effective_custom_rights_instructions
     unless custom_rights_statement_source_option == "entered_by_depositor"
-      raise "Custom rights for #{collection.id} not entered by depositor; thus it doesn't make sense to determine instructions for entering"
+      raise "Custom rights for collection id #{id} not entered by depositor; thus it doesn't make sense to determine instructions for entering"
     end
 
     if custom_rights_instructions_source_option == "provided_by_collection"
       custom_rights_statement_custom_instructions
     else
-      Settings.access.default_instructions_for_custom_use_statement
+      I18n.t("collection.depositor_custom_rights_instructions")
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,6 +86,7 @@ en:
     deposits: Deposits in collection
     deposit_status: Status
     deposit_size: Size
+    depositor_custom_rights_instructions: Enter additional terms of use not covered by your chosen license or the default terms shown above, which also display on the PURL page.
     last_modified: Modified
     number_of_files: Files
     persistent_link: Persistent link
@@ -138,7 +139,7 @@ en:
       related_link: This section allows you to provide links to other web pages that are related to your deposit. These links will display on the persistent URL (PURL) page for your deposit and on the Stanford Libraries' catalog record. Enter the text to be displayed on the page in the "Link text" box. This entire text will be hyperlinked to the URL you enter in the "URL" box. Examples of content you might consider linking to are lab, institute, or project pages; GitHub repositories for the current version of software code; or funder websites.
       license: A license helps others who access your content to understand what you are allowing them to do with your work and under what conditions.  Click on "Get help selecting a license" for assistance with the license options presented here.
       locked: This deposit can no longer be edited in this application. If you need to make changes to this deposit, please use the Help link at the top of this page to contact us.
-      custom_rights: For open access articles, use this section for required publisher's statement. For other deposits, use this section to describe other terms of use not covered by the license you select below. This section does not constitute a formal Data Use Agreement.
+      custom_rights_from_depositor: For open access articles, use this section if your publisher requires a statement when depositing your work to an institutional repository. For other deposits, use this section to describe other terms of use not covered by the license you have selected.
   hints:
     collection:
       review_enabled: >

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -95,7 +95,6 @@ notifications:
 
 access:
   use_and_reproduction_statement: User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.
-  default_instructions_for_custom_use_statement: Enter additional terms of use not covered by your chosen license or the default terms shown above, which also display on the PURL page.
 
 datacite:
   prefix: '10.80343'

--- a/spec/components/collections/terms_of_use_component_spec.rb
+++ b/spec/components/collections/terms_of_use_component_spec.rb
@@ -32,32 +32,30 @@ RSpec.describe Collections::TermsOfUseComponent, type: :component do
     context "when custom rights are not enabled for the collection" do
       let(:collection) { build_stubbed(:collection, allow_custom_rights_statement: false) }
 
-      it { is_expected.to include("Additional terms of use are disabled for this collection") }
+      it { is_expected.to have_xpath("//tr[contains(th, 'Additional terms of use') and contains(td, 'No')]") }
     end
 
     context "when a pre-determined custom right statement is provided by the collection" do
       let(:collection) { build_stubbed(:collection, :with_custom_rights_from_collection) }
 
-      it { is_expected.to include("\"#{collection.provided_custom_rights_statement}\"") }
+      it { is_expected.to have_xpath("//tr[contains(th, 'Additional terms of use') and contains(td, '#{collection.provided_custom_rights_statement}')]") }
     end
 
     context "when the user is able to enter their own custom rights statement" do
-      let(:expected_custom_rights_info) do
-        "The depositor is allowed to enter their own terms. They will be presented with the following instructions: \"#{effective_instructions}\""
-      end
+      let(:collection) { build_stubbed(:collection, :with_custom_rights_from_depositor) }
+
+      it { is_expected.to have_xpath("//tr[contains(th, 'Additional terms of use') and contains(td, 'Allow user to enter')]") }
 
       context "when instructions for the depositor's custom rights statement are specified by the collection" do
         let(:collection) { build_stubbed(:collection, :with_custom_rights_instructions_from_collection) }
-        let(:effective_instructions) { collection.custom_rights_statement_custom_instructions }
 
-        it { is_expected.to include(expected_custom_rights_info) }
+        it { is_expected.to have_xpath("//tr[contains(th, 'Instructions') and contains(td, \"#{collection.custom_rights_statement_custom_instructions}\")]") }
       end
 
       context "when the default H2 instructions for depositors entering custom rights should be displayed to the depositor" do
-        let(:collection) { build_stubbed(:collection, :with_custom_rights_from_depositor) }
-        let(:effective_instructions) { Settings.access.default_instructions_for_custom_use_statement }
+        let(:collection) { build_stubbed(:collection, :with_custom_rights_from_depositor, custom_rights_statement_custom_instructions: nil) }
 
-        it { is_expected.to include(expected_custom_rights_info) }
+        it { is_expected.to have_xpath("//tr[contains(th, 'Instructions') and contains(td, \"#{Settings.access.default_instructions_for_custom_use_statement}\")]") }
       end
     end
   end

--- a/spec/components/collections/terms_of_use_component_spec.rb
+++ b/spec/components/collections/terms_of_use_component_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Collections::TermsOfUseComponent, type: :component do
       context "when the default H2 instructions for depositors entering custom rights should be displayed to the depositor" do
         let(:collection) { build_stubbed(:collection, :with_custom_rights_from_depositor, custom_rights_statement_custom_instructions: nil) }
 
-        it { is_expected.to have_xpath("//tr[contains(th, 'Instructions') and contains(td, \"#{Settings.access.default_instructions_for_custom_use_statement}\")]") }
+        it { is_expected.to have_xpath("//tr[contains(th, 'Instructions') and contains(td, \"#{I18n.t("collection.depositor_custom_rights_instructions")}\")]") }
       end
     end
   end


### PR DESCRIPTION
# Why was this change made? 🤔

close #3317
close #3314

# How was this change tested? 🤨

* manual testing on localhost
* unit tests

## screenshots of fixes for the ticketed issues

### work creation/edit
custom instructions now display above the custom terms text entry field:
<img width="1292" alt="Screen Shot 2023-07-31 at 12 35 53 PM" src="https://github.com/sul-dlss/happy-heron/assets/7741604/e625ea18-ddfa-404a-944f-a8763abf0642">

the popover with additional guidance now displays the same text regardless of whether custom or default instructions are presented for custom terms entry:
<img width="1290" alt="Screen Shot 2023-07-31 at 12 33 44 PM" src="https://github.com/sul-dlss/happy-heron/assets/7741604/82a6b057-48ac-4fcb-a699-9b36f1a304ca">

no popover when custom terms are set by collection:
<img width="1292" alt="Screen Shot 2023-07-31 at 12 36 42 PM" src="https://github.com/sul-dlss/happy-heron/assets/7741604/28c303ab-084b-443a-b230-88f025aaac6c">

no additional terms section when additional terms are entirely disabled for the collection:
<img width="1295" alt="Screen Shot 2023-07-31 at 12 37 41 PM" src="https://github.com/sul-dlss/happy-heron/assets/7741604/3de27bd1-4981-43e6-98c0-f0f85d9eccc8">

### collection settings display
instructions displayed in separate table row from custom terms setting/value:
<img width="1113" alt="Screen Shot 2023-07-31 at 12 35 04 PM" src="https://github.com/sul-dlss/happy-heron/assets/7741604/ee12c813-faec-427a-b84f-1acf5e93f41c">

additional terms of use displayed without quotes, even when set by collection, and instructions row is hidden when custom terms are set by the collection:
<img width="1113" alt="Screen Shot 2023-07-31 at 12 36 22 PM" src="https://github.com/sul-dlss/happy-heron/assets/7741604/0a2e093f-35fd-4900-a7fd-ddcad4acef3b">


⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

no (according to SiteImprove plugin and firefox accessibility inspector)

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



