### PR TITLE
Minor update to accessibility best practice update for modal headers

### DIFF
--- a/app/views/shared/_help_modal.html.erb
+++ b/app/views/shared/_help_modal.html.erb
@@ -2,7 +2,7 @@
   <div class="modal-dialog modal-dialog-centered ">
     <div class="modal-content">
       <div class="modal-header">
-        <h3 class="modal-title" id="help-prompt">Help</h3>
+        <h1 class="modal-title h3" id="help-prompt">Help</h1>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">

--- a/app/views/shared/_terms_of_deposit.html.erb
+++ b/app/views/shared/_terms_of_deposit.html.erb
@@ -3,7 +3,7 @@
     <div class="modal-content">
       <div class="row justify-content-between modal-header">
           <div class="col-5">
-            <h3 class="modal-title" id="terms-of-deposit-prompt">Terms of Deposit</h3>
+            <h1 class="modal-title h3" id="terms-of-deposit-prompt">Terms of Deposit</h1>
           </div>
           <div class="col-2">
             <%= link_to Settings.faq_url, aria: {label: "FAQs about Terms of Deposit"}, id: "faq-link", class: "text-decoration-none", target: "_blank" do %>


### PR DESCRIPTION
# Why was this change made? 🤔

SiteImprove suggest the best practice for pages (and modals, etc) is that the top/header visual element be an H1 to apply proper hierarchy, starting with h2/h3 violates this best practice. From SiteImprove:

```
Heading tags help assistive technology users to understand how content is structured. They're also used for in-page screen reader navigation.

When determining heading levels, you should ensure that they follow a nested structure. h1 is used for the primary heading, followed by h2 for subheadings, and so on to h6.
```

# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

Fixes 2 violations.

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



