### PR TITLE
add some info the logs on groups passed in via headers for debugging

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,7 +44,7 @@ class ApplicationController < ActionController::Base
       raw_header = roles if Rails.env.development?
       # This test setting is for cypress.
       raw_header = roles if Rails.env.test? && roles
-      logger.debug("Roles are #{raw_header}")
+      logger.info("Rails Env: #{Rails.env}; User: #{current_user}; Roles: #{raw_header}")
       raw_header&.split(";") || []
     end
   end


### PR DESCRIPTION
# Why was this change made? 🤔

To investigate #3377

While we currently log roles coming from the header, it's at the "debug" level, which means it will never log in production/stage/QA.  This may help figure out what's going on.


# How was this change tested? 🤨

QA