### PR TITLE
Implement user version selection

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -339,7 +339,7 @@ Style/QuotedSymbols: # (new in 1.16)
 
 RSpec/IdenticalEqualityAssertion: # (new in 2.4)
   Enabled: true
-RSpec/Rails/AvoidSetupHook: # (new in 2.4)
+RSpecRails/AvoidSetupHook: # (new in 2.4)
   Enabled: true
 
 Layout/LineEndStringConcatenationIndentation: # (new in 1.18)
@@ -477,7 +477,7 @@ Rails/ToFormattedS: # new in 2.15
   Enabled: true
 Capybara/SpecificMatcher: # new in 2.12
   Enabled: true
-RSpec/Rails/HaveHttpStatus: # new in 2.12
+RSpecRails/HaveHttpStatus: # new in 2.12
   Enabled: true
 
 Style/MagicCommentFormat: # new in 1.35
@@ -526,7 +526,7 @@ Capybara/SpecificActions: # new in 2.14
   Enabled: true
 FactoryBot/ConsistentParenthesesStyle: # new in 2.14
   Enabled: true
-RSpec/Rails/InferredSpecType: # new in 2.14
+RSpecRails/InferredSpecType: # new in 2.14
   Enabled: true
 
 Style/ArrayIntersect: # new in 1.40
@@ -558,7 +558,7 @@ Style/ComparableClamp: # new in 1.44
   Enabled: true
 Capybara/MatchStyle: # new in <<next>>
   Enabled: true
-RSpec/Rails/MinitestAssertions: # new in 2.17
+RSpecRails/MinitestAssertions: # new in 2.17
   Enabled: true
 Lint/DuplicateMatchPattern: # new in 1.50
   Enabled: true
@@ -590,7 +590,7 @@ RSpec/RedundantAround: # new in 2.19
   Enabled: true
 RSpec/SkipBlockInsideExample: # new in 2.19
   Enabled: true
-RSpec/Rails/TravelAround: # new in 2.19
+RSpecRails/TravelAround: # new in 2.19
   Enabled: true
 
 Style/ExactRegexpMatch: # new in 1.51
@@ -652,7 +652,7 @@ RSpec/SpecFilePathFormat: # new in 2.24
   Enabled: true
 RSpec/SpecFilePathSuffix: # new in 2.24
   Enabled: true
-RSpec/Rails/NegationBeValid: # new in 2.23
+RSpecRails/NegationBeValid: # new in 2.23
   Enabled: true
 
 Lint/ItWithoutArgumentsInBlock: # new in 1.59

--- a/app/components/works/buttons_component.html.erb
+++ b/app/components/works/buttons_component.html.erb
@@ -28,12 +28,20 @@
       <% end %>
     <% end %>
   </div>
+
   <div class="col-auto">
     <%= link_to 'Cancel', cancel_link_location, class: 'btn btn-link' %>
-    <%= form.submit 'Save as draft', class: 'btn btn-primary', id: 'save-draft-button',
-                                     data: { action: 'unsaved-changes#allowFormSubmission' } %>
-    <%= form.submit submit_button_label, class: 'btn btn-primary',
-                                         disabled: false,
-                                         data: { action: 'unsaved-changes#allowFormSubmission', deposit_button_target: 'depositButton' } %>
+    <% if validate_user_version? %>
+        <%= form.submit 'Save as draft', class: 'btn btn-primary', id: 'save-draft-button',
+                                         data: { action: 'unsaved-changes#allowFormSubmission new-user-version#validateUserVersionSelection' } %>
+        <%= form.submit submit_button_label, class: 'btn btn-primary',
+                                             disabled: false,
+                                             data: { action: 'unsaved-changes#allowFormSubmission new-user-version#validateUserVersionSelection', deposit_button_target: 'depositButton' } %>
+    <% else %>
+      <%= form.submit 'Save as draft', class: 'btn btn-primary', id: 'save-draft-button',
+                                       data: { action: 'unsaved-changes#allowFormSubmission' } %>
+      <%= form.submit submit_button_label, class: 'btn btn-primary', disabled: false,
+                                           data: { action: 'unsaved-changes#allowFormSubmission', deposit_button_target: 'depositButton' } %>
+   <% end %>
   </div>
 </div>

--- a/app/components/works/buttons_component.rb
+++ b/app/components/works/buttons_component.rb
@@ -46,5 +46,12 @@ module Works
         collection_works_path(collection)
       end
     end
+
+    def validate_user_version?
+      return false unless Settings.user_versions_ui_enabled
+      return true if %w[deposited rejected version_draft].include? work_version.state
+
+      false
+    end
   end
 end

--- a/app/components/works/form_component.html.erb
+++ b/app/components/works/form_component.html.erb
@@ -19,8 +19,8 @@
     </div>
   <% end %>
   <%= f.hidden_field :work_type %>
