### PR TITLE
Add missing fieldsets on deposit form

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -7,122 +7,125 @@
     <% end %>
   </h2>
 
-  <div class="form-check" data-complex-radio-target="selection">
-    <%= form.radio_button :upload_type, "browser", class: "form-check-input", "data-file-uploads-target": "browserRadioButton",
-          data: {action: "complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus"} %>
-    <%= form.label :upload_type_browser, "Upload fewer than 250 files (total less than 10 GB) to be displayed as a flat list of files.", class: "form-check-label fw-semibold" %>
-    <div id="uploaded-files-panel" data-file-uploads-target="fileUploads">
-      <div data-controller="dropzone" data-dropzone-max-file-size="10000" data-dropzone-max-files="250" data-dropzone-previews-container=".dropzone-files-previews">
-        <fieldset>
-          <div class="dropzone dropzone-default" data-dropzone-target="container">
-            <%= form.file_field :files, multiple: true, direct_upload: true, namespace: "flat_list", "aria-label": "Upload files",
-                  data: {dropzone_target: "input"} %>
-            <div class="dz-message needsclick text-secondary">
-              <p>Drop files here</p>
+  <fieldset>
+    <legend class="visually-hidden">Add or modify files</legend>
+    <div class="form-check" data-complex-radio-target="selection">
+      <%= form.radio_button :upload_type, "browser", class: "form-check-input", "data-file-uploads-target": "browserRadioButton",
+            data: {action: "complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus"} %>
+      <%= form.label :upload_type_browser, "Upload fewer than 250 files (total less than 10 GB) to be displayed as a flat list of files.", class: "form-check-label fw-semibold" %>
+      <div id="uploaded-files-panel" data-file-uploads-target="fileUploads">
+        <div data-controller="dropzone" data-dropzone-max-file-size="10000" data-dropzone-max-files="250" data-dropzone-previews-container=".dropzone-files-previews">
+          <fieldset>
+            <div class="dropzone dropzone-default" data-dropzone-target="container">
+              <%= form.file_field :files, multiple: true, direct_upload: true, namespace: "flat_list", "aria-label": "Upload files",
+                    data: {dropzone_target: "input"} %>
+              <div class="dz-message needsclick text-secondary">
+                <p>Drop files here</p>
+              </div>
             </div>
-          </div>
-          <span style="margin: .7rem">or</span> <button type="button" class="dz-clickable btn btn-outline-primary">Choose files</button>
-          <div class="invalid-feedback" data-dropzone-target="feedback">You must attach a file<%= error_message %></div>
-          <div class="dropzone-previews dropzone-files-previews" data-dropzone-target="previewsContainer">
-          </div>
-          <div class="files-list">
-            <%= render Works::Edit::FilesComponent.new(work_version: form.object.model[:work_version], form:) %>
-          </div>
-        </fieldset>
+            <span style="margin: .7rem">or</span> <button type="button" class="dz-clickable btn btn-outline-primary">Choose files</button>
+            <div class="invalid-feedback" data-dropzone-target="feedback">You must attach a file<%= error_message %></div>
+            <div class="dropzone-previews dropzone-files-previews" data-dropzone-target="previewsContainer">
+            </div>
+            <div class="files-list">
+              <%= render Works::Edit::FilesComponent.new(work_version: form.object.model[:work_version], form:) %>
+            </div>
+          </fieldset>
 
