### PR TITLE
Add work type and subtypes to the admin item report

### DIFF
--- a/app/services/admin/work_csv_generator.rb
+++ b/app/services/admin/work_csv_generator.rb
@@ -40,6 +40,8 @@ module Admin
       'license',
       'custom rights',
       'DOI',
+      'work type',
+      'work subtypes',
       'collection title',
       'collection id',
       'collection druid'
@@ -66,6 +68,8 @@ module Admin
         version.license,
         version.custom_rights ? 'yes' : 'no',
         work.doi,
+        version.work_type,
+        version.subtype&.join('; '),
         collection.head.name,
         collection.id,
         collection.druid_without_namespace

--- a/spec/services/admin/work_csv_generator_spec.rb
+++ b/spec/services/admin/work_csv_generator_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Admin::WorkCsvGenerator do
 
     it 'generates a CSV' do
       expect(csv).to eq <<~CSV
-        item title,work id,druid,state,version number,depositor,owner,date created,date last modified,date last deposited,release,visibility,license,custom rights,DOI,collection title,collection id,collection druid
-        Test title 1,1,cn748wq9511,deposited,1,user1,user2,2007-02-10 15:30:45 UTC,2019-01-01 00:00:00 UTC,2019-01-01 00:00:00 UTC,immediate,world,CC0-1.0,yes,10.25740/bc123df4567,Test collection,2,bb000bb0000
+        item title,work id,druid,state,version number,depositor,owner,date created,date last modified,date last deposited,release,visibility,license,custom rights,DOI,work type,work subtypes,collection title,collection id,collection druid
+        Test title 1,1,cn748wq9511,deposited,1,user1,user2,2007-02-10 15:30:45 UTC,2019-01-01 00:00:00 UTC,2019-01-01 00:00:00 UTC,immediate,world,CC0-1.0,yes,10.25740/bc123df4567,text,Code; Oral history,Test collection,2,bb000bb0000
       CSV
     end
   end
@@ -52,8 +52,8 @@ RSpec.describe Admin::WorkCsvGenerator do
 
     it 'generates a CSV' do
       expect(csv).to eq <<~CSV
-        item title,work id,druid,state,version number,depositor,owner,date created,date last modified,date last deposited,release,visibility,license,custom rights,DOI,collection title,collection id,collection druid
-        Test title 1,1,cn748wq9511,deposited,1,user1,user2,2007-02-10 15:30:45 UTC,2019-01-01 00:00:00 UTC,2019-01-01 00:00:00 UTC,immediate,world,CC0-1.0,no,10.25740/bc123df4567,Test collection,2,bb000bb0000
+        item title,work id,druid,state,version number,depositor,owner,date created,date last modified,date last deposited,release,visibility,license,custom rights,DOI,work type,work subtypes,collection title,collection id,collection druid
+        Test title 1,1,cn748wq9511,deposited,1,user1,user2,2007-02-10 15:30:45 UTC,2019-01-01 00:00:00 UTC,2019-01-01 00:00:00 UTC,immediate,world,CC0-1.0,no,10.25740/bc123df4567,text,Code; Oral history,Test collection,2,bb000bb0000
       CSV
     end
   end


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3645 


# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



