### PR TITLE
Improve dev server logging around the debugger

### DIFF
--- a/config/initializers/byebug.rb
+++ b/config/initializers/byebug.rb
@@ -1,17 +1,25 @@
 # frozen_string_literal: true
 
-if Rails.env.development? && ENV.fetch("REMOTE_DEBUGGER", nil) == "byebug"
-  require "byebug/core"
+return unless Rails.env.development?
 
-  debugger_host = ENV.fetch("DEBUGGER_HOST", "localhost")
-  debugger_port = ENV.fetch("DEBUGGER_PORT", 8989).to_i
+debugger = ENV.fetch("REMOTE_DEBUGGER", nil)
+# Using `Rails.logger` won't output the messages below to stdout (e.g., as returned from `bin/dev`)
+logger = ActiveSupport::Logger.new($stdout)
 
-  # rubocop:disable Layout/LineLength
-  begin
-    Byebug.start_server(debugger_host, debugger_port)
-  rescue Errno::EADDRINUSE
-    Rails.logger.error("Debugger already running on #{debugger_host}:#{debugger_port}! Change `DEBUGGER_HOST` and/or `DEBUGGER_PORT` and try again.")
-  end
-  # rubocop:enable Layout/LineLength
+# byebug is the only remote debugger we support at the moment
+return if debugger.blank?
 
+abort("Debugger not supported: #{debugger}") unless debugger == "byebug"
+
+require "byebug/core"
+debugger_host = ENV.fetch("DEBUGGER_HOST", "localhost")
+debugger_port = ENV.fetch("DEBUGGER_PORT", 8989).to_i
+
+begin
+  # Include a useful message in server output
+  logger.info("Starting #{debugger}...")
+  Byebug.start_server(debugger_host, debugger_port)
+  logger.info("You may now connect to #{debugger} via: bundle exec #{debugger} -R #{debugger_host}:#{debugger_port}")
+rescue Errno::EADDRINUSE
+  abort("#{debugger} already running on #{debugger_host}:#{debugger_port}! Change DEBUGGER_HOST and/or DEBUGGER_PORT and try again.")
 end


### PR DESCRIPTION
# Why was this change made? 🤔

This commit tweaks the byebug initializer which allows using the byebug gem as a remote debugger, which is how we use byebug in H2 in development, by fixing the logging already in place and adding more helpful logging. This is a "quality of life" change for developers only.

# How was this change tested? 🤨

CI, local

# Does your change introduce accessibility violations? 🩺

No