-        <template data-dropzone-target='template'>
-          <%= form.fields_for :attached_files, AttachedFile.new, child_index: "TEMPLATE_RECORD" do |file_form| %>
-            <%= render Works::Edit::FileRowComponent.new(form: file_form) %>
-          <% end %>
-        </template>
+          <template data-dropzone-target='template'>
+            <%= form.fields_for :attached_files, AttachedFile.new, child_index: "TEMPLATE_RECORD" do |file_form| %>
+              <%= render Works::Edit::FileRowComponent.new(form: file_form) %>
+            <% end %>
+          </template>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="form-check pt-3" data-complex-radio-target="selection">
-    <%= form.radio_button :upload_type, "zipfile", class: "form-check-input",
-          data: {action: "complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus", file_uploads_target: "zipRadioButton"} %>
-    <%= form.label :upload_type_zipfile, "Upload a single zip file (containing fewer than 25,000 files and less than 10GB total), which will be unzipped, including any hierarchy.", class: "form-check-label fw-semibold" %>
-    <div id="zip-files-panel" data-file-uploads-target="zipUpload">
-      <p>Viewers will see the file hierarchy and be able to download individual files. Unzipping may take several minutes if your zip file contains a large number of individual files.</p>
-      <p><strong>Warning:</strong> this file upload option will automatically replace all existing files on your item with the content in the new zip file.</p>
-      <div data-controller="dropzone" data-dropzone-max-file-size="10000" data-dropzone-max-files="1"
-           data-dropzone-accepted-files=".zip" data-dropzone-clickable=".dz-zip-clickable"
-           data-dropzone-previews-container=".dropzone-zip-previews">
-        <fieldset>
-          <div class="dropzone dropzone-default" data-dropzone-target="container">
-            <%= form.file_field :files, multiple: false, direct_upload: true, namespace: "zip", "aria-label": "Upload files",
-                  data: {dropzone_target: "input"} %>
-            <div class="dz-message needsclick text-secondary">
-              <p>Drop zip file here</p>
+    <div class="form-check pt-3" data-complex-radio-target="selection">
+      <%= form.radio_button :upload_type, "zipfile", class: "form-check-input",
+            data: {action: "complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus", file_uploads_target: "zipRadioButton"} %>
+      <%= form.label :upload_type_zipfile, "Upload a single zip file (containing fewer than 25,000 files and less than 10GB total), which will be unzipped, including any hierarchy.", class: "form-check-label fw-semibold" %>
+      <div id="zip-files-panel" data-file-uploads-target="zipUpload">
+        <p>Viewers will see the file hierarchy and be able to download individual files. Unzipping may take several minutes if your zip file contains a large number of individual files.</p>
+        <p><strong>Warning:</strong> this file upload option will automatically replace all existing files on your item with the content in the new zip file.</p>
+        <div data-controller="dropzone" data-dropzone-max-file-size="10000" data-dropzone-max-files="1"
+            data-dropzone-accepted-files=".zip" data-dropzone-clickable=".dz-zip-clickable"
+            data-dropzone-previews-container=".dropzone-zip-previews">
+          <fieldset>
+            <div class="dropzone dropzone-default" data-dropzone-target="container">
+              <%= form.file_field :files, multiple: false, direct_upload: true, namespace: "zip", "aria-label": "Upload files",
+                    data: {dropzone_target: "input"} %>
+              <div class="dz-message needsclick text-secondary">
+                <p>Drop zip file here</p>
+              </div>
             </div>
-          </div>
-          <span style="margin: .7rem">or</span> <button type="button" class="dz-zip-clickable btn btn-outline-primary">Choose file</button>
-          <div class="invalid-feedback" data-dropzone-target="feedback">You must attach a file<%= error_message %></div>
-          <div class="dropzone-previews dropzone-zip-previews" data-dropzone-target="previewsContainer">
-          </div>
-        </fieldset>
+            <span style="margin: .7rem">or</span> <button type="button" class="dz-zip-clickable btn btn-outline-primary">Choose file</button>
+            <div class="invalid-feedback" data-dropzone-target="feedback">You must attach a file<%= error_message %></div>
+            <div class="dropzone-previews dropzone-zip-previews" data-dropzone-target="previewsContainer">
+            </div>
+          </fieldset>
 
