### PR TITLE
Change approach to persisting user_versions.

### DIFF
--- a/app/components/works/buttons_component.html.erb
+++ b/app/components/works/buttons_component.html.erb
@@ -31,17 +31,9 @@
 
   <div class="col-auto">
     <%= link_to 'Cancel', cancel_link_location, class: 'btn btn-link' %>
-    <% if validate_user_version? %>
-        <%= form.submit 'Save as draft', class: 'btn btn-primary', id: 'save-draft-button',
-                                         data: { action: 'unsaved-changes#allowFormSubmission new-user-version#validateUserVersionSelection' } %>
-        <%= form.submit submit_button_label, class: 'btn btn-primary',
-                                             disabled: false,
-                                             data: { action: 'unsaved-changes#allowFormSubmission new-user-version#validateUserVersionSelection', deposit_button_target: 'depositButton' } %>
-    <% else %>
-      <%= form.submit 'Save as draft', class: 'btn btn-primary', id: 'save-draft-button',
-                                       data: { action: 'unsaved-changes#allowFormSubmission' } %>
-      <%= form.submit submit_button_label, class: 'btn btn-primary', disabled: false,
-                                           data: { action: 'unsaved-changes#allowFormSubmission', deposit_button_target: 'depositButton' } %>
-   <% end %>
+    <%= form.submit 'Save as draft', class: 'btn btn-primary', id: 'save-draft-button',
+                                     data: { action: 'unsaved-changes#allowFormSubmission' } %>
+    <%= form.submit submit_button_label, class: 'btn btn-primary', disabled: false,
+                                         data: { action: 'unsaved-changes#allowFormSubmission', deposit_button_target: 'depositButton' } %>
   </div>
 </div>

--- a/app/components/works/buttons_component.rb
+++ b/app/components/works/buttons_component.rb
@@ -46,9 +46,5 @@ module Works
         collection_works_path(collection)
       end
     end
-
-    def validate_user_version?
-      Settings.user_versions_ui_enabled && %w[deposited rejected version_draft].include?(work_version.state)
-    end
   end
 end

--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -20,7 +20,7 @@ module Works
     def version
       return '1 - initial version' if first_draft?
 
-      "#{work_version.version} - #{version_description}"
+      "#{version_number} - #{version_description}"
     end
 
     def doi_setting
@@ -115,6 +115,12 @@ module Works
 
       # For example, "2020?/2021?" to "ca. 2020 - ca. 2021"
       edtf.sub(%r{/}, ' - ').gsub(/(\S+)\?/, 'ca. \1')
+    end
+
+    def version_number
+      return work_version.user_version if Settings.user_versions_ui_enabled
+
+      work_version.version
     end
   end
 end

