### PR TITLE
Add csv dependency to bundler

### DIFF
--- a/app/services/admin/collections_csv_generator.rb
+++ b/app/services/admin/collections_csv_generator.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 module Admin
   # Converts a set of collections to CSV.
   class CollectionsCsvGenerator

--- a/app/services/admin/work_csv_generator.rb
+++ b/app/services/admin/work_csv_generator.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 module Admin
   # Converts a set of works to CSV.
   class WorkCsvGenerator

--- a/lib/tasks/lock.rake
+++ b/lib/tasks/lock.rake
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 desc 'Lock specified works'
 # specify a CSV file that contains work druids, one per row (no header), and each work will be locked
 #  (if not already locked)

--- a/lib/tasks/version.rake
+++ b/lib/tasks/version.rake
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 desc 'Sync work versions with SDR'
 # specify a CSV file that contains work druids, one per row (no header),
 # and the current work version's version will be synced.


### PR DESCRIPTION
# Why was this change made?

This dependency is moving out of stdlib in Ruby 3.4 so it must be managed by bundler.

# How was this change tested?

CI