-        <template data-dropzone-target='template'>
-          <%= form.fields_for :attached_files, AttachedFile.new, child_index: "TEMPLATE_RECORD" do |file_form| %>
-            <%= render Works::Edit::FileRowComponent.new(form: file_form, zip_template: true) %>
-          <% end %>
-        </template>
+          <template data-dropzone-target='template'>
+            <%= form.fields_for :attached_files, AttachedFile.new, child_index: "TEMPLATE_RECORD" do |file_form| %>
+              <%= render Works::Edit::FileRowComponent.new(form: file_form, zip_template: true) %>
+            <% end %>
+          </template>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="form-check pt-3" data-complex-radio-target="selection">
-    <%= form.radio_button :upload_type, "globus", class: "form-check-input", "data-file-uploads-target": "globusRadioButton", "data-deposit-button-target": "globusRadioButton",
-          data: {action: "complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus"} %>
-    <%= form.label :upload_type_globus, "Upload one or more files via Globus (fewer than 25,000 files and less than 4TB total) which will be displayed as uploaded, including any file hierarchy.", class: "form-check-label fw-semibold" %>
+    <div class="form-check pt-3" data-complex-radio-target="selection">
+      <%= form.radio_button :upload_type, "globus", class: "form-check-input", "data-file-uploads-target": "globusRadioButton", "data-deposit-button-target": "globusRadioButton",
+            data: {action: "complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus"} %>
+      <%= form.label :upload_type_globus, "Upload one or more files via Globus (fewer than 25,000 files and less than 4TB total) which will be displayed as uploaded, including any file hierarchy.", class: "form-check-label fw-semibold" %>
 
-    <div data-file-uploads-target="globusUpload">
-      <p>Please notify us at <a href="mailto:sdr-contact@lists.stanford.edu">sdr-contact@lists.stanford.edu</a> if you are uploading 1TB or more of content.</p>
-      <div class="container py-4">
-        <ol class="row g-3 list-unstyled">
-          <li class="col">
-            <div class="border border-dark h-100 p-2 bg-light">
-              <p>STEP 1</p>
-              <p>If your files are located on Stanford Google Drive, Oak, or Sherlock, select where they are located below.</p>
-              <%= form.select :globus_origin, origin_options, {}, {class: "form-select", "aria-label": "Origin for Globus deposit"} %>
-            </div>
-          </li>
-          <li class="col">
-            <div class="border border-dark h-100 p-2 bg-light">
-              <p>STEP 2</p>
-              <p>Scroll to the bottom of this page and click "Save as draft".</p>
-              <p>You can finish filling out this form later.</p>
-            </div>
-          </li>
-          <li class="col">
-            <div class="border border-dark h-100 p-2 bg-light">
-              <p>STEP 3</p>
-              <p>Follow our <%= link_to "instructions", Settings.globus.help_doc_url.to_s, target: :blank %> to set up Globus (may require software installation).</p>
-              <p>Transfer your files to the location you'll see on your item page once you've saved this form.</p>
-            </div>
-          </li>
-          <li class="col">
-            <div class="border border-dark h-100 p-2 bg-light">
-              <p>STEP 4</p>
-              <p>Return to this page and make sure the form is complete. Then click "Deposit."</p>
-              <p>This will move your files from Globus to SDR.</p>
-            </div>
-          </li>
-        </ul>
-      </div>
-      <% if globus_endpoint? %>
-      <div class="container">
-        <div class="row">
-          <div class="col">
-            <div class="border border-dark h-100 p-2 ps-5 bg-light">
-              <%= form.check_box :fetch_globus_files, {class: "form-check-input form-check-input-lg", data: {deposit_button_target: "globusCheckbox", action: "deposit-button#updateDepositButtonStatus"}}, "true", "false" %>
-              <%= form.label :fetch_globus_files,
-                    "Check this box once all your files have completed uploading to Globus.",
-                    class: "form-check-label form-check-label-lg" %>
+      <div data-file-uploads-target="globusUpload">
+        <p>Please notify us at <a href="mailto:sdr-contact@lists.stanford.edu">sdr-contact@lists.stanford.edu</a> if you are uploading 1TB or more of content.</p>
+        <div class="container py-4">
+          <ol class="row g-3 list-unstyled">
+            <li class="col">
+              <div class="border border-dark h-100 p-2 bg-light">
+                <p>STEP 1</p>
+                <p>If your files are located on Stanford Google Drive, Oak, or Sherlock, select where they are located below.</p>
+                <%= form.select :globus_origin, origin_options, {}, {class: "form-select", "aria-label": "Origin for Globus deposit"} %>
+              </div>
+            </li>
+            <li class="col">
+              <div class="border border-dark h-100 p-2 bg-light">
+                <p>STEP 2</p>
+                <p>Scroll to the bottom of this page and click "Save as draft".</p>
+                <p>You can finish filling out this form later.</p>
+              </div>
+            </li>
+            <li class="col">
+              <div class="border border-dark h-100 p-2 bg-light">
+                <p>STEP 3</p>
+                <p>Follow our <%= link_to "instructions", Settings.globus.help_doc_url.to_s, target: :blank %> to set up Globus (may require software installation).</p>
+                <p>Transfer your files to the location you'll see on your item page once you've saved this form.</p>
+              </div>
+            </li>
+            <li class="col">
+              <div class="border border-dark h-100 p-2 bg-light">
+                <p>STEP 4</p>
+                <p>Return to this page and make sure the form is complete. Then click "Deposit."</p>
+                <p>This will move your files from Globus to SDR.</p>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <% if globus_endpoint? %>
+        <div class="container">
+          <div class="row">
+            <div class="col">
+              <div class="border border-dark h-100 p-2 ps-5 bg-light">
+                <%= form.check_box :fetch_globus_files, {class: "form-check-input form-check-input-lg", data: {deposit_button_target: "globusCheckbox", action: "deposit-button#updateDepositButtonStatus"}}, "true", "false" %>
+                <%= form.label :fetch_globus_files,
+                      "Check this box once all your files have completed uploading to Globus.",
+                      class: "form-check-label form-check-label-lg" %>
+              </div>
             </div>
           </div>
         </div>
