### PR TITLE
Serialize response object as hash for easier inspection in HB UI

### DIFF
--- a/app/controllers/fast_controller.rb
+++ b/app/controllers/fast_controller.rb
@@ -40,11 +40,11 @@ class FastController < ApplicationController
 
     return Success(parse(response.body)) if response.success?
 
-    Honeybadger.notify('FAST API Error', context: { response:, params: params.to_unsafe_h })
+    Honeybadger.notify('FAST API Error', context: { response: response.to_hash, params: params.to_unsafe_h })
     Failure("Autocomplete results for #{query} returned HTTP #{response.status}")
   rescue JSON::ParserError => e
     Honeybadger.notify('Unexpected response from FAST API',
-                       context: { response:, params: params.to_unsafe_h, exception: e })
+                       context: { response: response.to_hash, params: params.to_unsafe_h, exception: e })
     Failure("Autocomplete results for #{query} returned unexpected response '#{response.body}'")
   end
 


### PR DESCRIPTION
# Why was this change made? 🤔



# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



