### PR TITLE
Encode user-provided keyword strings before sending to FAST API

### DIFF
--- a/app/controllers/fast_controller.rb
+++ b/app/controllers/fast_controller.rb
@@ -28,7 +28,7 @@ class FastController < ApplicationController
 
   def lookup(query) # rubocop:disable Metrics/AbcSize
     response = lookup_connection.get do |req|
-      req.params['query'] = query
+      req.params['query'] = ERB::Util.url_encode(query)
       req.params['queryIndex'] = 'suggestall'
       req.params['queryReturn'] = 'idroot,suggestall,tag'
       req.params['suggest'] = 'autoSubject'


### PR DESCRIPTION
# Why was this change made?

Do this because it is a best practice and because it eliminates HB exceptions about unhelpful 400 Bad Request responses from the FAST API when we send it improperly escaped query strings.

# How was this change tested?

CI, prod