--- a/app/components/works/version_description_component.html.erb
+++ b/app/components/works/version_description_component.html.erb
@@ -1,47 +1,52 @@
-<% if Settings.user_versions_ui_enabled %>
-  <section class='version'>
-    <header>Do you want to create a new version of this deposit? *</header>
-    <div>
-      <div class='invalid-feedback' data-new-user-version-target='versionDescriptionError'></div>
-      <%= form.hidden_field :version_description, value: work_version.version_description, data: { new_user_version_target: 'versionDescription' } %>
-      <div class='mb-3 row'>
-        <div class='col-sm-10 form-check'>
-          <%= form.radio_button :new_user_version, 'yes', data: { action: 'click->new-user-version#displayVersionDescription', new_user_version_target: 'userVersionYes' }, class: 'form-check-input' %>
-          <%= form.label :new_user_version, 'Yes', value: 'yes', class: 'form-check-label fw-semibold' %>
-          <ul>
-            <li>Edit files and any or all form fields.</li>
-            <li>A new version of this deposit will be created. For example, if you are editing version 1, choosing this option will create a version 2 once you click “Deposit.”</li>
-            <li>The new version and any older versions will be accessible from the PURL page.</li>
-            <li>If this deposit has a DOI, the DOI will be the same for all versions of the item.</li>
-          </ul>
-          <%= form.label :new_user_version_description, "What's changing?", class: 'col-form-label' %>
-          <%= form.text_field :new_user_version_description, data: { new_user_version_target: 'versionDescriptionYes' }, class: 'form-control' %>
+<% if show? %>
+  <% if Settings.user_versions_ui_enabled %>
+    <section class='version'>
+      <header>Do you want to create a new version of this deposit? *</header>
+      <div>
+        <div class='invalid-feedback' data-new-user-version-target='versionDescriptionError'></div>
+        <%= form.hidden_field :version_description, value: work_version.version_description, data: { new_user_version_target: 'versionDescription' } %>
+        <div class='mb-3 row'>
+          <div class='col-sm-10 form-check'>
+            <%= form.radio_button :new_user_version, 'yes', required: true, data: { action: 'click->new-user-version#displayVersionDescription', new_user_version_target: 'userVersionYes' }, class: 'form-check-input' %>
+            <%= form.label :new_user_version, 'Yes', value: 'yes', class: 'form-check-label fw-semibold' %>
+            <ul>
+              <li>Edit files and any or all form fields.</li>
+              <li>A new version of this deposit will be created. For example, if you are editing version 1, choosing this option will create a version 2 once you click “Deposit.”</li>
+              <li>The new version and any older versions will be accessible from the PURL page.</li>
+              <li>If this deposit has a DOI, the DOI will be the same for all versions of the item.</li>
+            </ul>
+            <%= form.label :version_description, "What's changing?", class: 'col-form-label' %>
+            <%= form.text_field :version_description, data: { new_user_version_target: 'versionDescriptionYes' }, class: 'form-control' %>
+          </div>
+        </div>
+        <div class='mb-3 row'>
+          <div class='col-sm-10 form-check'>
+            <%= form.radio_button :new_user_version, 'no', required: true, data: { action: 'click->new-user-version#displayVersionDescription', new_user_version_target: 'userVersionNo' }, class: 'form-check-input' %>
+            <%= form.label :new_user_version, 'No', value: 'no', class: 'form-check-label fw-semibold' %>
+            <ul>
+              <li>Edit form fields only. Files may not be changed.</li>
+              <li>The version number of this deposit will not change.</li>
+              <li>Changes you make to this item will appear as updates to the current version on the PURL page.</li>
+            </ul>
+            <%= form.label :version_description, "What's changing?", class: 'col-form-label' %>
+            <%= form.text_field :version_description, data: { new_user_version_target: 'versionDescriptionNo' }, class: 'form-control' %>
+          </div>
         </div>
       </div>
+    </section>
+  <% else %>
+    <section class='version'>
+      <header>Version your work *</header>
       <div class='mb-3 row'>
-        <div class='col-sm-10 form-check'>
-          <%= form.radio_button :new_user_version, 'no', data: { action: 'click->new-user-version#displayVersionDescription', new_user_version_target: 'userVersionNo' }, class: 'form-check-input' %>
-          <%= form.label :new_user_version, 'No', value: 'no', class: 'form-check-label fw-semibold' %>
-          <ul>
-            <li>Edit form fields only. Files may not be changed.</li>
-            <li>The version number of this deposit will not change.</li>
-            <li>Changes you make to this item will appear as updates to the current version on the PURL page.</li>
-          </ul>
-          <%= form.label :current_version_description, "What's changing?", class: 'col-form-label' %>
-          <%= form.text_field :current_version_description, data: { new_user_version_target: 'versionDescriptionNo' }, class: 'form-control' %>
+        <%= form.label :version_description, "What's changing?", class: 'col-sm-2 col-form-label' %>
+        <div class='col-sm-10'>
+          <%= form.text_field :version_description, class: 'form-control', required: true %>
+          <div class='invalid-feedback'>You must describe your changes.</div>
         </div>
       </div>
-    </div>
-  </section>
-<% else %>
-  <section class='version'>
-    <header>Version your work *</header>
-    <div class='mb-3 row'>
-      <%= form.label :version_description, "What's changing?", class: 'col-sm-2 col-form-label' %>
-      <div class='col-sm-10'>
-        <%= form.text_field :version_description, class: 'form-control', required: true %>
-        <div class='invalid-feedback'>You must describe your changes.</div>
-      </div>
-    </div>
-  </section>
+    </section>
+  <% end %>
+<% end %>
+<% if show_hidden? %>
+  <%= form.hidden_field :new_user_version, value: 'no' %>
 <% end %>

