### PR TITLE
Revert wording on deposit for license and terms

### DIFF
--- a/app/components/works/license_component.html.erb
+++ b/app/components/works/license_component.html.erb
@@ -1,5 +1,5 @@
 <section id="license">
-  <h2 class="h5 fw-bold">License *</h2>
+  <h2 class="h5 fw-bold">Terms of use and license *</h2>
   <% if user_can_set_license? %>
     <div class="mb-3 row">
       <div class="col-sm-2">


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3348 

Reverts wording change that resulted from a conflict between the existing form and the mock up.

# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



