### PR TITLE
block all bots except on homepage

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,6 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+# Block all bots, except on the home page
+
+User-agent: *
+Allow: /$
+Disallow: /


### PR DESCRIPTION
# Why was this change made? 🤔

Bots have no purpose on H2, which is all behind auth, but can cause problems (like this: https://app.honeybadger.io/projects/77112/faults/100514724)

We still allow the homepage though since that is open to the world and useful to have in search engines.
