### PR TITLE
Exclude `vendor/*` from erb_lint runs

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,6 +1,6 @@
 ---
 exclude:
-  - '**/vendor/**/*'
+  - 'vendor/**/*'
 linters:
   Rubocop:
     enabled: true


### PR DESCRIPTION
I'm not sure if this line has always been broken or not, but I found we wanted this change in H3 so I'm porting it to H2.

CI is now linting ~920 fewer ERBs (all from dependencies, none that we want to lint)

