### PR TITLE
Allow linebreaks and display them in custom terms of use

### DIFF
--- a/app/components/collections/terms_of_use_component.html.erb
+++ b/app/components/collections/terms_of_use_component.html.erb
@@ -13,7 +13,7 @@
     </tr>
     <tr>
       <th class="col-3">Additional terms of use</th>
-      <td><%= collection_custom_rights_summary %></td>
+      <td><%= simple_format collection_custom_rights_summary, class: "mb-3" %></td>
     </tr>
     <% if allow_custom_rights_statement? && custom_rights_statement_source_option == "entered_by_depositor" %>
       <tr>

--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -210,7 +210,7 @@
     </tr>
     <tr>
       <th class="col-3" scope="row">Additional terms of use</th>
-      <td><%= custom_rights %></td>
+      <td><%= simple_format custom_rights, class: "mb-3" %></td>
     </tr>
     </tbody>
   </table>

--- a/app/components/works/license_component.html.erb
+++ b/app/components/works/license_component.html.erb
@@ -46,11 +46,10 @@
       <div class="col-sm-2"></div>
       <div class="col-sm-8">
         <% if collection.provided_custom_rights_statement %>
-          <p><%= collection.provided_custom_rights_statement %></p>
+          <%= simple_format collection.provided_custom_rights_statement %>
           <%= form.hidden_field :custom_rights, value: collection.provided_custom_rights_statement %>
         <% else %>
-          <%= form.text_area :custom_rights, class: "form-control",
-                data: {action: "no-newlines#change", no_newlines_target: "input", controller: "no-newlines"} %>
+          <%= form.text_area :custom_rights, class: "form-control", aria: {label: "Additional terms of use"} %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
# Why was this change made? 🤔
Resolves #3417 to support terms formatting that also displays in Purl. 

# How was this change tested? 🤨
Local dev. Deployed to QA and reviewed by Amy. Added `simple_format` to an additional view as a result.

# Does your change introduce accessibility violations? 🩺
No new accessibility issues. 
