### PR TITLE
Do not show version description form when rejected.

### DIFF
--- a/app/components/works/version_description_component.rb
+++ b/app/components/works/version_description_component.rb
@@ -14,7 +14,7 @@ module Works
     end
 
     def show?
-      %w[deposited rejected version_draft].include? work_version.state
+      (%w[deposited version_draft].include? work_version.state) || (work_version.rejected? && work_version.version > 1)
     end
 
     def hidden_user_version?

--- a/spec/components/works/version_description_component_spec.rb
+++ b/spec/components/works/version_description_component_spec.rb
@@ -24,6 +24,22 @@ RSpec.describe Works::VersionDescriptionComponent, type: :component do
     end
   end
 
+  context 'with a rejected work' do
+    let(:work_version) { build(:work_version, work:, state: 'rejected') }
+
+    it 'does not render the component' do
+      expect(rendered.to_html).not_to include('Version your work')
+    end
+  end
+
+  context 'with a rejected work that has been accessioned' do
+    let(:work_version) { build(:work_version, work:, version: 2, state: 'rejected') }
+
+    it 'renders the component' do
+      expect(rendered.to_html).to include('Version your work')
+    end
+  end
+
   context 'when user version feature flag is on' do
     let(:work_version) { build(:work_version, work:, state: 'deposited') }
 


### PR DESCRIPTION
closes #3606

# Why was this change made? 🤔
Per @amyehodge 


# How was this change tested? 🤨
Unit, Amy

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



