### PR TITLE
Handle unauthenticated access in `PreservationController#show`

### DIFF
--- a/app/controllers/preservation_controller.rb
+++ b/app/controllers/preservation_controller.rb
@@ -4,7 +4,7 @@
 class PreservationController < ApplicationController
   include ActionController::Live # required for streaming
 
-  before_action :authenticate_user!
+  # Authentication is done in the routes for reasons explained there.
   verify_authorized
 
   # rubocop:disable Metrics/AbcSize

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,17 @@ Rails.application.routes.draw do
   end
 
   resource :profile, only: :show
-  resources :preservation, only: :show
+
+  # Must authenticate on routes for authentication to work with
+  # ActionController::Live-based controllers, else Warden raises an
+  # UncaughtThrowError:
+  #
+  # https://app.honeybadger.io/projects/77112/faults/98674411/
+  #
+  # Workaround suggested by Devise maintainers: https://github.com/heartcombo/devise/issues/2332#issuecomment-15083116
+  authenticate :user do
+    resources :preservation, only: :show
+  end
 
   namespace :admin do
     resources :druid_searches, only: :index

--- a/spec/requests/preservation_spec.rb
+++ b/spec/requests/preservation_spec.rb
@@ -3,13 +3,16 @@
 require "rails_helper"
 
 RSpec.describe "Retrieve a file from preservation" do
-  describe "GET" do
-    let(:work_version) { create(:work_version) }
-    let(:attached_file) { create(:attached_file, :with_file, work_version:) }
-    let(:body) { "All happy families are alike, but every unhappy family is unhappy in its own way" }
+  let(:work_version) { create(:work_version) }
+  let(:attached_file) { create(:attached_file, :with_file, work_version:) }
+  let(:body) { "All happy families are alike, but every unhappy family is unhappy in its own way" }
 
+  before do
+    work_version.work.update(druid: "druid:bb111bb1111")
+  end
+
+  context "with authenticated, authorized user" do
     before do
-      work_version.work.update(druid: "druid:bb111bb1111")
       sign_in(work_version.work.owner)
 
       stub_request(:get, "https://preservation-catalog-stage-01.stanford.edu/v1/objects/druid:bb111bb1111/file?category=content&filepath=sul.svg&version=1")
@@ -21,10 +24,34 @@ RSpec.describe "Retrieve a file from preservation" do
         .to_return(status: 200, body:, headers: {})
     end
 
-    it "is successful" do
+    it "gets the expected file" do
       get "/preservation/#{attached_file.id}"
       expect(response).to have_http_status(:ok)
       expect(response.body).to eq body
+    end
+  end
+
+  context "with authenticated, unauthorized user" do
+    let(:unauthorized_user) { create(:user) }
+
+    before do
+      sign_in(unauthorized_user)
+    end
+
+    it "redirects to the root URL" do
+      get "/preservation/#{attached_file.id}"
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "with unauthenticated user" do
+    before do
+      sign_out
+    end
+
+    it "redirects to the login URL" do
+      get "/preservation/#{attached_file.id}"
+      expect(response).to redirect_to(new_user_session_path)
     end
   end
 end


### PR DESCRIPTION
# Why was this change made?

This commit resolves an outstanding issue between Devise/Warden and ActionController::Live where unauthenticated users wind up raising an UncaughtThrowError exception.

# How was this change tested? 🤨

- [x] CI
- [x] QA/stage
