### PR TITLE
File uploads should be disabled until version selection made

### DIFF
--- a/app/javascript/controllers/new_user_version_controller.js
+++ b/app/javascript/controllers/new_user_version_controller.js
@@ -6,6 +6,11 @@ export default class extends Controller {
   connect () {
     if (!this.hasUserVersionYesTarget || !this.hasUserVersionNoTarget) return
 
+    // when first loading page, neither version radio is selected
+    if (this.userVersionYesTarget.checked === false && this.userVersionNoTarget.checked === false) {
+      this.fileUploadsFieldsetTarget.disabled = true
+      this.fileSectionTarget.style.opacity = 0.5
+    }
     if (this.userVersionYesTarget.checked === true) {
       this.versionDescriptionNoTarget.disabled = true
       this.versionDescriptionNoTarget.value = ''

--- a/app/javascript/controllers/new_user_version_controller.js
+++ b/app/javascript/controllers/new_user_version_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
     // when first loading page, neither version radio is selected
     if (this.userVersionYesTarget.checked === false && this.userVersionNoTarget.checked === false) {
       this.fileUploadsFieldsetTarget.disabled = true
-      this.fileSectionTarget.style.opacity = 0.5
+      this.fileSectionTarget.classList.add('opacity-50')
     }
     if (this.userVersionYesTarget.checked === true) {
       this.versionDescriptionNoTarget.disabled = true
@@ -19,7 +19,8 @@ export default class extends Controller {
       this.versionDescriptionYesTarget.value = this.versionDescriptionTarget.value
       // enable the file upload section
       this.fileUploadsFieldsetTarget.disabled = false
-      this.fileSectionTarget.style.opacity = 1.0
+      this.fileSectionTarget.classList.add('opacity-100')
+      this.fileSectionTarget.classList.remove('opacity-50')
     }
     if (this.userVersionNoTarget.checked === true) {
       this.versionDescriptionYesTarget.disabled = true
@@ -29,7 +30,8 @@ export default class extends Controller {
       this.versionDescriptionNoTarget.value = this.versionDescriptionTarget.value
       // disable the file upload section
       this.fileUploadsFieldsetTarget.disabled = true
-      this.fileSectionTarget.style.opacity = 0.5
+      this.fileSectionTarget.classList.add('opacity-50')
+      this.fileSectionTarget.classList.remove('opacity-100')
     }
   }
 
@@ -51,10 +53,12 @@ export default class extends Controller {
   disableFileUploads (event) {
     if (event.currentTarget === this.userVersionNoTarget) {
       this.fileUploadsFieldsetTarget.disabled = true
-      this.fileSectionTarget.style.opacity = 0.5
+      this.fileSectionTarget.classList.add('opacity-50')
+      this.fileSectionTarget.classList.remove('opacity-100')
     } else if (event.currentTarget === this.userVersionYesTarget) {
       this.fileUploadsFieldsetTarget.disabled = false
-      this.fileSectionTarget.style.opacity = 1.0
+      this.fileSectionTarget.classList.add('opacity-100')
+      this.fileSectionTarget.classList.remove('opacity-50')
     }
   }
 

--- a/spec/features/update_existing_work_spec.rb
+++ b/spec/features/update_existing_work_spec.rb
@@ -111,9 +111,10 @@ RSpec.describe 'Update an existing work in a deposited collection', :js do
       click_link_or_button "Edit #{test_title}"
 
       expect(page).to have_content('Do you want to create a new version of this deposit?')
+      expect(find_by_id('work_upload_type_browser')).to be_disabled
 
       choose('No')
-
+      expect(find_by_id('work_upload_type_browser')).to be_disabled
       fill_in "What's changing?", with: 'Nothing really'
       click_link_or_button 'Deposit'
       expect(page).to have_content('You have successfully deposited your work')
@@ -129,6 +130,7 @@ RSpec.describe 'Update an existing work in a deposited collection', :js do
       visit work_path(work)
       click_link_or_button "Edit #{test_title}"
       expect(page).to have_content('Do you want to create a new version of this deposit?')
+      expect(find_by_id('work_upload_type_browser')).to be_disabled
 
       choose('Yes')
       expect(find_by_id('work_upload_type_zipfile')).not_to be_disabled


### PR DESCRIPTION
# Why was this change made? 🤔
Resolves #3612 to keep files upload section disabled until user makes a version selection. 

# How was this change tested? 🤨
Unit and PO. 


# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



