### PR TITLE
Show previous user version purl links

### DIFF
--- a/app/components/works/detail_component.html.erb
+++ b/app/components/works/detail_component.html.erb
@@ -64,9 +64,21 @@
         </tr>
       <% end %>
       <tr>
-        <th class="col-3" scope="row">Version details</th>
+        <% if Settings.user_versions_ui_enabled %>
+          <th class="col-3" scope="row">Current version</th>
+        <% else %>
+          <th class="col-3" scope="row">Version details</th>
+        <% end %>
         <td><%= version %></td>
       </tr>
+      <% if previous_user_versions? %>
+        <tr>
+          <th class="col-3" scope="row">Previous version(s)</th>
+          <td>
+            <%= safe_join(previous_user_versions.map { |version| link_to(version, version_purl(version)) }, ', ') %>
+          </td>
+        </tr>
+      <% end %>
       <tr>
         <th class="col-3" scope="row">Deposit created</th>
         <td><%= created_at %></td>

--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -115,7 +115,7 @@ module Works
     end
 
     def version_purl(version)
-      purl + "/v/#{version}"
+      purl + "/v#{version}"
     end
 
     private

--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -104,6 +104,22 @@ module Works
       work.last_rejection_description
     end
 
+    def previous_user_versions?
+      return false unless Settings.user_versions_ui_enabled
+
+      return true if work_version.user_version > 1
+
+      false
+    end
+
+    def previous_user_versions
+      (1..work_version.user_version - 1).to_a.reverse
+    end
+
+    def version_purl(version)
+      purl + "/v/#{version}"
+    end
+
     private
 
     def format_edtf(edtf)

--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -107,9 +107,7 @@ module Works
     def previous_user_versions?
       return false unless Settings.user_versions_ui_enabled
 
-      return true if work_version.user_version > 1
-
-      false
+      work_version.user_version > 1
     end
 
     def previous_user_versions

--- a/spec/components/works/detail_component_spec.rb
+++ b/spec/components/works/detail_component_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Works::DetailComponent, type: :component do
 
       it 'renders links to previous user versions' do
         expect(rendered.to_html).to include 'Previous version(s)'
-        expect(rendered.to_html).to include 'https://purl.stanford.edu/bc123df4567/v/2'
+        expect(rendered.to_html).to include 'https://purl.stanford.edu/bc123df4567/v2'
       end
     end
 

--- a/spec/components/works/detail_component_spec.rb
+++ b/spec/components/works/detail_component_spec.rb
@@ -31,8 +31,10 @@ RSpec.describe Works::DetailComponent, type: :component do
   end
 
   context 'when deposited' do
+    let(:work) { create(:work, :with_druid) }
     let(:work_version) do
-      build_stubbed(:work_version, :deposited, version: 2, version_description: 'changed the title', user_version: 3)
+      build_stubbed(:work_version, :deposited, version: 2, version_description: 'changed the title', user_version: 3,
+                                               work:)
     end
 
     it 'renders the draft title' do
@@ -47,6 +49,36 @@ RSpec.describe Works::DetailComponent, type: :component do
 
       it 'renders the user_version' do
         expect(rendered.to_html).to include '3 - changed the title'
+      end
+    end
+  end
+
+  context 'when user_versions_ui_enabled' do
+    let(:work) { create(:work, :with_druid) }
+
+    before do
+      allow(Settings).to receive(:user_versions_ui_enabled).and_return(true)
+    end
+
+    context 'with multiple user versions' do
+      let(:work_version) do
+        build_stubbed(:work_version, :deposited, version: 4, version_description: 'changed the files', user_version: 3,
+                                                 work:)
+      end
+
+      it 'renders links to previous user versions' do
+        expect(rendered.to_html).to include 'Previous version(s)'
+        expect(rendered.to_html).to include 'https://purl.stanford.edu/bc123df4567/v/2'
+      end
+    end
+
+    context 'when no previous user versions' do
+      let(:work_version) do
+        build_stubbed(:work_version, :deposited, version: 1, user_version: 1, work:)
+      end
+
+      it 'does not render previous versions' do
+        expect(rendered.to_html).not_to include 'Previous version(s)'
       end
     end
   end


### PR DESCRIPTION
# Why was this change made? 🤔
Resolves #3582 to show links to purls for previous versions. Does not change the current prod view where user versions are not enabled. HOLD for PO review.

When there is only one user version, no Previous versions row displays:

![Screenshot 2024-07-26 at 10 31 14 AM](https://github.com/user-attachments/assets/4e7cac87-a050-4dc8-b76b-8d0a5ed0818b)

When previous user versions exist: 

![Screenshot 2024-07-26 at 10 35 03 AM](https://github.com/user-attachments/assets/2c9c9e6d-f8b3-4fab-8a1e-c57279065ce9)


# How was this change tested? 🤨
Unit and testing on QA. 