### PR TITLE
Handle files with dupe names.

### DIFF
--- a/app/models/attached_file.rb
+++ b/app/models/attached_file.rb
@@ -10,7 +10,7 @@ class AttachedFile < ApplicationRecord
   end
 
   delegate :blob, to: :file
-  delegate :filename, :content_type, :byte_size, to: :blob
+  delegate :filename, :content_type, :byte_size, :checksum, to: :blob
 
   # This is a temporary method that makes the blobs that haven't yet been updated
   # appear to be from preservation, but it only changes the blob in memory.
@@ -60,6 +60,13 @@ class AttachedFile < ApplicationRecord
   # a string containing the base filename, removing any containing directories if they exist; e.g. 'test.pdf'
   def basename
     path.split(File::SEPARATOR).last
+  end
+
+  # @return [String nil] the MD5 checksum in hexadecimal format or nil if in globus
+  def md5
+    return if in_globus?
+
+    Base64.decode64(checksum).unpack1('H*')
   end
 
   private

--- a/app/services/cocina_generator/structural/file_generator.rb
+++ b/app/services/cocina_generator/structural/file_generator.rb
@@ -73,7 +73,7 @@ module CocinaGenerator
         return cocina_file.hasMessageDigests if cocina_file
 
         [
-          { type: 'md5', digest: base64_to_hexdigest(blob.checksum) },
+          { type: 'md5', digest: attached_file.md5 },
           { type: 'sha1', digest: Digest::SHA1.file(file_path(blob.key)).hexdigest }
         ]
       end
@@ -105,10 +105,6 @@ module CocinaGenerator
 
       def file_path(key)
         ActiveStorage::Blob.service.path_for(key)
-      end
-
-      def base64_to_hexdigest(base64)
-        Base64.decode64(base64).unpack1('H*')
       end
 
       def mime_type

--- a/app/services/cocina_generator/structural/generator.rb
+++ b/app/services/cocina_generator/structural/generator.rb
@@ -41,14 +41,19 @@ module CocinaGenerator
           .structural
           .contains
           .filter_map do |fileset|
-          next unless (preserved_file = get_preserved_file(fileset.structural.contains.first.filename))
+          cocina_file = fileset.structural.contains.first
+          next unless (preserved_file = get_preserved_file(cocina_file))
 
           build_fileset(attached_file: preserved_file, fileset:)
         end
       end
 
-      def get_preserved_file(filename)
-        work_version.preserved_files.find { |attached_file| attached_file.path == filename }
+      def get_preserved_file(cocina_file)
+        # Match on path and md5 (when possible)
+        work_version.preserved_files.find do |attached_file|
+          md5 = cocina_file.hasMessageDigests&.find { |digest| digest.type == 'md5' }&.digest
+          (attached_file.path == cocina_file.filename) && (attached_file.in_globus? || md5 == attached_file.md5)
+        end
       end
 
       # rubocop:disable Metrics/AbcSize

--- a/spec/services/cocina_generator/dro_generator_spec.rb
+++ b/spec/services/cocina_generator/dro_generator_spec.rb
@@ -492,7 +492,51 @@ RSpec.describe CocinaGenerator::DROGenerator do
       end
       let(:work) { build(:work, id: 7, druid: 'druid:bk123gh4567', collection:) }
       let(:cocina_obj) do
-        Cocina::RSpec::Factories.build(:dro_with_metadata, id: 'druid:bk123gh4567')
+        Cocina::RSpec::Factories.build(:dro_with_metadata, id: 'druid:bk123gh4567').new(
+          access: {
+            view: 'world',
+            download: 'world'
+          },
+          structural: {
+            contains: [
+              # This has the same filename but different label and md5.
+              {
+                label: 'Original MyString',
+                structural: {
+                  contains: [
+                    {
+                      access: {
+                        view: 'world', download: 'world'
+                      },
+                      administrative: {
+                        publish: true, sdrPreserve: true, shelve: true
+                      },
+                      filename: 'sul.svg',
+                      hasMessageDigests: [
+                        {
+                          digest: 'g6eff9e28f154f79f7a11261bc0d4b41', type: 'md5'
+                        },
+                        {
+                          digest: '2046f6584c2f0f5e9c0df7e8070d14d1ec65f382', type: 'sha1'
+                        }
+                      ],
+                      hasMimeType: 'image/svg+xml',
+                      label: 'MyString',
+                      size: 17_675,
+                      type: Cocina::Models::ObjectType.file,
+                      externalIdentifier: '9999999',
+                      version: 1
+                    }
+                  ]
+                },
+                type: Cocina::Models::FileSetType.file,
+                externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/bk123gh4567-123456',
+                version: 1
+              }
+            ],
+            isMemberOf: [collection.druid]
+          }
+        )
       end
       let(:expected_model) do
         Cocina::Models::DRO.new(


### PR DESCRIPTION
closes #3718

# Why was this change made? 🤔
H2 gets confused when the cocina has files with duplicate filenames.


# How was this change tested? 🤨
Unit
⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



