### PR TITLE
Do not add spurious file event messages.

### DIFF
--- a/app/services/work_version_event_description_builder.rb
+++ b/app/services/work_version_event_description_builder.rb
@@ -151,7 +151,7 @@ class WorkVersionEventDescriptionBuilder
     destroyed = attributes.values.any? { |params| params["_destroy"] == "1" }
 
     # we don't want description changes to cause an "added new file" message
-    added = form.attached_files.any? { |af| af.changed?("_destroy") }
+    added = form.attached_files.any? { |af| !af.persisted? }
 
     return unless added || destroyed
 

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -400,7 +400,7 @@ RSpec.describe "Create a new work" do
           last_event = Work.last.events.last
           expect(last_event.event_type).to eq "update_metadata"
           changes = ["title of deposit modified", "abstract modified", "contact email modified", "authors modified",
-            "keywords modified", "visibility modified", "license modified", "files added/removed",
+            "keywords modified", "visibility modified", "license modified",
             "file description changed"]
           expect(last_event.description).to eq changes.join(", ")
         end


### PR DESCRIPTION
closes #3355

# Why was this change made? 🤔
Avoid spurious event messages.


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Local, Amy

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



