### PR TITLE
Small fix to a bug when canceling the delete of a draft work

### DIFF
--- a/app/views/works/_delete_button.html.erb
+++ b/app/views/works/_delete_button.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag dom_id(work, ['delete', anchor].compact.join('_')) do %>
   <% if allowed_to?(:delete?, work) %>
-    <%= link_to work_path(work), aria: { label: "Delete #{work.head.title}" }, data: { confirm: 'Are you sure you want to delete this draft work? It cannot be undone.', turbo_method: :delete } do %>
+    <%= link_to work_path(work), aria: { label: "Delete #{work.head.title}" }, data: { turbo_confirm: 'Are you sure you want to delete this draft work? It cannot be undone.', turbo_method: :delete } do %>
         <span class="fa-regular fa-trash-alt"></span>
     <% end %>
   <% end %>


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3566 

With just `data->confirm` the cancel button still performs the action, this needs to be `data->turbo_confirm` in order to actually cancel the delete action.

# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



