### PR TITLE
Fix bug in DepositCompleteAuditor

### DIFF
--- a/spec/services/deposit_complete_auditor_spec.rb
+++ b/spec/services/deposit_complete_auditor_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe DepositCompleteAuditor do
     allow(Dor::Workflow::Client).to receive(:new).and_return(workflow_client)
     allow(Honeybadger).to receive(:notify)
     allow(DepositCompleter).to receive(:complete)
-    allow(workflow_client).to receive(:active_lifecycle)
-      .with(druid: object.druid, milestone_name: "submitted", version: object.head.version.to_s)
-      .and_return(active_lifecycle_value)
+    allow(workflow_client).to receive(:status)
+      .with(druid: object.druid, version: object.head.version.to_s)
+      .and_return(instance_double(Dor::Workflow::Client::Status, display_simplified: status))
   end
 
   context "with a work still going through accessioning" do
-    let(:active_lifecycle_value) { Time.now }
+    let(:status) { "In accessioning (described)" }
     let(:object) { create(:work_version_with_work_and_collection, state: :depositing, druid: "druid:bc123df4567").work }
 
     it "skips calling DepositCompleter and notifying Honeybadger" do
@@ -27,7 +27,29 @@ RSpec.describe DepositCompleteAuditor do
   end
 
   context "with a collection still going through accessioning" do
-    let(:active_lifecycle_value) { Time.now }
+    let(:status) { "In accessioning (described, published, deposited)" }
+    let(:object) { create(:collection_version_with_collection, state: :depositing, collection_druid: "druid:bc123df4569").collection }
+
+    it "skips calling DepositCompleter and notifying Honeybadger" do
+      described_class.execute
+      expect(DepositCompleter).not_to have_received(:complete)
+      expect(Honeybadger).not_to have_received(:notify)
+    end
+  end
+
+  context "with a work not yet going through accessioning" do
+    let(:status) { "Registered" }
+    let(:object) { create(:work_version_with_work_and_collection, state: :depositing, druid: "druid:bc123df4567").work }
+
+    it "skips calling DepositCompleter and notifying Honeybadger" do
+      described_class.execute
+      expect(DepositCompleter).not_to have_received(:complete)
+      expect(Honeybadger).not_to have_received(:notify)
+    end
+  end
+
+  context "with a collection not yet going through accessioning" do
+    let(:status) { "Registered" }
     let(:object) { create(:collection_version_with_collection, state: :depositing, collection_druid: "druid:bc123df4569").collection }
 
     it "skips calling DepositCompleter and notifying Honeybadger" do
@@ -38,7 +60,7 @@ RSpec.describe DepositCompleteAuditor do
   end
 
   context "with an accessioned work" do
-    let(:active_lifecycle_value) { nil }
+    let(:status) { "Accessioned" }
     let(:object) { create(:work_version_with_work_and_collection, state: :depositing, druid: "druid:bc123df4568").work }
 
     it "calls DepositCompleter and notifies Honeybadger" do
@@ -49,7 +71,7 @@ RSpec.describe DepositCompleteAuditor do
   end
 
   context "with an accessioned collection" do
-    let(:active_lifecycle_value) { nil }
+    let(:status) { "Accessioned" }
     let(:object) { create(:collection_version_with_collection, state: :depositing, collection_druid: "druid:bc123df4560").collection }
 
     it "calls DepositCompleter and notifies Honeybadger" do
@@ -60,7 +82,8 @@ RSpec.describe DepositCompleteAuditor do
   end
 
   context "with a work not yet assigned a druid" do
-    let(:active_lifecycle_value) { nil }
+    # The code doesn't check the status if the druid is blank, so the value here shouldn't really matter
+    let(:status) { "Unknown Status" }
     let(:object) { create(:work_version_with_work_and_collection, state: :depositing, druid: nil).work }
 
     before do
@@ -76,7 +99,8 @@ RSpec.describe DepositCompleteAuditor do
   end
 
   context "with a collection not yet assigned a druid" do
-    let(:active_lifecycle_value) { nil }
+    # The code doesn't check the status if the druid is blank, so the value here shouldn't really matter
+    let(:status) { "Unknown Status" }
     let(:object) { create(:collection_version_with_collection, state: :depositing, collection_druid: nil).collection }
 
     before do


### PR DESCRIPTION
# Why was this change made?

This commit fixes a bug in the DepositCompleteAuditor where the auditor will mark an object as deposited when in fact it is only `Registered` in SDR. The change made: instead of checking if an object is in accessioning, check that is has not yet been accessioned.

# How was this change tested?

- [x] CI
- [x] prod console commands
