### PR TITLE
Preserve files when creating / updating a work version with > 250 files.

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -13,9 +13,9 @@
       <% if browser_option? %>
         <%= form.radio_button :upload_type, "browser", class: "form-check-input", "data-file-uploads-target": "browserRadioButton",
               data: {action: "complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus"} %>
-        <%= form.label :upload_type_browser, "Upload fewer than 250 files (total less than 10 GB) to be displayed as a flat list of files.", class: "form-check-label fw-semibold" %>
+        <%= form.label :upload_type_browser, "Upload fewer than #{max_upload_files} files (total less than 10 GB) to be displayed as a flat list of files.", class: "form-check-label fw-semibold" %>
         <div id="uploaded-files-panel" data-file-uploads-target="fileUploads">
-          <div data-controller="dropzone" data-dropzone-max-file-size="10000" data-dropzone-max-files="250" data-dropzone-previews-container=".dropzone-files-previews">
+          <div data-controller="dropzone" data-dropzone-max-file-size="10000" data-dropzone-max-files="<%= max_upload_files %>" data-dropzone-previews-container=".dropzone-files-previews">
             <fieldset>
               <div class="dropzone dropzone-default" data-dropzone-target="container">
                 <%= form.file_field :files, multiple: true, direct_upload: true, namespace: "flat_list", "aria-label": "Upload files",
@@ -44,7 +44,7 @@
     <% else %>
       <p style="color: var(--stanford-warning);">
         <strong>
-          You have more than 250 files in your deposit. You can either upload a zip file with all your files or upload them via Globus.
+          You have more than <%= max_upload_files %> files in your deposit. You can either upload a zip file with all your files or upload them via Globus.
         </strong>
       </p>
     <% end %>

--- a/app/components/works/add_files_component.rb
+++ b/app/components/works/add_files_component.rb
@@ -9,12 +9,16 @@ module Works
 
     attr_reader :form
 
+    def max_upload_files
+      Settings.max_upload_files
+    end
+
     def has_attached_files?
       form.object.attached_files.any?
     end
 
     def browser_option?
-      form.object.attached_files.length <= 250
+      form.object.attached_files.length <= max_upload_files
     end
 
     def error?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -125,3 +125,5 @@ dor_services:
   token: secret-token
 
 workflow_url: 'https://workflow.example.com/workflow'
+
+max_upload_files: 250


### PR DESCRIPTION
closes #3392

# Why was this change made? 🤔
Per ticket.


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Local, stage

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