+  <div class="form-instructions"><h2 class="h4">* Required fields</h2></div>
   <%= render Works::VersionDescriptionComponent.new(form: f) %>
-  <p class="form-instructions"><h2 class="h4">* REQUIRED FIELDS</h2></p>
   <%= render Works::AddFilesComponent.new(form: f) %>
   <%= render Works::TitleComponent.new(form: f) %>
   <%= render Works::AuthorsAndContributorsComponent.new(form: f) %>

--- a/app/components/works/form_component.rb
+++ b/app/components/works/form_component.rb
@@ -45,6 +45,8 @@ module Works
     end
 
     def data_controllers
+      return 'auto-citation unsaved-changes deposit-button new-user-version' if Settings.user_versions_ui_enabled
+
       'auto-citation unsaved-changes deposit-button'
     end
   end

--- a/app/components/works/version_description_component.html.erb
+++ b/app/components/works/version_description_component.html.erb
@@ -5,33 +5,29 @@
       <div class='invalid-feedback' data-new-user-version-target='versionDescriptionError'></div>
       <%= form.hidden_field :version_description, value: work_version.version_description, 'data-new-user-version-target': 'versionDescription' %>
       <div class='mb-3 row'>
-        <div class='col-sm-1 form-check'>
+        <div class='col-sm-10 form-check'>
           <%= form.radio_button :new_user_version, 'yes', data: { action: 'click->new-user-version#displayVersionDescription' }, 'data-new-user-version-target': 'userVersionYes', class: 'form-check-input' %>
           <%= form.label :new_user_version_yes, 'Yes', class: 'form-check-label fw-semibold' %>
-        </div>
-        <div class='col-sm-11'>
           <ul>
             <li>Edit files and any or all form fields.</li>
             <li>A new version of this deposit will be created. For example, if you are editing version 1, choosing this option will create a version 2 once you click “Deposit.”</li>
             <li>The new version and any older versions will be accessible from the PURL page.</li>
             <li>If this deposit has a DOI, the DOI will be the same for all versions of the item.</li>
           </ul>
-          <%= form.label :new_user_version_description, "What's changing?", class: 'col-sm-2 col-form-label' %>
+          <%= form.label :new_user_version_description, "What's changing?", class: 'col-form-label' %>
           <%= form.text_field :new_user_version_description, 'data-new-user-version-target': 'versionDescriptionYes', class: 'form-control' %>
         </div>
       </div>
       <div class='mb-3 row'>
-        <div class='col-sm-1 form-check'>
+        <div class='col-sm-10 form-check'>
           <%= form.radio_button :new_user_version, 'no', data: { action: 'click->new-user-version#displayVersionDescription' }, 'data-new-user-version-target': 'userVersionNo', class: 'form-check-input' %>
           <%= form.label :new_user_version_no, 'No', class: 'form-check-label fw-semibold' %>
-        </div>
-        <div class='col-sm-11'>
           <ul>
             <li>Edit form fields only. Files may not be changed.</li>
             <li>The version number of this deposit will not change.</li>
             <li>Changes you make to this item will appear as updates to the current version on the PURL page.</li>
           </ul>
-          <%= form.label :current_version_description, "What's changing?", class: 'col-sm-2 col-form-label' %>
+          <%= form.label :current_version_description, "What's changing?", class: 'col-form-label' %>
           <%= form.text_field :current_version_description, 'data-new-user-version-target': 'versionDescriptionNo', class: 'form-control' %>
         </div>
       </div>

