### PR TITLE
Refine allow readd file same name

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -684,3 +684,6 @@ Style/SuperArguments: # new in 1.64
   Enabled: true
 Rails/WhereRange: # new in 2.25
   Enabled: false
+
+Gemspec/AddRuntimeDependency: # new in 1.65
+  Enabled: true

--- a/app/javascript/controllers/dropzone_controller.js
+++ b/app/javascript/controllers/dropzone_controller.js
@@ -32,9 +32,13 @@ export default class extends Controller {
   }
 
   isVisible (elem) {
-    // cobbled together from a combo of Jeremy's solution in https://github.com/sul-dlss/happy-heron/pull/1582 (commit 27c81bc2a) and
-    // this stack overflow discussion, particularly this thread: https://stackoverflow.com/a/33456469
-    return !!(elem.offsetParent || elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length) && window.getComputedStyle(elem).visibility !== 'hidden'
+    // courtesy mjgiarlo and https://stackoverflow.com/a/72717388/24039837
+    // see also https://drafts.csswg.org/cssom-view-1/#dom-element-checkvisibility
+    return elem.checkVisibility({
+      checkOpacity: true, // if elem, or an ancestor of elem in the flat tree, has a computed opacity value of 0, return false.
+      checkVisibilityCSS: true, // if elem is invisible, return false.
+      contentVisibilityAuto: true // if an ancestor of elem in the flat tree skips its contents due to content-visibility: auto, return false.
+    })
   }
 
   checkForDuplicates (fileName) {


### PR DESCRIPTION
# Why was this change made? 🤔

* @mjgiarlo made a good suggestion for refining the check after the PR was merged: https://github.com/sul-dlss/happy-heron/pull/3603#discussion_r1718543042
* i noticed a small rubocop touchup

# How was this change tested? 🤨

* existing feature test from #3603
* browser testing using chrome and FF, on dev laptop and stage


https://github.com/user-attachments/assets/0e3f0bc5-6e34-422d-b784-c7bcd72d09a1


⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

n/a

# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡

hope not!


