### PR TITLE
Coerce HTTP response in accountservice to hash

### DIFF
--- a/app/services/account_service.rb
+++ b/app/services/account_service.rb
@@ -20,7 +20,7 @@ class AccountService
       begin
         tries ||= 1
         response = connection.get(url)
-        Honeybadger.context(sunetid:, response:)
+        Honeybadger.context(sunetid:, response: response.to_hash)
         # Raise and retry if the response is an HTTP 500.
         #
         # If, on the other hand, a bogus sunetid is provided, the `status` of the response will be 404, and then we:


### PR DESCRIPTION
# Why was this change made?

Make it easier to figure out why the account API is causing problems. Else the HB context includes unhelpful info like:   `"response" => "#<Faraday::Response>"`


# How was this change tested?

CI

