### PR TITLE
ask globus to NOT send the user an email when creating new globus endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,7 +300,7 @@ GEM
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    globus_client (0.13.0)
+    globus_client (0.14.0)
       activesupport (>= 4.2, < 8)
       faraday
       faraday-retry
@@ -746,4 +746,4 @@ DEPENDENCIES
   zipline (~> 1.4)
 
 BUNDLED WITH
-   2.4.20
+   2.4.14

--- a/app/jobs/globus_setup_job.rb
+++ b/app/jobs/globus_setup_job.rb
@@ -58,7 +58,7 @@ class GlobusSetupJob < ApplicationJob
     return true if test_mode?
     return true if integration_test_mode? && path == integration_endpoint
 
-    GlobusClient.mkdir(user_id: user.email, path:)
+    GlobusClient.mkdir(user_id: user.email, path:, notify_email: false)
   end
 
   # simulate globus calls in development if settings indicate we should for testing

--- a/spec/jobs/globus_setup_job_spec.rb
+++ b/spec/jobs/globus_setup_job_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe GlobusSetupJob do
           expect { described_class.perform_now(work_version) }.to have_enqueued_job(ActionMailer::MailDeliveryJob)
             .with("WorksMailer", "globus_endpoint_created", "deliver_now",
               {params: {user:, work_version:}, args: []})
-          expect(GlobusClient).to have_received(:mkdir)
+          expect(GlobusClient).to have_received(:mkdir).with(user_id: user.email, path: work_version.globus_endpoint, notify_email: false)
           work_version.reload
           expect(work_version.state).to eq "first_draft"
         end


### PR DESCRIPTION
# Why was this change made? 🤔

We already send the user an email when we create a new Globus endpoint for them - and the email they get from Globus is not as helpful.  The Globus API allows us to skip sending this email and the new globus_client (0.14.0) enables this functionality.  This PR should stop the globus email from being sent (by Globus) when we create a new endpoint.

~~HOLD to test and verify with PO~~

Verified with PO

# How was this change tested? 🤨

Updated specs, tested on QA