### PR TITLE
Use list types when presenting content as a list

### DIFF
--- a/app/views/shared/_terms_of_deposit.html.erb
+++ b/app/views/shared/_terms_of_deposit.html.erb
@@ -5,20 +5,24 @@
           <div class="col-5">
             <h1 class="modal-title h3" id="terms-of-deposit-prompt">Terms of Deposit</h1>
           </div>
-          <div class="col-2">
-            <%= link_to Settings.faq_url, aria: {label: "FAQs about Terms of Deposit"}, id: "faq-link", class: "text-decoration-none", target: "_blank" do %>
-              <span class="fa-solid fa-question-circle"></span> FAQs
-            <% end %>
-          </div>
-          <div class="col-2">
-            <%= link_to Settings.terms_url, aria: {label: "Save Terms of Deposit"}, id: "print-link", class: "text-decoration-none", target: "_blank" do %>
-              <span class="fa-solid fa-save"></span> Save
-            <% end %>
-          </div>
-          <div class="col-2">
-            <%= link_to print_terms_of_deposit_path, aria: {label: "Print Terms of Deposit"}, id: "save-link", class: "text-decoration-none", target: "_blank" do %>
-              <span class="fa-solid fa-print"></span> Print
-            <% end %>
+          <div class="col-6">
+            <ul class="row list-unstyled">
+              <li class="col-4">
+                <%= link_to Settings.faq_url, aria: {label: "FAQs about Terms of Deposit"}, id: "faq-link", class: "text-decoration-none", target: "_blank" do %>
+                  <span class="fa-solid fa-question-circle"></span> FAQs
+                <% end %>
+              </li>
+              <li class="col-4">
+                <%= link_to Settings.terms_url, aria: {label: "Save Terms of Deposit"}, id: "print-link", class: "text-decoration-none", target: "_blank" do %>
+                  <span class="fa-solid fa-save"></span> Save
+                <% end %>
+              </li>
+              <li class="col-4">
+                <%= link_to print_terms_of_deposit_path, aria: {label: "Print Terms of Deposit"}, id: "save-link", class: "text-decoration-none", target: "_blank" do %>
+                  <span class="fa-solid fa-print"></span> Print
+                <% end %>
+              </li>
+            </ul>
           </div>
           <div class="col-1">
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>


### PR DESCRIPTION
# Why was this change made? 🤔

This reformats the terms of use modal link at the top to use a list for assisting screen readers. The visual representation did not change:

before:
![Screenshot 2023-08-07 at 3 34 56 PM](https://github.com/sul-dlss/happy-heron/assets/2294288/8014f49d-68fb-4df4-8dc7-b0409a0b42e6)

after:
![Screenshot 2023-08-07 at 3 43 20 PM](https://github.com/sul-dlss/happy-heron/assets/2294288/2e25685f-22ca-4a0e-8fa9-4ba37026f1ba)


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



