### PR TITLE
Merge departments and Stanford degree granting institutions.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -53,6 +53,7 @@ external_links:
 # feature flags
 allow_sdr_content_changes: true
 user_versions_ui_enabled: false
+merge_stanford_and_organization: false
 
 authorization_group_header: HTTP_X_GROUPS
 first_name_header: HTTP_X_PERSON_NAME


### PR DESCRIPTION
refs https://github.com/sul-dlss/hungry-hungry-hippo/issues/1298

# Why was this change made? 🤔
Aligning departments / Stanford degree granting institutions with H3 will help with migration.


# How was this change tested? 🤨
Unit

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



