### PR TITLE
Stop mapping deposit modification events.

### DIFF
--- a/app/services/cocina_generator/description/events_generator.rb
+++ b/app/services/cocina_generator/description/events_generator.rb
@@ -32,18 +32,12 @@ module CocinaGenerator
       def deposit_events
         return [] if deposit_versions.blank?
 
-        Array(deposit_publication_event) + deposit_modification_events
+        Array(deposit_publication_event)
       end
 
       def deposit_publication_event
         event_for_work_version(work_version: deposit_publication_version, event_type: 'deposit',
                                date_type: 'publication')
-      end
-
-      def deposit_modification_events
-        deposit_modification_versions.map do |deposit_version|
-          event_for_work_version(work_version: deposit_version, event_type: 'deposit', date_type: 'modification')
-        end
       end
 
       def deposit_versions
@@ -55,10 +49,6 @@ module CocinaGenerator
 
       def deposit_publication_version
         deposit_versions.first
-      end
-
-      def deposit_modification_versions
-        deposit_versions.slice(1..-1)
       end
 
       def event_for_date(date:, event_type:, date_type:, primary: false)

--- a/spec/services/cocina_generator/description/events_generator_spec.rb
+++ b/spec/services/cocina_generator/description/events_generator_spec.rb
@@ -73,26 +73,6 @@ RSpec.describe CocinaGenerator::Description::EventsGenerator do
                                                     encoding: { code: 'edtf' }
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                type: 'deposit',
-                                                date: [
-                                                  {
-                                                    type: 'modification',
-                                                    value: '2018-01-01',
-                                                    encoding: { code: 'edtf' }
-                                                  }
-                                                ]
-                                              },
-                                              {
-                                                type: 'deposit',
-                                                date: [
-                                                  {
-                                                    type: 'modification',
-                                                    value: '2019-01-01',
-                                                    encoding: { code: 'edtf' }
-                                                  }
-                                                ]
                                               }
                                             ]))
     end


### PR DESCRIPTION
refs https://github.com/sul-dlss/hungry-hungry-hippo/issues/533'

# Why was this change made? 🤔
These events are deprecated. Getting rid of them will simplify H3 migration.


# How was this change tested? 🤨
Unit

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



