### PR TITLE
Disable cite link when not deposited

### DIFF
--- a/app/components/citation_component.rb
+++ b/app/components/citation_component.rb
@@ -7,11 +7,13 @@ class CitationComponent < ApplicationComponent
   end
 
   def call
+    link_class = disabled? ? "citation-button disabled" : "citation-button"
+
     attrs = {
-      data: data_attributes, class: "citation-button", "aria-label": aria_label, href: "#citationModal", id: citation_link_id
+      data: data_attributes, class: link_class, "aria-label": aria_label, href: "#citationModal", id: citation_link_id
     }
 
-    attrs[:disabled] = work_version.first_draft? || work_version.purl_reserved?
+    attrs[:disabled] = disabled?
 
     tag.a(**attrs) do
       # It's a SafeBuffer, not a String
@@ -41,5 +43,9 @@ class CitationComponent < ApplicationComponent
 
   def citation_link_id
     "get-citation-#{work_version.id}"
+  end
+
+  def disabled?
+    work_version.first_draft? || work_version.purl_reserved?
   end
 end


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3350 

![Screenshot 2023-08-09 at 1 16 04 PM](https://github.com/sul-dlss/happy-heron/assets/2294288/f6d8a5b5-4d99-42da-8ea6-3bfb82c2db0f)

The citation (`cite`) links were initially button types but were switched to anchors for accessibility, this changed the method of disabling.

# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



