### PR TITLE
Adds user version to work history.

### DIFF
--- a/app/forms/base_work_form.rb
+++ b/app/forms/base_work_form.rb
@@ -19,7 +19,7 @@ class BaseWorkForm < Reform::Form
     # If this is an existing work version, then "yes" if the user_version is different from the previous version.
     # If this is an existing work version, then "no" if the user_version is same as from the previous version.
     if work_version.version != 1 && work_version.user_version && !work_version.deposited?
-      self.new_user_version = work_version.user_version == work_version.previous_version.user_version ? 'no' : 'yes'
+      self.new_user_version = work_version.new_user_version? ? 'yes' : 'no'
     end
   end)
   property :user_version, on: :work_version

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # Models the deposit of an single version of a digital repository object
+# rubocop:disable Metrics/ClassLength
 class WorkVersion < ApplicationRecord
   include AggregateAssociations
 
@@ -212,6 +213,12 @@ class WorkVersion < ApplicationRecord
     )
   end
 
+  # @return [Boolean] true if the user_version is different from the previous version's user_version
+  # or this is the first version
+  def new_user_version?
+    user_version != previous_version&.user_version
+  end
+
   private
 
   def locally_cached_file_for(blob)
@@ -220,3 +227,4 @@ class WorkVersion < ApplicationRecord
     blob.service.path_for(blob.key)
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/services/deposit_completer.rb
+++ b/app/services/deposit_completer.rb
@@ -18,7 +18,7 @@ class DepositCompleter
 
     parent.event_context = {
       user: sdr_user,
-      description: "What changed: #{what_changed}"
+      description:
     }
 
     object_version.deposit_complete!
@@ -37,6 +37,15 @@ class DepositCompleter
   end
 
   def what_changed
-    object_version.version_description.presence || 'not specified'
+    "What changed: #{object_version.version_description.presence || 'not specified'}"
+  end
+
+  def description
+    return what_changed unless object_version.is_a?(WorkVersion)
+    return what_changed unless Settings.user_versions_ui_enabled
+
+    return what_changed unless object_version.new_user_version?
+
+    "Version #{object_version.user_version} created. #{what_changed}"
   end
 end


### PR DESCRIPTION
closes #3531

# Why was this change made? 🤔
Per ticket


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡
Unit, Amy


# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