+        <% end %>
       </div>
-      <% end %>
     </div>
-  </div>
+  </fieldset>
 </section>

--- a/app/components/works/title_component.html.erb
+++ b/app/components/works/title_component.html.erb
@@ -1,20 +1,24 @@
 <section id="title">
    <h2 class="h5 fw-bold">Title of deposit and contact information *</h2>
-   <div class="mb-3 row">
-     <div class='col-sm-2'>
-       <%= form.label :title, "Title of deposit *", class: "col-form-label" %>
-       <%= render PopoverComponent.new key: "work.title" %>
-     </div>
-     <div class="col-sm-9">
-       <%= form.text_area :title, class: "form-control", required: true, rows: 1,
-             "aria-describedby": "popover-work.title",
-             data: {action: "no-newlines#change change->auto-citation#updateDisplay",
-                    auto_citation_target: "titleField",
-                    no_newlines_target: "input",
-                    controller: "no-newlines"} %>
-       <div class="invalid-feedback">You must provide a title</div>
-     </div>
-   </div>
+   <fieldset>
+     <legend class="visually-hidden">Title of deposit and contact information</legend>
+    <div class="mb-3 row">
+      <div class='col-sm-2'>
+        <%= form.label :title, "Title of deposit *", class: "col-form-label" %>
+        <%= render PopoverComponent.new key: "work.title" %>
+      </div>
+      <div class="col-sm-9">
+        <%= form.text_area :title, class: "form-control", required: true, rows: 1,
+              "aria-describedby": "popover-work.title",
+              data: {action: "no-newlines#change change->auto-citation#updateDisplay",
+                     auto_citation_target: "titleField",
+                     no_newlines_target: "input",
+                     controller: "no-newlines"} %>
+        <div class="invalid-feedback">You must provide a title</div>
+      </div>
+    </div>
 
-  <%= render Works::ContactEmailComponent.new(form: form, key: "work.contact_email") %>
+    <%= render Works::ContactEmailComponent.new(form: form, key: "work.contact_email") %>
+    </legend>
+  </fieldset>
  </section>


### PR DESCRIPTION
# Why was this change made? 🤔

The diff looks larger than it is below as the only change is wrapping the 2 sections with a fieldset and indenting,. This improves the screen reader experience on the deposit form so that users know how many check boxes are presented for file upload for instance.

# How was this change tested? 🤨

CI


# Does your change introduce accessibility violations? 🩺

Manual screen reader review


