### PR TITLE
Dedupe access contacts when mapping to cocina.

### DIFF
--- a/app/services/cocina_generator/description/generator.rb
+++ b/app/services/cocina_generator/description/generator.rb
@@ -95,7 +95,7 @@ module CocinaGenerator
       def access_contacts
         return if work_version.contact_emails.empty?
 
-        work_version.contact_emails.map do |email|
+        work_version.contact_emails.uniq(&:email).map do |email|
           {
             value: email.email,
             type: 'email',


### PR DESCRIPTION
# Why was this change made? 🤔
H3 doesn't allow dupes, so this will help with roundtripping.


# How was this change tested? 🤨
Unit

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