--- a/app/components/works/version_description_component.html.erb
+++ b/app/components/works/version_description_component.html.erb
@@ -47,6 +47,6 @@
     </section>
   <% end %>
 <% end %>
-<% if show_hidden? %>
+<% if hidden_user_version? %>
   <%= form.hidden_field :new_user_version, value: 'no' %>
 <% end %>

--- a/app/components/works/version_description_component.rb
+++ b/app/components/works/version_description_component.rb
@@ -13,8 +13,12 @@ module Works
       form.object.model.fetch(:work_version)
     end
 
-    def render?
+    def show?
       %w[deposited rejected version_draft].include? work_version.state
+    end
+
+    def show_hidden?
+      !Settings.user_versions_ui_enabled || !show?
     end
   end
 end

--- a/app/components/works/version_description_component.rb
+++ b/app/components/works/version_description_component.rb
@@ -17,7 +17,7 @@ module Works
       %w[deposited rejected version_draft].include? work_version.state
     end
 
-    def show_hidden?
+    def hidden_user_version?
       !Settings.user_versions_ui_enabled || !show?
     end
   end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -72,9 +72,7 @@ class WorksController < ObjectsController
     clean_params = orig_clean_params.deep_dup
 
     if work_version.deposited?
-      # Here we are moving the user_version from the previous WorkVersion to the head WorkVersion.
       work_version = create_new_version(work_version)
-      orig_work_version.update(user_version: nil)
       NewVersionParameterFilter.call(clean_params, work.head)
     end
 

--- a/app/forms/work_form.rb
+++ b/app/forms/work_form.rb
@@ -25,6 +25,8 @@ class WorkForm < BaseWorkForm
   validates :embargo_date, embargo_date: true, if: :availability_component_present?
   validates :agree_to_terms, presence: true
   validates :upload_type, presence: true
+  validates :new_user_version, presence: true, if: :not_first_version?
+  validates :user_version, presence: true
 
   has_contributors(validate: true)
 
@@ -69,5 +71,9 @@ class WorkForm < BaseWorkForm
     return false if already_embargo_released?
 
     collection.user_can_set_availability?
+  end
+
+  def not_first_version?
+    work_version.version != 1
   end
 end

