### PR TITLE
Move the user version to the new WorkVersion

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -72,7 +72,9 @@ class WorksController < ObjectsController
     clean_params = orig_clean_params.deep_dup
 
     if work_version.deposited?
+      # Here we are moving the user_version from the previous WorkVersion to the head WorkVersion.
       work_version = create_new_version(work_version)
+      orig_work_version.update(user_version: nil)
       NewVersionParameterFilter.call(clean_params, work.head)
     end
 

--- a/app/services/new_version_service.rb
+++ b/app/services/new_version_service.rb
@@ -25,6 +25,7 @@ class NewVersionService
     new_version.version = old_version.version + 1 if increment_version
     new_version.version_description = version_description if version_description
     new_version.state = state if state
+    old_version.user_version = nil # Ensure user version is unique across all versions of the work
     yield new_version if block_given?
     perform_save if save
 
@@ -62,8 +63,9 @@ class NewVersionService
   def perform_save
     work = old_version.work
     work.transaction do
-      new_version.save!
-      work.update!(head_id: new_version.id)
+      old_version.save!
+      work.head = new_version
+      work.save!
     end
   end
 end

--- a/spec/factories/work_versions.rb
+++ b/spec/factories/work_versions.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
     published_at { Time.zone.parse('2019-01-01') }
     upload_type { 'browser' }
     globus_origin { nil }
+    user_version { 1 }
     work
 
     factory :valid_work_version do

--- a/spec/features/revert_work_to_previous_version_spec.rb
+++ b/spec/features/revert_work_to_previous_version_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Delete a draft work', :js do
   let(:collection) { create(:collection_version_with_collection).collection }
   let(:work) { create(:work, collection:) }
-  let!(:version1) { create(:work_version, :deposited, version: 1, work:) }
+  let!(:version1) { create(:work_version, :deposited, version: 1, work:, user_version: nil) }
   let(:version2) { create(:work_version, :version_draft, version: 2, work:) }
   let(:user) { work.owner }
 

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe 'Create a new work' do
 
         let(:work_params) do
           attributes_for(:work_version)
-            .except(:published_at, :state) # Unpermitted params
+            .except(:user_version, :published_at, :state) # Unpermitted params
             .merge(:authors_attributes => authors,
                    :attached_files_attributes => files,
                    :contact_emails_attributes => contact_emails,

--- a/spec/requests/dashboard_collection_spec.rb
+++ b/spec/requests/dashboard_collection_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Dashboard collection requests' do
     end
     let(:work7) { create(:work, owner: user, collection:) }
     let(:work_version7) do
-      create(:work_version, state: 'decommissioned', title: 'I am decommissioned', work: work6)
+      create(:work_version, state: 'decommissioned', title: 'I am decommissioned', work: work7)
     end
 
     before do

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Dashboard requests' do
       create(:work_version, state: 'pending_approval', title: 'I am a pending approval', work: work6)
     end
     let(:work7) { create(:work, owner: user, collection:) }
-    let(:work_version7) { create(:work_version, state: 'purl_reserved', title: 'I am reserved purl', work: work6) }
+    let(:work_version7) { create(:work_version, state: 'purl_reserved', title: 'I am reserved purl', work: work7) }
 
     before do
       create(:collection_version_with_collection, collection:)

--- a/spec/requests/delete_work_version_spec.rb
+++ b/spec/requests/delete_work_version_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 RSpec.describe 'Deleting a version' do
   let(:work) { head_work_version.work }
-  let(:head_work_version) { create(:work_version, state: :version_draft, version: head_version) }
   let(:head_version) { 1 }
   let(:user) { work.owner }
 
@@ -13,6 +12,8 @@ RSpec.describe 'Deleting a version' do
   end
 
   context 'when first version' do
+    let(:head_work_version) { create(:work_version, state: :version_draft, version: head_version) }
+
     before do
       sign_in user, groups: ['dlss:hydrus-app-collection-creators']
     end
@@ -27,7 +28,8 @@ RSpec.describe 'Deleting a version' do
 
   context 'when a subsequent version' do
     let(:head_version) { 2 }
-    let!(:first_version) { create(:work_version, version: 1, work:) }
+    let(:head_work_version) { create(:work_version, state: :version_draft, user_version: nil, version: head_version) }
+    let!(:first_version) { create(:work_version, user_version: 1, version: 1, work:) }
 
     before do
       sign_in user, groups: ['dlss:hydrus-app-collection-creators']

--- a/spec/requests/edit_collection_spec.rb
+++ b/spec/requests/edit_collection_spec.rb
@@ -194,12 +194,12 @@ RSpec.describe 'Updating an existing collection' do
 
           before do
             create(:collection_version_with_collection, collection:)
-            create(:work_version_with_work, :embargoed, collection:, work:)
+            create(:work_version_with_work, :embargoed, collection:, work:, user_version: nil)
           end
 
           context 'when works with embargoes would be orphaned' do
             before do
-              create(:work_version_with_work, :embargoed, collection:, work:)
+              create(:work_version_with_work, :embargoed, collection:, work:, user_version: 1)
             end
 
             it 'does not allow the change' do
@@ -211,7 +211,7 @@ RSpec.describe 'Updating an existing collection' do
 
           context 'when works with embargoes would not be orphaned' do
             before do
-              create(:work_version_with_work, :expired_embargo, collection:, work:)
+              create(:work_version_with_work, :expired_embargo, collection:, work:, user_version: 1)
             end
 
             it 'allows the change' do


### PR DESCRIPTION
Fixes #3512

# Why was this change made? 🤔

Avoids unique constraint exceptions for user_version

# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



