### PR TITLE
Fix display of collection move event

### DIFF
--- a/app/controllers/work_move_controller.rb
+++ b/app/controllers/work_move_controller.rb
@@ -34,7 +34,7 @@ class WorkMoveController < ApplicationController
         collection.save!
         work.update!(collection:)
         work.events.create(user: current_user, event_type: 'collection_moved',
-                           description: "Moved to \"#{collection.head.description}\" collection")
+                           description: "Moved to \"#{collection.head.name}\" collection")
       end
       flash[:success] = "Moved #{work.head.title} to #{collection.head.name}"
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,7 +26,7 @@ en:
       unlock_work: Work unlocked
       decommission: Decommissioned
       no_review_workflow: Review no longer required
-      collection_moved: ''
+      collection_moved: Changed collection
       unzip: Starting unzip
       unzip_and_submit_for_review: Starting unzip
       unzip_and_begin_deposit: Starting unzip


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3462:

- The locale file was missing a description of the collection moved event, I set it to "Changed collection".  This will fix all history event displays once deployed.
- The name of the collection moved to in the event description was set to use the collection "description" field instead of the "name" (which is the title).  I changed it to use "name" going forward.  This will **not** fix previous entries unless we change them in the database manually for each event.

The reason it appeared to work OK for others is simply because the name and the description are sometimes very similar, e.g. 

"Undergraduate Theses, Materials Science and Engineering" == name/title
"Honors theses for undergraduates majoring in Materials Science and Engineering." == description

When done, go onto https://github.com/sul-dlss/happy-heron/issues/3464

# How was this change tested? 🤨

On Stage