--- a/app/javascript/controllers/new_user_version_controller.js
+++ b/app/javascript/controllers/new_user_version_controller.js
@@ -4,20 +4,30 @@ export default class extends Controller {
   static targets = ['versionDescription', 'userVersionYes', 'userVersionNo', 'versionDescriptionYes', 'versionDescriptionNo', 'versionDescriptionError']
 
   connect () {
-    this.versionDescriptionYesTarget.disabled = true
-    this.versionDescriptionNoTarget.disabled = true
-    this.versionDescriptionYesTarget.value = this.versionDescriptionTarget.value
-    this.versionDescriptionNoTarget.value = this.versionDescriptionTarget.value
+    if (this.userVersionYesTarget.checked === true) {
+      this.versionDescriptionNoTarget.disabled = true
+      this.versionDescriptionYesTarget.required = true
+      this.versionDescriptionYesTarget.value = this.versionDescriptionTarget.value
+    }
+    if (this.userVersionNoTarget.checked === true) {
+      this.versionDescriptionYesTarget.disabled = true
+      this.versionDescriptionNoTarget.required = true
+      this.versionDescriptionNoTarget.value = this.versionDescriptionTarget.value
+    }
   }
 
   displayVersionDescription (event) {
     // Version description input enabled when radio selected
     if (event.currentTarget === this.userVersionYesTarget) {
       this.versionDescriptionYesTarget.disabled = false
+      this.versionDescriptionYesTarget.required = true
       this.versionDescriptionNoTarget.disabled = true
+      this.versionDescriptionNoTarget.required = false
     } else if (event.currentTarget === this.userVersionNoTarget) {
       this.versionDescriptionNoTarget.disabled = false
+      this.versionDescriptionNoTarget.required = true
       this.versionDescriptionYesTarget.disabled = true
+      this.versionDescriptionYesTarget.required = false
     }
   }
 

--- a/app/services/new_version_service.rb
+++ b/app/services/new_version_service.rb
@@ -25,7 +25,6 @@ class NewVersionService
     new_version.version = old_version.version + 1 if increment_version
     new_version.version_description = version_description if version_description
     new_version.state = state if state
-    old_version.user_version = nil # Ensure user version is unique across all versions of the work
     yield new_version if block_given?
     perform_save if save
 

--- a/db/migrate/20240510172252_remove_unique_from_work_version.rb
+++ b/db/migrate/20240510172252_remove_unique_from_work_version.rb
@@ -1,0 +1,7 @@
+class RemoveUniqueFromWorkVersion < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :work_versions, [:work_id, :user_version]
+    WorkVersion.where.not(state: 'version_draft').update_all(user_version: 1)
+    WorkVersion.where(state: 'version_draft').update_all(user_version: nil)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,13 +10,6 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: public; Type: SCHEMA; Schema: -; Owner: -
---
-
--- *not* creating schema, since initdb creates it
-
-
---
 -- Name: work_access; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -1224,13 +1217,6 @@ CREATE INDEX index_work_versions_on_work_id ON public.work_versions USING btree 
 
 
 --
--- Name: index_work_versions_on_work_id_and_user_version; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_work_versions_on_work_id_and_user_version ON public.work_versions USING btree (work_id, user_version);
-
-
---
 -- Name: index_works_on_collection_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1498,6 +1484,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230726172521'),
 ('20240501135224'),
 ('20240502142444'),
-('20240503114446');
+('20240503114446'),
+('20240510172252');
 
 

--- a/spec/components/works/detail_component_spec.rb
+++ b/spec/components/works/detail_component_spec.rb
@@ -32,12 +32,22 @@ RSpec.describe Works::DetailComponent, type: :component do
 
   context 'when deposited' do
     let(:work_version) do
-      build_stubbed(:work_version, :deposited, version: 2, version_description: 'changed the title')
+      build_stubbed(:work_version, :deposited, version: 2, version_description: 'changed the title', user_version: 3)
     end
 
     it 'renders the draft title' do
       expect(rendered.css('.state').to_html).not_to include('Not deposited')
       expect(rendered.to_html).to include '2 - changed the title'
+    end
+
+    context 'when user_versions_ui_enabled enabled' do
+      before do
+        allow(Settings).to receive(:user_versions_ui_enabled).and_return(true)
+      end
+
+      it 'renders the user_version' do
+        expect(rendered.to_html).to include '3 - changed the title'
+      end
     end
   end
 

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -6,7 +6,11 @@ RSpec.describe WorkForm do
   subject(:form) { described_class.new(work_version:, work:) }
 
   let(:work) { work_version.work }
-  let(:work_version) { build(:work_version) }
+  let(:work_version) { create(:work_version, version: 2, user_version: 2) }
+
+  before do
+    create(:work_version, version: 1, user_version: 1, work:)
+  end
 
   describe 'populator on files' do
     let!(:blob) do
@@ -366,12 +370,10 @@ RSpec.describe WorkForm do
   describe 'user version description feature flag' do
     subject(:deserialized) { form.deserialize!(params) }
 
-    let(:new_user_version) { 'yes' }
-    let(:new_user_version_description) { 'User version description' }
+    let(:version_description) { 'User version description' }
     let(:params) do
       { 'new_user_version' => new_user_version,
-        'new_user_version_description' => new_user_version_description,
-        'version_description' => nil }
+        'version_description' => version_description }
     end
 
     before do
@@ -379,8 +381,11 @@ RSpec.describe WorkForm do
     end
 
     context 'when Yes is selected' do
+      let(:new_user_version) { 'yes' }
+
       it 'uses the user version description' do
-        expect(deserialized['version_description']).to eq 'User version description'
+        expect(deserialized['version_description']).to eq version_description
+        expect(deserialized['user_version']).to eq 2
       end
     end
 
@@ -388,12 +393,12 @@ RSpec.describe WorkForm do
       let(:new_user_version) { 'no' }
       let(:params) do
         { 'new_user_version' => new_user_version,
-          'current_version_description' => 'Current version description',
           'version_description' => nil }
       end
 
       it 'uses the current version description box' do
