### PR TITLE
Move csv in Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem 'rails', '~> 7.0.1'
 
 group :development, :test do
   gem 'axe-core-rspec'
-  gem 'csv'
   gem 'cypress-on-rails', '~> 1.0'
   gem 'cypress-rails'
   gem 'debug'
@@ -62,6 +61,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'bunny', '~> 2.17' # RabbitMQ library
 gem 'config'
 gem 'cssbundling-rails'
+gem 'csv'
 gem 'devise', '~> 4.7'
 gem 'devise-remote-user', '~> 1.0'
 gem 'dor-services-client', '~> 14.0'


### PR DESCRIPTION
# Why was this change made? 🤔
```
warning: /usr/local/rvm/rubies/ruby-3.3.1/lib/ruby/3.3.0/csv.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec.
```


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



