### PR TITLE
Add comment about `mutex_m` dependency in `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem 'jbuilder'
 gem 'jsbundling-rails'
 gem 'lograge', '~> 0.11.2'
 gem 'mais_orcid_client'
-gem 'mutex_m'
+gem 'mutex_m' # This can be removed when H2 is upgraded to Rails 7.1
 gem 'okcomputer'
 gem 'pg'
 gem 'preservation-client', '~> 6.0'


### PR DESCRIPTION
H2 does not depend upon `mutex_m` directly, but Rails does. Rails adds this dependency as of version 7.1.0, so we will no longer need this in the H2 `Gemfile`.
