### PR TITLE
Accessibility: Improve color contrast for focused objects

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -64,3 +64,13 @@ ul.collections {
     text-decoration: underline;
   }
 }
+
+// This adds a visible border with a high contrast ratio
+// to improve keyboard and voice read navigation for links and buttons
+.nav-link:focus,
+.copy-button:focus,
+.citation-button:focus,
+.form-control:focus,
+a:focus {
+  outline: 1px solid #8c1515;
+}

--- a/app/components/works/link_to_show_component.rb
+++ b/app/components/works/link_to_show_component.rb
@@ -8,7 +8,7 @@ module Works
     end
 
     def link
-      link_to truncate(title, length: 150, separator: " "), work, title:
+      link_to truncate(title, length: 150, separator: " "), work, title:, class: "work-link"
     end
 
     def title


### PR DESCRIPTION
# Why was this change made? 🤔

This is a small PR to add a high contrast ratio border to improve visibility of targets when using keyboard navigation. This addresses a few of the color contrast "major" issues reported by soda.

While not obtrusive, this improves the ratio that is currently in place:

![Screenshot 2023-08-07 at 9 37 23 AM](https://github.com/sul-dlss/happy-heron/assets/2294288/409105e9-2fe8-4432-83c7-662abc054634)


# Does your change introduce accessibility violations? 🩺

No.

