### PR TITLE
[WIP] File count validation

### DIFF
--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -56,7 +56,7 @@
     <div class="form-check pt-3" data-complex-radio-target="selection">
       <%= form.radio_button :upload_type, 'zipfile', class: 'form-check-input',
                                                      data: { action: 'complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus', file_uploads_target: 'zipRadioButton' } %>
-      <%= form.label :upload_type_zipfile, "Upload a single zip file (containing fewer than #{number_with_delimiter(Settings.max_files_in_zip)} files and less than 10GB total), which will be unzipped, including any hierarchy.", class: 'form-check-label fw-semibold' %>
+      <%= form.label :upload_type_zipfile, "Upload a single zip file (containing fewer than #{number_with_delimiter(Settings.max_files_in_object)} files and less than 10GB total), which will be unzipped, including any hierarchy.", class: 'form-check-label fw-semibold' %>
       <div id="zip-files-panel" data-file-uploads-target="zipUpload">
         <p>Viewers will see the file hierarchy and be able to download individual files. Unzipping may take several minutes if your zip file contains a large number of individual files.</p>
         <p><strong>Warning:</strong> this file upload option will automatically replace all existing files on your item with the content in the new zip file.</p>
@@ -88,7 +88,7 @@
     <div class="form-check pt-3" data-complex-radio-target="selection">
       <%= form.radio_button :upload_type, 'globus', class: 'form-check-input', 'data-file-uploads-target': 'globusRadioButton', 'data-deposit-button-target': 'globusRadioButton',
                                                     data: { action: 'complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus' } %>
-      <%= form.label :upload_type_globus, "Upload one or more files via Globus (fewer than #{number_with_delimiter(Settings.max_files_in_zip)} files and less than 4TB total) which will be displayed as uploaded, including any file hierarchy.", class: 'form-check-label fw-semibold' %>
+      <%= form.label :upload_type_globus, "Upload one or more files via Globus (fewer than #{number_with_delimiter(Settings.max_files_in_object)} files and less than 4TB total) which will be displayed as uploaded, including any file hierarchy.", class: 'form-check-label fw-semibold' %>
 
       <div data-file-uploads-target="globusUpload">
         <p>Please notify us at <a href="mailto:sdr-contact@lists.stanford.edu">sdr-contact@lists.stanford.edu</a> if you are uploading 1TB or more of content.</p>

--- a/app/components/works/add_files_component.html.erb
+++ b/app/components/works/add_files_component.html.erb
@@ -56,7 +56,7 @@
     <div class="form-check pt-3" data-complex-radio-target="selection">
       <%= form.radio_button :upload_type, 'zipfile', class: 'form-check-input',
                                                      data: { action: 'complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus', file_uploads_target: 'zipRadioButton' } %>
-      <%= form.label :upload_type_zipfile, 'Upload a single zip file (containing fewer than 25,000 files and less than 10GB total), which will be unzipped, including any hierarchy.', class: 'form-check-label fw-semibold' %>
+      <%= form.label :upload_type_zipfile, "Upload a single zip file (containing fewer than #{number_with_delimiter(Settings.max_files_in_zip)} files and less than 10GB total), which will be unzipped, including any hierarchy.", class: 'form-check-label fw-semibold' %>
       <div id="zip-files-panel" data-file-uploads-target="zipUpload">
         <p>Viewers will see the file hierarchy and be able to download individual files. Unzipping may take several minutes if your zip file contains a large number of individual files.</p>
         <p><strong>Warning:</strong> this file upload option will automatically replace all existing files on your item with the content in the new zip file.</p>
@@ -88,7 +88,7 @@
     <div class="form-check pt-3" data-complex-radio-target="selection">
       <%= form.radio_button :upload_type, 'globus', class: 'form-check-input', 'data-file-uploads-target': 'globusRadioButton', 'data-deposit-button-target': 'globusRadioButton',
                                                     data: { action: 'complex-radio#disableUnselectedInputs file-uploads#updatePanelVisibility deposit-button#updateDepositButtonStatus' } %>
-      <%= form.label :upload_type_globus, 'Upload one or more files via Globus (fewer than 25,000 files and less than 4TB total) which will be displayed as uploaded, including any file hierarchy.', class: 'form-check-label fw-semibold' %>
+      <%= form.label :upload_type_globus, "Upload one or more files via Globus (fewer than #{number_with_delimiter(Settings.max_files_in_zip)} files and less than 4TB total) which will be displayed as uploaded, including any file hierarchy.", class: 'form-check-label fw-semibold' %>
 
       <div data-file-uploads-target="globusUpload">
         <p>Please notify us at <a href="mailto:sdr-contact@lists.stanford.edu">sdr-contact@lists.stanford.edu</a> if you are uploading 1TB or more of content.</p>

--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -30,7 +30,6 @@ class WorkVersion < ApplicationRecord
   validates :license, inclusion: { in: License.license_list(include_displayable: true) }
   validates :subtype, work_subtype: true
   validates :work_type, presence: true, work_type: true
-  validate :number_of_files
 
   strip_attributes allow_empty: true, only: %i[title abstract citation]
 
@@ -221,25 +220,6 @@ class WorkVersion < ApplicationRecord
   end
 
   private
-
-  # if the user selects browser or zip upload types, prevent them from depositing an object with more
-  # than the allowed number of files which could cause problems with the deposit process in accessioning
-  def number_of_files
-    return if globus?
-
-    return if attached_files.empty?
-
-    max_files_allowed = if browser?
-                          Settings.max_upload_files
-                        else
-                          Settings.max_files_in_zip
-                        end
-    return unless attached_files.length > max_files_allowed
-
-    error_msg = "You cannot add more than #{max_files_allowed} files via #{upload_type} upload. "
-    error_msg += 'Please select a different method.'
-    errors.add(:base, error_msg)
-  end
 
   def locally_cached_file_for(blob)
     return unless blob.service.instance_of?(ActiveStorage::Service::DiskService)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -128,4 +128,4 @@ dor_services:
 workflow_url: 'https://workflow.example.com/workflow'
 
 max_upload_files: 250
-max_files_in_zip: 3
+max_files_in_object: 25000

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -128,3 +128,4 @@ dor_services:
 workflow_url: 'https://workflow.example.com/workflow'
 
 max_upload_files: 250
+max_files_in_zip: 3


### PR DESCRIPTION
# Why was this change made? 🤔

Because when users deposit more than a certain number of files via H2, it causes pain downstream.  This blocks the DepositJob from even starting.  

~~Unclear what the error messaging looks like in production (it causes a state machine transition exception in localhost), but there is a similar pattern for version mismatches.~~

Will produce a flash validation message telling the user what went wrong (and will notify HB for our benefit).  Will also do this for a version mismatch issue (which currently will just throw a 500 and not give the user any useful message).

One thing I am wondering about is why the `Unzip` or `FetchGlobus` jobs happen after the state transition to depositing on https://github.com/sul-dlss/happy-heron/blob/main/app/controllers/works_controller.rb#L204 (which will kick off the deposit job via https://github.com/sul-dlss/happy-heron/blob/main/app/services/work_observer.rb#L30-L33).  I think this logic means that the validation in this PR won't run in time to catch large globus/zip objects (which is what we want), but i'm an unclear as to how this all fits together (see https://github.com/sul-dlss/happy-heron/blob/main/app/controllers/works_controller.rb#L202-L210

![Screenshot 2024-11-25 at 9 44 09 AM](https://github.com/user-attachments/assets/8e886508-88a1-4172-85ed-3f615e769f57)


# How was this change tested? 🤨

Localhost