### PR TITLE
Remove publisher from publication events.

### DIFF
--- a/app/services/cocina_generator/description/contributors_generator.rb
+++ b/app/services/cocina_generator/description/contributors_generator.rb
@@ -4,14 +4,9 @@ module CocinaGenerator
   module Description
     # generates Cocina::Models::Contributors to be used by DescriptionGenerator
     # (ultimately in a Cocina::Models::RequestDRO)
-    # rubocop:disable Metrics/ClassLength
     class ContributorsGenerator
       def self.generate(work_version:)
         new(work_version:).generate
-      end
-
-      def self.events_from_publisher_contributors(work_version:, pub_date: nil)
-        new(work_version:).publication_event_values(pub_date)
       end
 
       def initialize(work_version:)
@@ -31,18 +26,6 @@ module CocinaGenerator
         end
       end
 
-      def publication_event_values(pub_date)
-        (work_version.authors + work_version.contributors).select { |c| c.role == 'Publisher' }.map do |publisher|
-          event = {
-            type: 'publication',
-            contributor: [publication_contributor(publisher)]
-          }
-          event[:date] = pub_date.date if pub_date
-
-          Cocina::Models::Event.new(event)
-        end
-      end
-
       private
 
       attr_reader :work_version
@@ -57,15 +40,6 @@ module CocinaGenerator
         }.compact
 
         contrib_hash[:status] = 'primary' if primary
-        Cocina::Models::Contributor.new(contrib_hash)
-      end
-
-      def publication_contributor(contributor)
-        contrib_hash = {
-          name: name_descriptive_value(contributor),
-          role: [marcrelator_role(contributor.role)],
-          type: contributor_type(contributor)
-        }
         Cocina::Models::Contributor.new(contrib_hash)
       end
 
@@ -204,7 +178,6 @@ module CocinaGenerator
           Cocina::Models::DescriptiveValue.new(type: 'ORCID', value:, source: { uri: source })
         ]
       end
-      # rubocop:enable Metrics/ClassLength
     end
   end
 end

--- a/app/services/cocina_generator/description/events_generator.rb
+++ b/app/services/cocina_generator/description/events_generator.rb
@@ -13,19 +13,12 @@ module CocinaGenerator
       end
 
       def generate
-        events = deposit_events + Array(created_date_event)
-        events += publisher_events.presence || Array(published_date_event)
-        events
+        deposit_events + Array(created_date_event) + Array(published_date_event)
       end
 
       private
 
       attr_reader :work_version
-
-      def publisher_events
-        @publisher_events ||= ContributorsGenerator.events_from_publisher_contributors(work_version:,
-                                                                                       pub_date: published_date_event)
-      end
 
       def published_date_event
         event_for_date(date: work_version.published_edtf, event_type: 'publication', date_type: 'publication',

--- a/spec/services/cocina_generator/description/contributors_generator_spec.rb
+++ b/spec/services/cocina_generator/description/contributors_generator_spec.rb
@@ -43,122 +43,6 @@ RSpec.describe CocinaGenerator::Description::ContributorsGenerator do
     ]
   end
 
-  describe '.events_from_publisher_contributors' do
-    context 'with no pub_date' do
-      context 'with no publisher' do
-        let(:contributor) { build(:person_contributor) }
-        let(:work_version) { build(:work_version, contributors: [contributor]) }
-        let(:cocina_model) { described_class.events_from_publisher_contributors(work_version:) }
-
-        it 'returns empty Array' do
-          expect(cocina_model).to eq []
-        end
-      end
-
-      context 'with multiple publishers' do
-        let(:org_contrib1) { build(:org_contributor, role: 'Publisher') }
-        let(:org_contrib2) { build(:org_contributor, role: 'Publisher') }
-        let(:work_version) { build(:work_version, contributors: [org_contrib1, org_contrib2]) }
-        let(:cocina_model) { described_class.events_from_publisher_contributors(work_version:) }
-
-        it 'returns Array of populated cocina model events, one for each publisher' do
-          expect(cocina_props).to eq(
-            [
-              Cocina::Models::Event.new({
-                                          type: 'publication',
-                                          contributor: [
-                                            {
-                                              name: [{ value: org_contrib1.full_name }],
-                                              role: publisher_roles,
-                                              type: 'organization'
-                                            }
-                                          ]
-                                        }).to_h,
-              Cocina::Models::Event.new({
-                                          type: 'publication',
-                                          contributor: [
-                                            {
-                                              name: [{ value: org_contrib2.full_name }],
-                                              role: publisher_roles,
-                                              type: 'organization'
-                                            }
-                                          ]
-                                        }).to_h
-            ]
-          )
-        end
-      end
-    end
-
-    context 'with a pub date' do
-      let(:pub_date_value) do
-        [
-          {
-            value: work_version.published_edtf,
-            encoding: { code: 'edtf' },
-            type: 'publication'
-          }
-        ]
-      end
-      let(:pub_date) do
-        Cocina::Models::Event.new(
-          type: 'publication',
-          date: pub_date_value
-        )
-      end
-
-      context 'with no publisher' do
-        let(:contributor) { build(:person_contributor) }
-        let(:work_version) { build(:work_version, contributors: [contributor]) }
-        let(:cocina_model) do
-          described_class.events_from_publisher_contributors(work_version:, pub_date:)
-        end
-
-        it 'returns empty Array' do
-          expect(cocina_model).to eq []
-        end
-      end
-
-      context 'with multiple publishers' do
-        let(:org_contrib1) { build(:org_contributor, role: 'Publisher') }
-        let(:org_contrib2) { build(:org_contributor, role: 'Publisher') }
-        let(:work_version) { build(:work_version, contributors: [org_contrib1, org_contrib2]) }
-        let(:cocina_model) do
-          described_class.events_from_publisher_contributors(work_version:, pub_date:)
-        end
-
-        it 'returns Array of populated cocina model events, one for each publisher' do
-          expect(cocina_props).to eq(
-            [
-              Cocina::Models::Event.new({
-                                          type: 'publication',
-                                          date: pub_date_value,
-                                          contributor: [
-                                            {
-                                              name: [{ value: org_contrib1.full_name }],
-                                              role: publisher_roles,
-                                              type: 'organization'
-                                            }
-                                          ]
-                                        }).to_h,
-              Cocina::Models::Event.new({
-                                          type: 'publication',
-                                          date: pub_date_value,
-                                          contributor: [
-                                            {
-                                              name: [{ value: org_contrib2.full_name }],
-                                              role: publisher_roles,
-                                              type: 'organization'
-                                            }
-                                          ]
-                                        }).to_h
-            ]
-          )
-        end
-      end
-    end
-  end
-
   context 'without marcrelator mapping' do
     let(:contributor) { build(:org_contributor, role: 'Conference') }
     let(:work_version) { build(:work_version, contributors: [contributor]) }