--- a/app/components/works/version_description_component.html.erb
+++ b/app/components/works/version_description_component.html.erb
@@ -1,10 +1,51 @@
-<section class="version">
-   <header>Version your work *</header>
-   <div class="mb-3 row">
-     <%= form.label :version_description, "What's changing?", class: 'col-sm-2 col-form-label' %>
-     <div class="col-sm-10">
-       <%= form.text_field :version_description, class: 'form-control', required: true %>
-       <div class="invalid-feedback">You must describe your changes.</div>
-     </div>
-   </div>
- </section>
+<% if Settings.user_versions_ui_enabled %>
+  <section class='version'>
+    <header>Do you want to create a new version of this deposit? *</header>
+    <div>
+      <div class='invalid-feedback' data-new-user-version-target='versionDescriptionError'></div>
+      <%= form.hidden_field :version_description, value: work_version.version_description, 'data-new-user-version-target': 'versionDescription' %>
+      <div class='mb-3 row'>
+        <div class='col-sm-1 form-check'>
+          <%= form.radio_button :new_user_version, 'yes', data: { action: 'click->new-user-version#displayVersionDescription' }, 'data-new-user-version-target': 'userVersionYes', class: 'form-check-input' %>
+          <%= form.label :new_user_version_yes, 'Yes', class: 'form-check-label fw-semibold' %>
+        </div>
+        <div class='col-sm-11'>
+          <ul>
+            <li>Edit files and any or all form fields.</li>
+            <li>A new version of this deposit will be created. For example, if you are editing version 1, choosing this option will create a version 2 once you click “Deposit.”</li>
+            <li>The new version and any older versions will be accessible from the PURL page.</li>
+            <li>If this deposit has a DOI, the DOI will be the same for all versions of the item.</li>
+          </ul>
+          <%= form.label :new_user_version_description, "What's changing?", class: 'col-sm-2 col-form-label' %>
+          <%= form.text_field :new_user_version_description, 'data-new-user-version-target': 'versionDescriptionYes', class: 'form-control' %>
+        </div>
+      </div>
+      <div class='mb-3 row'>
+        <div class='col-sm-1 form-check'>
+          <%= form.radio_button :new_user_version, 'no', data: { action: 'click->new-user-version#displayVersionDescription' }, 'data-new-user-version-target': 'userVersionNo', class: 'form-check-input' %>
+          <%= form.label :new_user_version_no, 'No', class: 'form-check-label fw-semibold' %>
+        </div>
+        <div class='col-sm-11'>
+          <ul>
+            <li>Edit form fields only. Files may not be changed.</li>
+            <li>The version number of this deposit will not change.</li>
+            <li>Changes you make to this item will appear as updates to the current version on the PURL page.</li>
+          </ul>
+          <%= form.label :current_version_description, "What's changing?", class: 'col-sm-2 col-form-label' %>
+          <%= form.text_field :current_version_description, 'data-new-user-version-target': 'versionDescriptionNo', class: 'form-control' %>
+        </div>
+      </div>
+    </div>
+  </section>
+<% else %>
+  <section class='version'>
+    <header>Version your work *</header>
+    <div class='mb-3 row'>
+      <%= form.label :version_description, "What's changing?", class: 'col-sm-2 col-form-label' %>
+      <div class='col-sm-10'>
+        <%= form.text_field :version_description, class: 'form-control', required: true %>
+        <div class='invalid-feedback'>You must describe your changes.</div>
+      </div>
+    </div>
+  </section>
+<% end %>

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -250,6 +250,7 @@ class WorksController < ObjectsController
     context_form
   end
 
+  # rubocop:disable Metrics/MethodLength
   def work_params
     params
       .require(:work)
@@ -265,19 +266,21 @@ class WorksController < ObjectsController
               :access, :license, :custom_rights, :version_description,
               :release, 'embargo_date(1i)', 'embargo_date(2i)', 'embargo_date(3i)',
               :agree_to_terms, :assign_doi, :upload_type, :globus, :fetch_globus_files,
-              :globus_origin, subtype: [], files: [],
-                              attached_files_attributes: %i[_destroy id label hide file path],
-                              authors_attributes: [:_destroy, :id, :full_name, :first_name, :last_name,
-                                                   :contributor_type, :role, :weight, :orcid, :with_orcid,
-                                                   { affiliations_attributes: affiliation_attributes }],
-                              contributors_attributes: [:_destroy, :id, :full_name, :first_name, :last_name,
-                                                        :contributor_type, :role, :weight, :orcid, :with_orcid,
-                                                        { affiliations_attributes: affiliation_attributes }],
-                              contact_emails_attributes: %i[_destroy id email],
-                              keywords_attributes: %i[_destroy id label uri cocina_type],
-                              related_works_attributes: %i[_destroy id citation],
-                              related_links_attributes: %i[_destroy id link_title url])
+              :globus_origin, :new_user_version, :new_user_version_description, :current_version_description,
+              subtype: [], files: [],
+              attached_files_attributes: %i[_destroy id label hide file path],
+              authors_attributes: [:_destroy, :id, :full_name, :first_name, :last_name,
+                                   :contributor_type, :role, :weight, :orcid, :with_orcid,
+                                   { affiliations_attributes: affiliation_attributes }],
+              contributors_attributes: [:_destroy, :id, :full_name, :first_name, :last_name,
+                                        :contributor_type, :role, :weight, :orcid, :with_orcid,
+                                        { affiliations_attributes: affiliation_attributes }],
+              contact_emails_attributes: %i[_destroy id email],
+              keywords_attributes: %i[_destroy id label uri cocina_type],
+              related_works_attributes: %i[_destroy id citation],
+              related_links_attributes: %i[_destroy id link_title url])
   end
+  # rubocop:enable Metrics/MethodLength
 
   def affiliation_attributes
     %i[_destroy id label department uri]

