### PR TITLE
Alert Honeybadger when OCLC FAST API service returns errors

### DIFF
--- a/app/controllers/fast_controller.rb
+++ b/app/controllers/fast_controller.rb
@@ -48,9 +48,10 @@ class FastController < ApplicationController
       req.params['sort'] = 'usage desc'
     end
 
-    return Failure("Autocomplete results for #{query} returned #{resp.status}") unless resp.success?
+    return Success(parse(resp.body)) if resp.success?
 
-    Success(parse(resp.body))
+    Honeybadger.notify('FAST API Error', context: { params: params.to_unsafe_h, response: resp })
+    Failure("Autocomplete results for #{query} returned #{resp.status}")
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/spec/requests/fast_spec.rb
+++ b/spec/requests/fast_spec.rb
@@ -307,6 +307,7 @@ RSpec.describe 'Fast Controller' do
         .with(headers:)
         .to_return(status: [404, 'some error message'], body: '', headers: {})
       allow(Rails.logger).to receive(:warn)
+      allow(Honeybadger).to receive(:notify)
     end
 
     it 'returns status 500 and an empty body' do
@@ -314,6 +315,7 @@ RSpec.describe 'Fast Controller' do
       expect(response).to have_http_status :internal_server_error
       expect(response.body).to eq ''
       expect(Rails.logger).to have_received(:warn).with('Autocomplete results for tea returned 404')
+      expect(Honeybadger).to have_received(:notify).with('FAST API Error', context: hash_including(:params, :response))
     end
   end
 end


### PR DESCRIPTION
Connects to #3581

# Why was this change made?

So we know when the keywords typeahead API goes down or is decommissioned.

# How was this change tested?

CI