@@ -219,9 +103,7 @@ RSpec.describe CocinaGenerator::Description::ContributorsGenerator do
   describe 'h2 mapping specification examples' do
     let(:cocina_props) do
       {
-        contributor: cocina_model.map(&:to_h),
-        event: described_class.events_from_publisher_contributors(work_version:,
-                                                                  pub_date:).map(&:to_h)
+        contributor: cocina_model.map(&:to_h)
       }.compact_blank
     end
 
@@ -961,32 +843,6 @@ RSpec.describe CocinaGenerator::Description::ContributorsGenerator do
                                                   }
                                                 ]
                                               }).to_h
-            ],
-            event: [
-              Cocina::Models::Event.new({
-                                          type: 'publication',
-                                          contributor: [
-                                            {
-                                              name: [
-                                                {
-                                                  value: 'Stanford University Press'
-                                                }
-                                              ],
-                                              type: 'organization',
-                                              role: [
-                                                {
-                                                  value: 'publisher',
-                                                  code: 'pbl',
-                                                  uri: 'http://id.loc.gov/vocabulary/relators/pbl',
-                                                  source: {
-                                                    code: 'marcrelator',
-                                                    uri: 'http://id.loc.gov/vocabulary/relators/'
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          ]
-                                        }).to_h
             ]
           }
         )
@@ -1031,32 +887,6 @@ RSpec.describe CocinaGenerator::Description::ContributorsGenerator do
                                                   }
                                                 ]
                                               }).to_h
-            ],
-            event: [
-              Cocina::Models::Event.new({
-                                          type: 'publication',
-                                          contributor: [
-                                            {
-                                              name: [
-                                                {
-                                                  value: 'Stanford University Press'
-                                                }
-                                              ],
-                                              type: 'organization',
-                                              role: [
-                                                {
-                                                  value: 'publisher',
-                                                  code: 'pbl',
-                                                  uri: 'http://id.loc.gov/vocabulary/relators/pbl',
-                                                  source: {
-                                                    code: 'marcrelator',
-                                                    uri: 'http://id.loc.gov/vocabulary/relators/'
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          ]
-                                        }).to_h
             ]
           }
         )

--- a/spec/services/cocina_generator/description/events_generator_spec.rb
+++ b/spec/services/cocina_generator/description/events_generator_spec.rb
@@ -113,46 +113,12 @@ RSpec.describe CocinaGenerator::Description::EventsGenerator do
                                               deposit_publication_event,
                                               {
                                                 type: 'publication',
-                                                contributor: [
-                                                  {
-                                                    name: [{ value: contributor.full_name }],
-                                                    role: publisher_roles,
-                                                    type: 'organization'
-                                                  }
-                                                ],
                                                 date: [
                                                   {
                                                     encoding: { code: 'edtf' },
                                                     value: '2020-02-14',
                                                     type: 'publication',
                                                     status: 'primary'
-                                                  }
-                                                ]
-                                              }
-                                            ]))
-    end
-  end
-
-  # see https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_contributor.txt
-  #   example 13
-  #   Note:  no top level contributor -- publisher is under event
-  context 'when publisher entered by user, no publication date' do
-    let(:contributor) { build(:org_contributor, role: 'Publisher') }
-    let(:work_version) do
-      build(:work_version, :with_work, :with_contact_emails,
-            contributors: [contributor], title: 'Test title')
-    end
-
-    it 'creates event of type publication without date' do
-      expect(events).to eq(normalize_events([
-                                              deposit_publication_event,
-                                              {
-                                                type: 'publication',
-                                                contributor: [
-                                                  {
-                                                    name: [{ value: contributor.full_name }],
-                                                    role: publisher_roles,
-                                                    type: 'organization'
                                                   }
                                                 ]
                                               }
@@ -175,13 +141,6 @@ RSpec.describe CocinaGenerator::Description::EventsGenerator do
                                deposit_publication_event,
                                {
                                  type: 'publication',
-                                 contributor: [
-                                   {
-                                     name: [{ value: pub_contrib.full_name }],
-                                     role: publisher_roles,
-                                     type: 'organization'
-                                   }
-                                 ],
                                  date: [
                                    {
                                      encoding: { code: 'edtf' },


### PR DESCRIPTION
# Why was this change made? 🤔
Publishers are deprecated in H3. This helps with roundtripping.


# How was this change tested? 🤨
Unit

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



