### PR TITLE
Add a basic filelist report for all files attached to current works

### DIFF
--- a/lib/tasks/file_list.rake
+++ b/lib/tasks/file_list.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+desc 'Provide a list of all files in H2 and associated work information'
+task file_list: :environment do
+  CSV.open('works_files_list.csv', 'wb') do |csv|
+    csv << %w[druid title filename description]
+    deposited_current_versions.each do |work_version|
+      work_version.attached_files.each do |attached_file|
+        csv << [work_version.work.druid, work_version.title, attached_file.filename, attached_file.label]
+      end
+    end
+  end
+end
+
+def deposited_current_versions
+  WorkVersion.with_state(:deposited).joins(:work).where('works.head_id = work_versions.id')
+end


### PR DESCRIPTION
# Why was this change made? 🤔

Closes #3534 

A basic report of filenames and descriptions for each file attached to the current version of deposited works.

# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