-        expect(deserialized['version_description']).to eq 'Current version description'
+        expect(deserialized['version_description']).to be_nil
+        expect(deserialized['user_version']).to eq 1
       end
     end
   end

--- a/spec/requests/create_work_spec.rb
+++ b/spec/requests/create_work_spec.rb
@@ -211,7 +211,8 @@ RSpec.describe 'Create a new work' do
                    'created_range(4i)' => '2020', 'created_range(5i)' => '10', 'created_range(6i)' => '31',
                    'release' => 'embargo',
                    'embargo_date(1i)' => embargo_year, 'embargo_date(2i)' => '4', 'embargo_date(3i)' => '4',
-                   :access => 'stanford') # an access selection that will be overwritten
+                   :access => 'stanford', # an access selection that will be overwritten
+                   :new_user_version => 'no')
         end
 
         before { create(:collection_version_with_collection, collection:) }
@@ -243,6 +244,7 @@ RSpec.describe 'Create a new work' do
           expect(DepositJob).to have_received(:perform_later).with(work_version)
           expect(work_version.state).to eq 'depositing'
           expect(work_version.access).to eq 'world' # shows that `stanford` was overwritten
+          expect(work_version.user_version).to eq 1
         end
       end
 
@@ -313,7 +315,8 @@ RSpec.describe 'Create a new work' do
             'commit' => 'Save as draft',
             'controller' => 'works',
             'action' => 'create',
-            'collection_id' => collection.id
+            'collection_id' => collection,
+            'new_user_version' => 'no'
           }
         end
 
@@ -346,7 +349,8 @@ RSpec.describe 'Create a new work' do
             license: 'CC0-1.0',
             upload_type: 'browser',
             release: 'immediate',
-            access: 'stanford'
+            access: 'stanford',
+            new_user_version: 'no'
           }
         end
 
@@ -582,7 +586,8 @@ RSpec.describe 'Create a new work' do
             },
             license: 'CC0-1.0',
             upload_type: 'browser',
-            release: 'immediate'
+            release: 'immediate',
+            new_user_version: 'no'
           }
         end
 
@@ -661,7 +666,8 @@ RSpec.describe 'Create a new work' do
             release: 'embargo',
             'embargo_date(1i)': '2030',
             'embargo_date(2i)': '09',
-            'embargo_date(3i)': '01'
+            'embargo_date(3i)': '01',
+            new_user_version: 'no'
           }
         end
 
@@ -729,7 +735,8 @@ RSpec.describe 'Create a new work' do
             },
             license: 'CC0-1.0',
             upload_type: 'browser',
-            release: 'embargo'
+            release: 'embargo',
+            new_user_version: 'no'
           }
         end
 
@@ -795,7 +802,8 @@ RSpec.describe 'Create a new work' do
               '0' => { '_destroy' => 'false', 'label' => 'Feminism', 'uri' => 'http://id.worldcat.org/fast/922671' }
             },
             license: 'CC0-1.0',
-            upload_type: 'browser'
+            upload_type: 'browser',
+            new_user_version: 'no'
           }
         end
 

--- a/spec/requests/edit_work_spec.rb
+++ b/spec/requests/edit_work_spec.rb
@@ -66,7 +66,8 @@ RSpec.describe 'Updating an existing work' do
             authors_attributes: {},
             contact_emails_attributes: {},
             license: 'CC0-1.0',
-            release: 'immediate'
+            release: 'immediate',
+            new_user_version: 'no'
           }.tap do |param|
             # Keywords aren't changing.
             work_version.keywords.each_with_object(param[:keywords_attributes]).with_index do |(keyword, attrs), index|
@@ -103,6 +104,7 @@ RSpec.describe 'Updating an existing work' do
             expect(CollectionObserver).to have_received(:version_draft_created)
             expect(WorkVersion.where(work:).count).to eq 2
             expect(work.reload.head).to be_version_draft
+            expect(work.head.user_version).to eq 1
             expect(work.head.subtype).to eq []
             # Only changed fields are recorded in event.
             expect(work.events.first.description).to eq('title of deposit modified, contact email modified, ' \


### PR DESCRIPTION
closes #3506

# Why was this change made? 🤔
* Make it easier to manage user versions.
* Allow user versions to be persisted and synced with form.


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Unit, Amy

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



