### PR TITLE
Visually indicate when the form buttons get focus

### DIFF
--- a/app/assets/stylesheets/editor.scss
+++ b/app/assets/stylesheets/editor.scss
@@ -52,4 +52,8 @@
   .dropdown .list-group-item {
     cursor: default;
   }
+
+  button:focus-visible {
+    border: 1px solid $stanford-cardinal;
+  }
 }

--- a/app/components/works/description_component.html.erb
+++ b/app/components/works/description_component.html.erb
@@ -49,7 +49,7 @@
                   }
                 },
                 "true", "false" %>
-          <div class="slider round">
+          <div class="slider round" tabindex="0">
             <span class="on">Yes</span>
             <span class="off">No</span>
           </div>


### PR DESCRIPTION
# Why was this change made? 🤔

Refs #3170 - this adds a visual indication when a button has gained focus using tab navigation.

WGAG Recommendation:
```
Ensure that when actionable elements receive focus, that it appears on screen and that a visible focus
indicator is present. Focus can be indicated in different ways, including change of background, lightness,
border, outline, underline, and other visual methods. Avoid the use of the "outline: none" CSS property.
As of WCAG 2.1, a custom focus indicator should have a minimum contrast ratio of 3:1 against the background.
```


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



