### PR TITLE
Improve accessibility of work cite links

### DIFF
--- a/app/components/citation_component.rb
+++ b/app/components/citation_component.rb
@@ -8,12 +8,12 @@ class CitationComponent < ApplicationComponent
 
   def call
     attrs = {
-      data: data_attributes, class: "citation-button"
+      data: data_attributes, class: "citation-button", "aria-label": aria_label, href: "#citationModal", id: citation_link_id
     }
 
     attrs[:disabled] = work_version.first_draft? || work_version.purl_reserved?
 
-    tag.button(**attrs) do
+    tag.a(**attrs) do
       # It's a SafeBuffer, not a String
       tag.span(class: "fa-solid fa-quote-left") + " Cite" # rubocop:disable Style/StringConcatenation
     end
@@ -33,5 +33,13 @@ class CitationComponent < ApplicationComponent
       bs_toggle: "modal",
       bs_target: "#citationModal"
     }
+  end
+
+  def aria_label
+    "Get citation for #{work_version.title}"
+  end
+
+  def citation_link_id
+    "get-citation-#{work_version.id}"
   end
 end

--- a/spec/components/citation_component_spec.rb
+++ b/spec/components/citation_component_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe CitationComponent, type: :component do
-  subject(:button) { rendered.css("button").first }
+  subject(:link) { rendered.css("a").first }
 
   let(:rendered) { render_inline(described_class.new(work_version:)) }
 
@@ -11,9 +11,9 @@ RSpec.describe CitationComponent, type: :component do
     let(:work_version) { build(:work_version, :deposited) }
 
     it "renders a button" do
-      expect(button["data-bs-target"]).to eq "#citationModal"
-      expect(button["data-controller"]).to eq "show-citation"
-      expect(button["disabled"]).not_to be_present
+      expect(link["data-bs-target"]).to eq "#citationModal"
+      expect(link["data-controller"]).to eq "show-citation"
+      expect(link["disabled"]).not_to be_present
     end
   end
 
@@ -21,7 +21,7 @@ RSpec.describe CitationComponent, type: :component do
     let(:work_version) { build(:work_version, :purl_reserved) }
 
     it "renders a disabled button" do
-      expect(button["disabled"]).to be_present
+      expect(link["disabled"]).to be_present
     end
   end
 
@@ -29,7 +29,7 @@ RSpec.describe CitationComponent, type: :component do
     let(:work_version) { build(:work_version, :first_draft) }
 
     it "renders a disabled button" do
-      expect(button["disabled"]).to be_present
+      expect(link["disabled"]).to be_present
     end
   end
 end

--- a/spec/components/collections/works_component_spec.rb
+++ b/spec/components/collections/works_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Collections::WorksComponent, type: :component do
       let(:groups) { [Settings.authorization_workgroup_names.administrators] }
 
       it "renders the works detail table component" do
-        expect(rendered.css("table").to_html).to include("Test title").exactly(6).times
+        expect(rendered.css("table").to_html).to include("Test title").exactly(8).times
         expect(rendered.to_html).to include('data-datatable-works-hide-depositor-value="false"')
       end
     end


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3188 

- Adds unique ids to the cite buttons
- Improves the screen reader experience by adding a meaningful aria-label to the link.

# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

It improves a couple. tested using VoiceOver screen reader on my laptop.

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



