### PR TITLE
Don't show dash when no version description

### DIFF
--- a/app/components/works/detail_component.rb
+++ b/app/components/works/detail_component.rb
@@ -21,7 +21,9 @@ module Works
     def version
       return '1 - initial version' if first_draft?
 
-      "#{version_number} - #{version_description}"
+      return "#{version_number} - #{version_description}" if version_description.present?
+
+      version_number
     end
 
     def doi_setting

--- a/spec/components/works/detail_component_spec.rb
+++ b/spec/components/works/detail_component_spec.rb
@@ -74,11 +74,14 @@ RSpec.describe Works::DetailComponent, type: :component do
 
     context 'when no previous user versions' do
       let(:work_version) do
-        build_stubbed(:work_version, :deposited, version: 1, user_version: 1, work:)
+        build_stubbed(:work_version, :deposited, version: 1, user_version: 1, version_description: nil, work:)
       end
 
       it 'does not render previous versions' do
         expect(rendered.to_html).not_to include 'Previous version(s)'
+        expect(rendered.to_html).to include 'Current version'
+        expect(rendered.css('td').to_html).not_to include '1 -'
+        expect(rendered.css('td').to_html).to include '1'
       end
     end
 


### PR DESCRIPTION
# Why was this change made? 🤔

A version 1 user version may not have a version description. Instead of showing a dash next to empty space, hide the dash. (I know this wasn't ticketed, @amyehodge, but it's been bugging me while we've been working on versions and is easy to fix.) 

Before:

![Screenshot 2024-08-08 at 12 38 57 PM](https://github.com/user-attachments/assets/76a783e2-b0b8-426d-a36e-07e23be8158e)

After:

![Screenshot 2024-08-08 at 12 45 11 PM](https://github.com/user-attachments/assets/b05bd092-dad9-4401-983e-afaf8da71baf)

If a work version and description created later:

![Screenshot 2024-08-08 at 12 58 14 PM](https://github.com/user-attachments/assets/f3ca4f7a-6dd3-4f9c-ba86-974a86c5ae07)
