### PR TITLE
Adjust retry strategy deposit complete job.

### DIFF
--- a/app/jobs/deposit_complete_job.rb
+++ b/app/jobs/deposit_complete_job.rb
@@ -17,29 +17,38 @@ class DepositCompleteJob
   FIND_SLEEP = 1
 
   # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   def work(msg)
     druid = parse_message(msg)
     Honeybadger.context(druid:)
     Rails.logger.info("Trying deposit complete on #{druid}")
 
-    # Without this, the database connection pool gets exhausted
-    ActiveRecord::Base.connection_pool.with_connection do
-      object = find_object(druid)
+    # There is a race condition whereby the druid may not yet have been assigned to the work / collection.
+    # Retries gives time for the druid to be assigned.
+    # See https://github.com/sul-dlss/happy-heron/issues/3297
+    # Retries are performed at this level so avoid holding onto a db connection.
+    begin
+      tries ||= 1
+      # Without this, the database connection pool gets exhausted
+      ActiveRecord::Base.connection_pool.with_connection do
+        object = Work.find_by(druid:) || Collection.find_by!(druid:)
 
-      unless object
-        Rails.logger.info("Not completing deposit for #{druid} since not found")
-        return ack!
+        Honeybadger.context(object: object.to_global_id.to_s)
+        Rails.logger.info("Deposit complete on #{druid}")
+
+        DepositCompleter.complete(object_version: object.head)
       end
-
-      Honeybadger.context(object: object.to_global_id.to_s)
-      Rails.logger.info("Deposit complete on #{druid}")
-
-      DepositCompleter.complete(object_version: object.head)
+    rescue ActiveRecord::RecordNotFound
+      if (tries += 1) <= FIND_TRIES
+        sleep(FIND_SLEEP)
+        retry
+      end
+      Rails.logger.info("Not completing deposit for #{druid} since not found")
     end
-
     ack!
   end
   # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
 
   def parse_message(msg)
     json = JSON.parse(msg)
@@ -47,22 +56,5 @@ class DepositCompleteJob
     return druid if druid.present?
 
     raise "Unable to find required field 'druid' in payload:\n\t#{json}"
-  end
-
-  def find_object(druid)
-    # There is a race condition whereby the druid may not yet have been assigned to the work / collection.
-    # Retries gives time for the druid to be assigned.
-    # See https://github.com/sul-dlss/happy-heron/issues/3297
-    object = nil
-    begin
-      tries ||= 1
-      object = Work.find_by(druid:) || Collection.find_by!(druid:)
-    rescue ActiveRecord::RecordNotFound
-      if (tries += 1) <= FIND_TRIES
-        sleep(FIND_SLEEP)
-        retry
-      end
-    end
-    object
   end
 end


### PR DESCRIPTION
closes #3489

# Why was this change made? 🤔
To avoid holding onto db connections and exhausting connection pool.


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit, integration

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



