### PR TITLE
Allow metadata-only deposits without draft-saving

### DIFF
--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -7,7 +7,13 @@ class WorkForm < BaseWorkForm
   validates :abstract, :access, :title, presence: true, allow_nil: false
   validates :keywords, length: {minimum: 1, message: "Please add at least one keyword."}
   validates :attached_files, length: {minimum: 1, message: "Please add at least one file."},
-    if: -> { %w[browser zip].include?(upload_type) }
+    if: -> do
+      if work.head
+        %w[browser zip].include?(upload_type) && work.head.attached_files.none?
+      else
+        %w[browser zip].include?(upload_type)
+      end
+    end
   validates :contact_emails, length: {minimum: 1, message: "Please add at least contact email."}
   validates :license, presence: true, inclusion: {in: License.license_list}
   validates :authors, length: {minimum: 1, message: "Please add at least one author."}

--- a/spec/features/update_existing_work_spec.rb
+++ b/spec/features/update_existing_work_spec.rb
@@ -73,7 +73,11 @@ RSpec.describe "Update an existing work in a deposited collection", js: true do
       fill_in "Title of deposit", with: new_title
       fill_in "Abstract", with: "I did really cool stuff"
 
-      click_button "Save as draft"
+      click_button "Deposit"
+
+      expect(page).to have_content("You have successfully deposited your work")
+
+      visit work_path(work_version.work)
 
       # work detail page has new title
       expect(page).to have_content(new_title)


### PR DESCRIPTION
# Why was this change made?

Fixes #3397

# How was this change tested?

- [x] CI
- [x] `spec/features/mediated_deposit_versioning_spec.rb` (failing locally)
- [x] QA/stage
