### PR TITLE
add rake task to produce csv report on work types/subtypes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,6 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
-    bcrypt_pbkdf (1.1.1-arm64-darwin)
     benchmark (0.4.0)
     better_html (2.1.1)
       actionview (>= 6.0)

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+namespace :reports do
+  desc 'Exports work type and subtypes of current version of each work'
+  task work_types: :environment do
+    CSV.open('tmp/work_types.csv', 'wb') do |csv|
+      csv << %w[work_id title work_type work_subtypes state]
+      Work.find_each do |work|
+        work_version = work.head
+        csv << [work.id, work_version.title, work_version.work_type, work_version.subtype&.join('|'),
+                work_version.state]
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes #3689 - create a csv file with work types/subtypes

# How was this change tested? 🤨

Rails console on the server