### PR TITLE
Additional logging for assign_pid_job.

### DIFF
--- a/app/jobs/assign_pid_job.rb
+++ b/app/jobs/assign_pid_job.rb
@@ -31,6 +31,7 @@ class AssignPidJob
         Collection.find(unprefixed.delete_prefix("collection-"))
       end
 
+      Rails.logger.info("Assigning #{args[:druid]} to #{unprefixed}")
       object.update(args)
 
       return unless object.is_a? Work


### PR DESCRIPTION
refs #3297

# Why was this change made? 🤔
To attempt to troubleshoot probable race condition between assigning druid and completing deposit.


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



