### PR TITLE
prevent zip job from getting stuck

### DIFF
--- a/spec/jobs/unzip_job_spec.rb
+++ b/spec/jobs/unzip_job_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe UnzipJob do
   let(:attached_file2) { build(:attached_file) }
   let(:zip_attached_file) { build(:attached_file) }
 
-  let(:blob) { instance_double(ActiveStorage::Blob, key: '123') }
   let(:work) { build(:work) }
   let(:zip_path) { 'tmp/folder3.zip' }
 
@@ -23,14 +22,34 @@ RSpec.describe UnzipJob do
     work.update!(head: first_work_version)
   end
 
-  it 'unzips the attached file' do
-    expect { described_class.perform_now(first_work_version) }
-      .to change { first_work_version.attached_files.count }.from(3).to(2)
-      .and change(first_work_version, :state).to('first_draft')
-      .and change(first_work_version, :upload_type).to('browser')
+  context 'when the attached file is a zip file' do
+    # simulate the attached file is actually a zip file
+    let(:blob) { instance_double(ActiveStorage::Blob, key: '123', content_type: 'application/zip') }
 
-    expect(ActiveStorage::Blob.service).to have_received(:path_for).with('123')
-    expect(AttachedFile.find_by(id: zip_attached_file.id)).to be_nil
-    expect(AttachedFile.find_by(id: attached_file1.id)).to be_nil
+    it 'unzips the attached file' do
+      expect { described_class.perform_now(first_work_version) }
+        .to change { first_work_version.attached_files.count }.from(3).to(2)
+        .and change(first_work_version, :state).to('first_draft')
+        .and change(first_work_version, :upload_type).to('browser')
+
+      expect(ActiveStorage::Blob.service).to have_received(:path_for).with('123')
+      expect(AttachedFile.find_by(id: zip_attached_file.id)).to be_nil # the zipped file is destroyed
+      expect(AttachedFile.find_by(id: attached_file1.id)).to be_nil # the attached file is destroyed
+    end
+  end
+
+  context 'when the attached file is not a zip file' do
+    # simulate the attached file is not a zip file
+    let(:blob) { instance_double(ActiveStorage::Blob, key: '123', content_type: 'image/svg+xml') }
+
+    it 'just reverts back to browser upload type' do
+      expect { described_class.perform_now(first_work_version) }
+        .to change(first_work_version, :state).to('first_draft')
+        .and change(first_work_version, :upload_type).to('browser')
+      expect(first_work_version.attached_files.count).to eq 3 # still three files
+      expect(ActiveStorage::Blob.service).not_to have_received(:path_for).with('123')
+      expect(AttachedFile.find_by(id: zip_attached_file.id)).to eq zip_attached_file # existing files are not touched
+      expect(AttachedFile.find_by(id: attached_file1.id)).to eq attached_file1
+    end
   end
 end

--- a/spec/jobs/unzip_job_spec.rb
+++ b/spec/jobs/unzip_job_spec.rb
@@ -22,34 +22,57 @@ RSpec.describe UnzipJob do
     work.update!(head: first_work_version)
   end
 
-  context 'when the attached file is a zip file' do
-    # simulate the attached file is actually a zip file
-    let(:blob) { instance_double(ActiveStorage::Blob, key: '123', content_type: 'application/zip') }
+  context 'when the attached file is on the file system' do
+    before { allow(zip_attached_file).to receive(:in_globus?).and_return(false) }
 
-    it 'unzips the attached file' do
-      expect { described_class.perform_now(first_work_version) }
-        .to change { first_work_version.attached_files.count }.from(3).to(2)
-        .and change(first_work_version, :state).to('first_draft')
-        .and change(first_work_version, :upload_type).to('browser')
+    context 'when the attached file is a zip file' do
+      # simulate the attached file is actually a zip file
+      let(:blob) { instance_double(ActiveStorage::Blob, key: '123', content_type: 'application/zip') }
 
-      expect(ActiveStorage::Blob.service).to have_received(:path_for).with('123')
-      expect(AttachedFile.find_by(id: zip_attached_file.id)).to be_nil # the zipped file is destroyed
-      expect(AttachedFile.find_by(id: attached_file1.id)).to be_nil # the attached file is destroyed
+      it 'unzips the attached file' do
+        expect { described_class.perform_now(first_work_version) }
+          .to change { first_work_version.attached_files.count }.from(3).to(2)
+          .and change(first_work_version, :state).to('first_draft')
+          .and change(first_work_version, :upload_type).to('browser')
+
+        expect(ActiveStorage::Blob.service).to have_received(:path_for).with('123')
+        expect(AttachedFile.find_by(id: zip_attached_file.id)).to be_nil # the zipped file is destroyed
+        expect(AttachedFile.find_by(id: attached_file1.id)).to be_nil # the attached file is destroyed
+      end
+    end
+
+    context 'when the attached file is not a zip file' do
+      # simulate the attached file is not a zip file
+      let(:blob) { instance_double(ActiveStorage::Blob, key: '123', content_type: 'image/svg+xml') }
+
+      it 'just reverts back to browser upload type' do
+        expect { described_class.perform_now(first_work_version) }
+          .to change(first_work_version, :state).to('first_draft')
+          .and change(first_work_version, :upload_type).to('browser')
+        expect(first_work_version.attached_files.count).to eq 3 # still three files
+        expect(ActiveStorage::Blob.service).not_to have_received(:path_for).with('123')
+        expect(AttachedFile.find_by(id: zip_attached_file.id)).to eq zip_attached_file # existing files are not touched
+        expect(AttachedFile.find_by(id: attached_file1.id)).to eq attached_file1
+      end
     end
   end
 
-  context 'when the attached file is not a zip file' do
-    # simulate the attached file is not a zip file
-    let(:blob) { instance_double(ActiveStorage::Blob, key: '123', content_type: 'image/svg+xml') }
+  context 'when the attached file is in globus' do
+    before { allow(zip_attached_file).to receive(:in_globus?).and_return(true) }
 
-    it 'just reverts back to browser upload type' do
-      expect { described_class.perform_now(first_work_version) }
-        .to change(first_work_version, :state).to('first_draft')
-        .and change(first_work_version, :upload_type).to('browser')
-      expect(first_work_version.attached_files.count).to eq 3 # still three files
-      expect(ActiveStorage::Blob.service).not_to have_received(:path_for).with('123')
-      expect(AttachedFile.find_by(id: zip_attached_file.id)).to eq zip_attached_file # existing files are not touched
-      expect(AttachedFile.find_by(id: attached_file1.id)).to eq attached_file1
+    context 'when the attached file is a zip file' do
+      # simulate the attached file is actually a zip file
+      let(:blob) { instance_double(ActiveStorage::Blob, key: '123', content_type: 'application/zip') }
+
+      it 'just reverts back to browser upload type' do
+        expect { described_class.perform_now(first_work_version) }
+          .to change(first_work_version, :state).to('first_draft')
+          .and change(first_work_version, :upload_type).to('browser')
+        expect(first_work_version.attached_files.count).to eq 3 # still three files
+        expect(ActiveStorage::Blob.service).not_to have_received(:path_for).with('123')
+        expect(AttachedFile.find_by(id: zip_attached_file.id)).to eq zip_attached_file # existing files are not touched
+        expect(AttachedFile.find_by(id: attached_file1.id)).to eq attached_file1
+      end
     end
   end
 end


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3454 -- the Unzip job should not do anything unless the last uploaded file is actually a ZIP file and is on the file system (i.e. not from Globus)

~~Hold for PO verification~~

# How was this change tested? 🤨

Localhost, stage and new spec