### PR TITLE
Do not provide file upload option when too many files.

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -10,36 +10,44 @@
   <fieldset>
     <legend class="visually-hidden">Add or modify files</legend>
     <div class="form-check" data-complex-radio-target="selection">
-      <%= form.radio_button :upload_type, "browser", class: "form-check-input", "data-file-uploads-target": "browserRadioButton",
-            data: {action: "complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus"} %>
-      <%= form.label :upload_type_browser, "Upload fewer than 250 files (total less than 10 GB) to be displayed as a flat list of files.", class: "form-check-label fw-semibold" %>
-      <div id="uploaded-files-panel" data-file-uploads-target="fileUploads">
-        <div data-controller="dropzone" data-dropzone-max-file-size="10000" data-dropzone-max-files="250" data-dropzone-previews-container=".dropzone-files-previews">
-          <fieldset>
-            <div class="dropzone dropzone-default" data-dropzone-target="container">
-              <%= form.file_field :files, multiple: true, direct_upload: true, namespace: "flat_list", "aria-label": "Upload files",
-                    data: {dropzone_target: "input"} %>
-              <div class="dz-message needsclick text-secondary">
-                <p>Drop files here</p>
+      <% if browser_option? %>
+        <%= form.radio_button :upload_type, "browser", class: "form-check-input", "data-file-uploads-target": "browserRadioButton",
+              data: {action: "complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus"} %>
+        <%= form.label :upload_type_browser, "Upload fewer than 250 files (total less than 10 GB) to be displayed as a flat list of files.", class: "form-check-label fw-semibold" %>
+        <div id="uploaded-files-panel" data-file-uploads-target="fileUploads">
+          <div data-controller="dropzone" data-dropzone-max-file-size="10000" data-dropzone-max-files="250" data-dropzone-previews-container=".dropzone-files-previews">
+            <fieldset>
+              <div class="dropzone dropzone-default" data-dropzone-target="container">
+                <%= form.file_field :files, multiple: true, direct_upload: true, namespace: "flat_list", "aria-label": "Upload files",
+                      data: {dropzone_target: "input"} %>
+                <div class="dz-message needsclick text-secondary">
+                  <p>Drop files here</p>
+                </div>
               </div>
-            </div>
-            <span style="margin: .7rem">or</span> <button type="button" class="dz-clickable btn btn-outline-primary">Choose files</button>
-            <div class="invalid-feedback" data-dropzone-target="feedback">You must attach a file<%= error_message %></div>
-            <div class="dropzone-previews dropzone-files-previews" data-dropzone-target="previewsContainer">
-            </div>
-            <div class="files-list">
-              <%= render Works::Edit::FilesComponent.new(work_version: form.object.model[:work_version], form:) %>
-            </div>
-          </fieldset>
+              <span style="margin: .7rem">or</span> <button type="button" class="dz-clickable btn btn-outline-primary">Choose files</button>
+              <div class="invalid-feedback" data-dropzone-target="feedback">You must attach a file<%= error_message %></div>
+              <div class="dropzone-previews dropzone-files-previews" data-dropzone-target="previewsContainer">
+              </div>
+              <div class="files-list">
+                <%= render Works::Edit::FilesComponent.new(work_version: form.object.model[:work_version], form:) %>
+              </div>
+            </fieldset>
 
-          <template data-dropzone-target='template'>
-            <%= form.fields_for :attached_files, AttachedFile.new, child_index: "TEMPLATE_RECORD" do |file_form| %>
-              <%= render Works::Edit::FileRowComponent.new(form: file_form) %>
-            <% end %>
-          </template>
+            <template data-dropzone-target='template'>
+              <%= form.fields_for :attached_files, AttachedFile.new, child_index: "TEMPLATE_RECORD" do |file_form| %>
+                <%= render Works::Edit::FileRowComponent.new(form: file_form) %>
+              <% end %>
+            </template>
+          </div>
         </div>
       </div>
-    </div>
+    <% else %>
+      <p style="color: var(--stanford-warning);">
+        <strong>
+          You have more than 250 files in your deposit. You can either upload a zip file with all your files or upload them via Globus.
+        </strong>
+      </p>
+    <% end %>
     <div class="form-check pt-3" data-complex-radio-target="selection">
       <%= form.radio_button :upload_type, "zipfile", class: "form-check-input",
             data: {action: "complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus", file_uploads_target: "zipRadioButton"} %>

--- a/app/components/works/add_files_component.rb
+++ b/app/components/works/add_files_component.rb
@@ -13,6 +13,10 @@ module Works
       form.object.attached_files.any?
     end
 
+    def browser_option?
+      form.object.attached_files.length <= 250
+    end
+
     def error?
       errors.present?
     end

--- a/spec/components/works/add_files_component_spec.rb
+++ b/spec/components/works/add_files_component_spec.rb
@@ -42,4 +42,14 @@ RSpec.describe Works::AddFilesComponent do
       expect(rendered.to_html).not_to include("Check this box once all your files have completed uploading to Globus.")
     end
   end
+
+  context "when more than 250 files" do
+    let(:work_version) { build(:work_version, work:, attached_files: attached_files) }
+    let(:attached_files) { [].tap { |af| 300.times { af << build(:attached_file) } } }
+
+    it "show message and does not show upload section" do
+      expect(rendered.to_html).to include("You have more than 250 files in your deposit.")
+      expect(rendered.to_html).not_to include("Upload fewer than 250 files")
+    end
+  end
 end


### PR DESCRIPTION
closes #3352

# Why was this change made? 🤔
The browser upload section does not function well with too many files.


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Local, unit

<img width="1225" alt="image" src="https://github.com/sul-dlss/happy-heron/assets/588335/4834f344-a81a-4791-a4ec-dd7cd46a75d5">


# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡

Tested with SiteImprove plugin.



