### PR TITLE
pin mais-orcid-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem 'honeybadger'
 gem 'jbuilder'
 gem 'jsbundling-rails'
 gem 'lograge', '~> 0.11.2'
-gem 'mais_orcid_client'
+gem 'mais_orcid_client', '< 1' # MAIS ORCID Client will have breaking changes in v1.0, see https://github.com/sul-dlss/mais_orcid_client/issues/108
 gem 'okcomputer'
 gem 'pg'
 gem 'preservation-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -741,7 +741,7 @@ DEPENDENCIES
   jsbundling-rails
   listen (~> 3.2)
   lograge (~> 0.11.2)
-  mais_orcid_client
+  mais_orcid_client (< 1)
   multi_json
   okcomputer
   pg


### PR DESCRIPTION
# Why was this change made? 🤔

We need to pin the mais-orcid-client so that the changes in the new API do not go into effect until we do the new gem release and update the codebase.

# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



