### PR TITLE
Improve accessibility of simpledatatable display(s)

### DIFF
--- a/app/components/collections/works_component.html.erb
+++ b/app/components/collections/works_component.html.erb
@@ -5,7 +5,7 @@
       <th><span class="visually-hidden"><%= I18n.t "collection.actions" %></span></th>
       <th width="10%"><%= I18n.t "collection.owner" %></th>
       <th><%= I18n.t "collection.deposit_status" %></th>
-      <th data-type="date" data-format="MMM D, YYYY"><%= I18n.t "collection.last_modified" %></th>
+      <th data-type="date" data-format="MMM D, YYYY" aria-sort="descending"><%= I18n.t "collection.last_modified" %></th>
       <th><%= I18n.t "collection.number_of_files" %></th>
       <th><%= I18n.t "collection.deposit_size" %></th>
       <th><%= I18n.t "collection.persistent_link" %></th>

--- a/app/javascript/controllers/datatable_works_controller.js
+++ b/app/javascript/controllers/datatable_works_controller.js
@@ -41,6 +41,15 @@ export default class extends Controller {
       searchInput.insertAdjacentHTML("afterend", '<label for="dataTable-search" class="visually-hidden">Search for works</label>')
     })
 
+    dt.on('datatable.init', () => {
+      applyTablePaginationLabels()
+      // }
+    })
+
+    dt.on('datatable.update', () => {
+      applyTablePaginationLabels()
+    })
+
     dt.on('datatable.sort', function(column, direction) {
       const searchColHeader = document.querySelector("table.dataTable-table > thead > tr")
 
@@ -52,6 +61,29 @@ export default class extends Controller {
           searchColHeader.cells[i].removeAttribute("aria-sort")
         }
       }
+
+      // Make sure the table maintains focus when interacting with sort
+      const tableElement = document.querySelector("table.dataTable-table")
+      tableElement.focus()
     })
   }
 }
+
+function applyTablePaginationLabels() {
+  const paginationList = document.querySelectorAll("ul.dataTable-pagination-list > li > a")
+  for (var i = 0; i < paginationList.length; i++) {
+    // If the text of the page link is a number, set the label to "Go to {page}
+    // else if the first button set "Go to previous page" else set "Go to next page"
+    var value = Number(paginationList[i].text);
+    if (Math.floor(value) == value) {
+      paginationList[i].setAttribute("aria-label", "Go to page " + value)
+    } else {
+      if (i == 0) {
+        paginationList[i].setAttribute("aria-label", "Go to previous page")
+      } else {
+        paginationList[i].setAttribute("aria-label", "Go to next page")
+      }
+    }
+  }
+}
+

--- a/app/javascript/controllers/datatable_works_controller.js
+++ b/app/javascript/controllers/datatable_works_controller.js
@@ -40,5 +40,18 @@ export default class extends Controller {
       searchInput.setAttribute("id", "dataTable-search")
       searchInput.insertAdjacentHTML("afterend", '<label for="dataTable-search" class="visually-hidden">Search for works</label>')
     })
+
+    dt.on('datatable.sort', function(column, direction) {
+      const searchColHeader = document.querySelector("table.dataTable-table > thead > tr")
+
+      for (var i = 0; i < searchColHeader.cells.length; i++) {
+        var dir = direction == "asc" ? "ascending" : "descending"
+        if (i == column) {
+          searchColHeader.cells[i].setAttribute("aria-sort", dir)
+        } else {
+          searchColHeader.cells[i].removeAttribute("aria-sort")
+        }
+      }
+    })
   }
 }


### PR DESCRIPTION
# Why was this change made? 🤔

This fixes 3 accessibility issues reported by SODA:

1 - This add the `aria-sort` value to the sorted column of the table and removes it from any other column (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort)
2 - Sets the document focus to the table when sort is clicked as it currently loses focus to somewhere else on the screen confusing screen reader users
3 - It sets `aria-label` properties on the paging buttons when the page is loaded or refreshed (needed if the number of objects per page or search changes the number of pages in the table) so that screen readers get meaningful information such as "go to next page"

# How was this change tested? 🤨

Manually using a screen reader

# Does your change introduce accessibility violations? 🩺

No - it improves three major issues reported by SODA


