### PR TITLE
Make form headings fit h1/h2/h3 hierarchy for accessibility

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -1,11 +1,11 @@
 <section data-controller="complex-radio file-uploads" id="file">
-  <header>
+  <h2 class="h5 fw-bold">
     <% if has_attached_files? %>
       Modify your files *
     <% else %>
       Add your files *
     <% end %>
-  </header>
+  </h2>
 
   <div class="form-check" data-complex-radio-target="selection">
     <%= form.radio_button :upload_type, "browser", class: "form-check-input", "data-file-uploads-target": "browserRadioButton",

--- a/app/components/works/agreement_component.html.erb
+++ b/app/components/works/agreement_component.html.erb
@@ -1,5 +1,5 @@
 <section>
-  <header>Terms of Deposit *</header>
+  <h2 class="h5 fw-bold">Terms of Deposit *</h2>
   <div class="row">
     <div class="form-check col-auto">
       <% if agreed_to_terms_recently? %>

--- a/app/components/works/authors_and_contributors_component.html.erb
+++ b/app/components/works/authors_and_contributors_component.html.erb
@@ -1,5 +1,5 @@
 <section data-controller="nested-form" id="author">
-  <header>List authors and contributors *</header>
+  <h2 class="h5 fw-bold">List authors and contributors *</h2>
   <p>Enter the name(s) of people, organizations or events responsible for producing the deposit.</p>
 
   <%= render Works::AuthorsComponent.new(form: form) %>

--- a/app/components/works/authors_component.html.erb
+++ b/app/components/works/authors_component.html.erb
@@ -1,8 +1,8 @@
 <section data-controller="ordered-nested-form" data-ordered-nested-form-selector-value=".inner-container">
-  <header aria-describedby="popover-work.author">
+  <h3 class="h5 fw-bold" aria-describedby="popover-work.author">
     Authors to include in citation
     <%= render PopoverComponent.new key: "work.author" %>
-  </header>
+  </h3>
   <p>When there are multiple authors, list them in the order they should appear in the citation. If you need to change the order of the authors, click the arrows to move individual authors up or down in the list.</p>
 
   <template data-ordered-nested-form-target='template'>

--- a/app/components/works/contributors_component.html.erb
+++ b/app/components/works/contributors_component.html.erb
@@ -1,7 +1,7 @@
 <section data-controller="nested-form" data-nested-form-selector-value=".inner-container">
-  <header aria-describedby="popover-work.contributor">Additional contributors
+  <h3 class="h5 fw-bold" aria-describedby="popover-work.contributor">Additional contributors
    <%= render PopoverComponent.new key: "work.contributor" %>
-  </header>
+  </h3>
   <p>Names will be listed in the order shown below.</p>
 
   <template data-nested-form-target='template'>

--- a/app/components/works/dates_component.html.erb
+++ b/app/components/works/dates_component.html.erb
@@ -1,7 +1,7 @@
 <section id="dates">
-  <header aria-describedby="popover-work.date">Enter dates related to your deposit
+  <h2 class="h5 fw-bold" aria-describedby="popover-work.date">Enter dates related to your deposit
     <%= render PopoverComponent.new key: "work.date" %>
-  </header>
+  </h2>
   <%= render Works::PublicationDateComponent.new(form: form,
         min_year: min_year,
         max_year: max_year) %>

--- a/app/components/works/description_component.html.erb
+++ b/app/components/works/description_component.html.erb
@@ -1,5 +1,5 @@
 <section id="description">
-  <header>Describe your deposit *</header>
+  <h2 class="h5 fw-bold">Describe your deposit *</h2>
   <p>Enter a summary statement about the deposit (600 words max) to help others
     discover your deposits in SearchWorks and on the internet. Add at least one
     keyword that relates to the content of the deposit.</p>

--- a/app/components/works/embargo_component.html.erb
+++ b/app/components/works/embargo_component.html.erb
@@ -1,10 +1,10 @@
 <section id="release">
-  <header>
+  <h2 class="h5 fw-bold">
     Settings for release date and download access
     <% if user_can_set_availability? || user_can_set_access? %>
      *
     <% end %>
-  </header>
+  </h2>
   <% if user_can_set_availability? %>
     <fieldset class="mb-5">
       <legend class="h5">

--- a/app/components/works/license_component.html.erb
+++ b/app/components/works/license_component.html.erb
@@ -1,5 +1,5 @@
 <section id="license">
-  <header>License *</header>
+  <h2 class="h5 fw-bold">License *</h2>
   <% if user_can_set_license? %>
     <div class="mb-3 row">
       <div class="col-sm-2">

--- a/app/components/works/title_component.html.erb
+++ b/app/components/works/title_component.html.erb
@@ -1,5 +1,5 @@
 <section id="title">
-   <header>Title of deposit and contact information *</header>
+   <h2 class="h5 fw-bold">Title of deposit and contact information *</h2>
    <div class="mb-3 row">
      <div class='col-sm-2'>
        <%= form.label :title, "Title of deposit *", class: "col-form-label" %>

--- a/spec/components/works/agreement_component_spec.rb
+++ b/spec/components/works/agreement_component_spec.rb
@@ -12,6 +12,6 @@ RSpec.describe Works::AgreementComponent do
   it "renders the component" do
     expect(rendered.to_html)
       .to include("SDR Terms of Deposit")
-    expect(rendered.css("header").text).to eq "Terms of Deposit *"
+    expect(rendered.css("h2").text).to eq "Terms of Deposit *"
   end
 end

--- a/spec/support/capybara_actions.rb
+++ b/spec/support/capybara_actions.rb
@@ -7,7 +7,9 @@ module CapybaraActions
   end
 
   def within_section(title, &)
-    within(:xpath, "//section[contains(header/text(),'#{title}')]", &)
+    within(:xpath, "//section[contains(h2/text(),'#{title}')]", &)
+  rescue Capybara::ElementNotFound
+    within(:xpath, "//section[contains(h3/text(),'#{title}')]", &)
   end
 
   # NOTE: this is here to ensure all turbo frames are loaded before auditing a11y


### PR DESCRIPTION
# Why was this change made? 🤔

Refs #3170 

This moves the `<header>` components on the deposit form to actual `h2` and `h3` values to support the proper hierarchy for accessibility. 

Note from SODA recommendation:
```
Including the text in a <header> element does not make the text a heading.  
```

# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



