### PR TITLE
Update purl version links to new pattern

### DIFF
--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -116,7 +116,7 @@ module Works
     end
 
     def version_purl(version)
-      purl + "/v#{version}"
+      purl + "/version/#{version}"
     end
 
     private

--- a/app/javascript/controllers/auto_citation_controller.js
+++ b/app/javascript/controllers/auto_citation_controller.js
@@ -96,7 +96,7 @@ export default class extends Controller {
     if (!this.userVersionsUiEnabledValue) {
       return ''
     }
-    return `/v${this.version}`
+    return `/version/${this.version}`
   }
 
   get versionClause () {

--- a/spec/components/works/detail_component_spec.rb
+++ b/spec/components/works/detail_component_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Works::DetailComponent, type: :component do
 
       it 'renders links to previous user versions' do
         expect(rendered.to_html).to include 'Previous version(s)'
-        expect(rendered.to_html).to include 'https://purl.stanford.edu/bc123df4567/v2'
+        expect(rendered.to_html).to include 'https://purl.stanford.edu/bc123df4567/version/2'
       end
     end
 


### PR DESCRIPTION
# Why was this change made? 🤔
Resolves #3594 to use new version URL pattern in purl links and auto-citation.  Because the citation is saved to the database, it's possible that there may be old saved version URLs in citations where the auto-generated citation wasn't being used. I think this is OK though, since it's just stage and QA?


![Screenshot 2024-08-08 at 10 02 37 AM](https://github.com/user-attachments/assets/af860f27-649b-42d9-8c28-f9f0d860ad5e)

Will also be updating H2 version integration test.

# How was this change tested? 🤨
Unit and stage.


