### PR TITLE
work edit, file upload via browser: allow a user to re-add a file of the same name as one that was removed from the list

### DIFF
--- a/app/javascript/controllers/dropzone_controller.js
+++ b/app/javascript/controllers/dropzone_controller.js
@@ -31,6 +31,12 @@ export default class extends Controller {
     }
   }
 
+  isVisible (elem) {
+    // cobbled together from a combo of Jeremy's solution in https://github.com/sul-dlss/happy-heron/pull/1582 (commit 27c81bc2a) and
+    // this stack overflow discussion, particularly this thread: https://stackoverflow.com/a/33456469
+    return !!(elem.offsetParent || elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length) && window.getComputedStyle(elem).visibility !== 'hidden'
+  }
+
   checkForDuplicates (fileName) {
     // Extract all filenames that are visible
     // Unfortunately, the filename targets are not contained in the scope of the controller.
@@ -39,6 +45,10 @@ export default class extends Controller {
     const fileNameNodes = Array.from(document.querySelectorAll('[data-dropzone-path]'))
 
     const filepaths = fileNameNodes.map(fileNameNode => {
+      // If it's not visible (e.g. the parent element style is set to 'display: none'), that implies that the user has removed it from
+      // the list of files to upload or keep, so we don't need to worry about a name collision.
+      if (!this.isVisible(fileNameNode)) return null
+
       const path = fileNameNode.getAttribute('data-dropzone-path')
       const filename = fileNameNode.innerText.trim()
 

--- a/spec/features/create_new_work_spec.rb
+++ b/spec/features/create_new_work_spec.rb
@@ -87,16 +87,30 @@ RSpec.describe 'Create a new work in a deposited collection', :js do
             click_link_or_button('Choose files')
           end
           expect(page).to have_css('div.dz-success-mark')
+
           page.attach_file(Rails.root.join('spec/fixtures/files/sul.svg')) do
             click_link_or_button('Choose files')
           end
-
           expect(page).to have_content('Duplicate file')
+
           # remove the file which has the 'duplicate' error
           within('div.dz-error', visible: true) do
             find('.remove-file').click
           end
           expect(page).to have_no_content('Duplicate file')
+
+          # it should be possible to add back a file that's been removed
+          choose 'work_upload_type_browser'
+          page.attach_file(Rails.root.join('spec/fixtures/files/test-data.txt')) do
+            click_link_or_button('Choose files')
+          end
+          expect(page).to have_css('div.dz-success-mark')
+          find('input[value="test-data.txt"]', visible: false).find(:xpath, './/..').click_link_or_button('Remove file')
+          page.attach_file(Rails.root.join('spec/fixtures/files/test-data.txt')) do
+            click_link_or_button('Choose files')
+          end
+          expect(page).to have_no_content('Duplicate file')
+          expect(page).to have_css('div.dz-success-mark', count: 2)
           # End of client-side validation testing
 
           choose 'work_upload_type_browser'


### PR DESCRIPTION
# Why was this change made? 🤔

fixes #3602

# How was this change tested? 🤨

- augmented feature spec (commented out fix temporarily on localhost and confirmed the test failed because it couldn't find the expected success indicator when trying to re-add the same file after removal)
- manual testing in firefox and chrome, on localhost and stage

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

n/a

# Does your change introduce accessibility violations? 🩺

it shouldn't

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



