### PR TITLE
show the browser upload radio even when more than max files uploaded

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -41,13 +41,18 @@
           </div>
         </div>
       </div>
-    <% else %>
-      <p style="color: var(--stanford-warning);">
-        <strong>
-          You have more than <%= max_upload_files %> files in your deposit. We can not display all of your files here, but if you need to make changes, select one of the two options below.
-        </strong>
-      </p>
-    <% end %>
+      <% else %>
+      <div class="form-check pt-3" data-complex-radio-target="selection">
+        <%= form.radio_button :upload_type, 'browser', class: 'form-check-input', 'data-file-uploads-target': 'browserRadioButton',
+                                                       data: { action: 'complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus' } %>
+        <%= form.label :upload_type_browser, "Keep the more than #{max_upload_files} files uploaded.", class: 'form-check-label fw-semibold' %>
+        <p style="color: var(--stanford-warning);">
+          <strong>
+            You have more than <%= max_upload_files %> files in your deposit. We can not display all of your files here, but if you need to make changes, select one of the two options below.
+          </strong>
+        </p>
+      </div>
+      <% end %>
     <div class="form-check pt-3" data-complex-radio-target="selection">
       <%= form.radio_button :upload_type, 'zipfile', class: 'form-check-input',
                                                      data: { action: 'complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus', file_uploads_target: 'zipRadioButton' } %>


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3465 

When a user uploads more than the max number of files in the browser (currently 250), we do not allow them to add more or show the list in the edit page.  We currently hide the entire browser upload panel, including the radio button.  This means if the user selects the zip upload option radio button (maybe by mistake), they cannot unselect it, which means they are stuck.  

This PR shows the radio button in this scenario with a different message, but without the ability to upload more files or show the file list (see below).  This makes it clear this is the default/current option, allows the user to change to globus or zip but also allows them to return to the "keep my lottsa files" option before saving.

![Screen Shot 2024-02-06 at 1 41 02 PM](https://github.com/sul-dlss/happy-heron/assets/47137/68785eb4-f928-484d-8575-891df9debe43)

~~HOLD for PO Testing~~

# How was this change tested? 🤨

Localhost, stage