### PR TITLE
Fix autogen citation disabled bug

### DIFF
--- a/app/javascript/controllers/auto_citation_controller.js
+++ b/app/javascript/controllers/auto_citation_controller.js
@@ -39,6 +39,10 @@ export default class extends Controller {
   }
 
   get citation () {
+    if (this.doi === '') {
+      return `${this.authorAsSentence} (${this.date}). ${this.title}. Stanford Digital Repository. Available at ${this.purl}.`
+    }
+
     return `${this.authorAsSentence} (${this.date}). ${this.title}. Stanford Digital Repository. Available at ${this.purl}. ${this.doi}`
   }
 


### PR DESCRIPTION
# Why was this change made? 🤔

Quick fix for #3529 - there is a bug in the citation code that adds a space to the string if the dot is empty and therefore the values no longer match and the autogen button is disabled incorrectly.

# How was this change tested? 🤨

Verified in stage and prod (using the item in the ticket)

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