--- a/app/javascript/controllers/new_user_version_controller.js
+++ b/app/javascript/controllers/new_user_version_controller.js
@@ -1,0 +1,51 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['versionDescription', 'userVersionYes', 'userVersionNo', 'versionDescriptionYes', 'versionDescriptionNo', 'versionDescriptionError']
+
+  connect () {
+    this.versionDescriptionYesTarget.disabled = true
+    this.versionDescriptionNoTarget.disabled = true
+    this.versionDescriptionYesTarget.value = this.versionDescriptionTarget.value
+    this.versionDescriptionNoTarget.value = this.versionDescriptionTarget.value
+  }
+
+  displayVersionDescription (event) {
+    // Version description input enabled when radio selected
+    if (event.currentTarget === this.userVersionYesTarget) {
+      this.versionDescriptionYesTarget.disabled = false
+      this.versionDescriptionNoTarget.disabled = true
+    } else if (event.currentTarget === this.userVersionNoTarget) {
+      this.versionDescriptionNoTarget.disabled = false
+      this.versionDescriptionYesTarget.disabled = true
+    }
+  }
+
+  validateUserVersionSelection (event) {
+    if (this.userVersionYesTarget.checked === false && this.userVersionNoTarget.checked === false) {
+      this.showError('Please select a version option')
+      event.preventDefault()
+    }
+    if (this.userVersionYesTarget.checked === true && this.versionDescriptionYesTarget.value === '') {
+      this.showError('Please enter a version description')
+      event.preventDefault()
+    }
+    if (this.userVersionNoTarget.checked === true && this.versionDescriptionNoTarget.value === '') {
+      this.showError('Please enter a version description')
+      event.preventDefault()
+    }
+  }
+
+  showError (err) {
+    if (err) {
+      this.versionDescriptionErrorTarget.innerHTML = err
+      this.versionDescriptionErrorTarget.style.display = 'block'
+    } else {
+      this.hideError()
+    }
+  }
+
+  hideError () {
+    this.versionDescriptionErrorTarget.style.display = 'none'
+  }
+}

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -52,6 +52,7 @@ external_links:
 
 # feature flags
 allow_sdr_content_changes: true
+user_versions_ui_enabled: false
 
 authorization_group_header: HTTP_X_GROUPS
 first_name_header: HTTP_X_PERSON_NAME

--- a/spec/components/works/version_description_component_spec.rb
+++ b/spec/components/works/version_description_component_spec.rb
@@ -23,4 +23,17 @@ RSpec.describe Works::VersionDescriptionComponent, type: :component do
       expect(rendered.to_html).to include('Version your work')
     end
   end
+
+  context 'when user version feature flag is on' do
+    let(:work_version) { build(:work_version, work:, state: 'deposited') }
+
+    before do
+      allow(Settings).to receive(:user_versions_ui_enabled).and_return(true)
+    end
+
+    it 'renders the user version selection' do
+      expect(rendered.to_html).to include('Do you want to create a new version of this deposit?')
+      expect(rendered.to_html).not_to include('Version your work')
+    end
+  end
 end

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -362,4 +362,39 @@ RSpec.describe WorkForm do
       expect(messages).to be_empty
     end
   end
+
+  describe 'user version description feature flag' do
+    subject(:deserialized) { form.deserialize!(params) }
+
+    let(:new_user_version) { 'yes' }
+    let(:new_user_version_description) { 'User version description' }
+    let(:params) do
+      { 'new_user_version' => new_user_version,
+        'new_user_version_description' => new_user_version_description,
+        'version_description' => nil }
+    end
+
+    before do
+      allow(Settings).to receive(:user_versions_ui_enabled).and_return(true)
+    end
+
+    context 'when Yes is selected' do
+      it 'uses the user version description' do
+        expect(deserialized['version_description']).to eq 'User version description'
+      end
+    end
+
+    context 'when No is selected' do
+      let(:new_user_version) { 'no' }
+      let(:params) do
+        { 'new_user_version' => new_user_version,
+          'current_version_description' => 'Current version description',
+          'version_description' => nil }
+      end
+
+      it 'uses the current version description box' do
+        expect(deserialized['version_description']).to eq 'Current version description'
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Why was this change made? 🤔
Resolves #3504 to show a new user version section under a feature flag. 

Note this PR does not implement:
- Saving whether or not the version is a new user version
- When re-opening the draft, putting a previously provided version description in the correct version description box (requires above)
- Scrolling up to error when client-side validation detects that a description has not been provided.

# How was this change tested? 🤨
Locally and specs 

![Screenshot 2024-05-08 at 11 02 05 AM](https://github.com/sul-dlss/happy-heron/assets/1619369/205f56f9-51c5-4408-a0a6-cbbff2611ff7)

![Screenshot 2024-05-08 at 11 03 10 AM](https://github.com/sul-dlss/happy-heron/assets/1619369/59bfb40f-224b-401c-bb15-58ac8f6c02f3)



# Does your change introduce accessibility violations? 🩺
Used aXe chrome extension to assess form labels. No new violations. 


