### PR TITLE
Adds retries to deposit complete job.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   ruby-rails: sul-dlss/ruby-rails@4.1.0
-  browser-tools: circleci/browser-tools@1.4.0
+  browser-tools: circleci/browser-tools@1.4.8
   node: circleci/node@5.0.0
   ruby: circleci/ruby@1.8.0
   cypress: cypress-io/cypress@2.2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,10 @@ jobs:
           post-install:
             - run: sudo apt-get update
             - run: sudo apt-get install --fix-missing libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
-      - browser-tools/install-firefox
+      - browser-tools/install-firefox:
+          # Fixing the version of firefox since cypress won't run correctly with the latest.
+          # This can probably be removed once cypress is updated.
+          version: 115.9.0esr
       - node/install-packages:
           pkg-manager: yarn
       - run:

--- a/spec/jobs/deposit_complete_job_spec.rb
+++ b/spec/jobs/deposit_complete_job_spec.rb
@@ -11,8 +11,15 @@ RSpec.describe DepositCompleteJob do
     # An intentionally invalid druid so it does not collide with any test objects
     let(:message) { '{"druid":"druid:aa11ii1111"}' }
 
+    before do
+      allow(Work).to receive(:find_by).and_call_original
+      allow(Collection).to receive(:find_by!).and_call_original
+    end
+
     it 'acks the message (and does not raise)' do
       expect(run).to eq(:ack)
+      expect(Work).to have_received(:find_by).with(druid: 'druid:aa11ii1111').exactly(10).times
+      expect(Collection).to have_received(:find_by!).with(druid: 'druid:aa11ii1111').exactly(10).times
     end
   end
 


### PR DESCRIPTION
refs #3297

# Why was this change made? 🤔
Handle race condition between assigning a druid and marking a deposit as complete.


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



