### PR TITLE
Skip deposit completion for objects lacking druids

### DIFF
--- a/app/services/deposit_complete_auditor.rb
+++ b/app/services/deposit_complete_auditor.rb
@@ -7,7 +7,7 @@ class DepositCompleteAuditor
 
   def execute
     depositing_objects.each do |object|
-      next if accessioning?(object)
+      next if object.druid.blank? || accessioning?(object)
 
       Honeybadger.notify("Object is still in depositing state, but accessioning is complete", context: {druid: object.druid, version: object.head.version})
       Rails.logger.info("Object is still in depositing state, but accessioning is complete: #{object.druid}")


### PR DESCRIPTION
On hold 'til J-Litt has time to do some analysis to determine if this is a legit situation or a weird data corner case. I'm throwing up a quick HOLD PR at the end of my day so J-Litt can take a gander in the morning. Yay timezones.

# Why was this change made?

They are waiting on a druid assignment and we cannot ask the Workflow service if they are accessioned or not until they have a druid. This bug was revealed in a cronjob today.

# How was this change tested?

CI
