### PR TITLE
Allow for original work form being validated when setting user_version param

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -64,6 +64,7 @@ class WorksController < ObjectsController
 
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/MethodLength
+  # Note the work_form will be validated twice with updates: once to identify changes and then as a new work_version
   def update
     work = Work.find(params[:id])
     work_version = work.head

--- a/app/forms/base_work_form.rb
+++ b/app/forms/base_work_form.rb
@@ -157,7 +157,11 @@ class BaseWorkForm < Reform::Form
     params['license'] = collection.required_license
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def select_user_version(params)
+    # handle building event context on original work_version before new work_version validated
+    return if params['new_user_version'] == 'yes' && work_version.previous_version.nil?
+
     params['user_version'] = case params['new_user_version']
                              when 'yes'
                                work_version.previous_version.user_version + 1
@@ -165,6 +169,7 @@ class BaseWorkForm < Reform::Form
                                work_version&.previous_version&.user_version || 1
                              end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   collection :attached_files,
              populator: AttachedFilesPopulator.new(:attached_files, AttachedFile),


### PR DESCRIPTION
# Why was this change made? 🤔
Fixes bug when submitting version 2 with a new user version, so that user_version can be calculated. 

# How was this change tested? 🤨
Run locally and stage

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



