### PR TITLE
Only add unexpired embargoes.

### DIFF
--- a/app/services/cocina_generator/access_generator.rb
+++ b/app/services/cocina_generator/access_generator.rb
@@ -12,7 +12,7 @@ module CocinaGenerator
     end
 
     def generate
-      access = work_version.embargo_date ? embargoed_access : regular_access
+      access = embargo? ? embargoed_access : regular_access
 
       base_access.merge(access)
     end
@@ -20,6 +20,10 @@ module CocinaGenerator
     private
 
     attr_reader :work_version
+
+    def embargo?
+      work_version.embargo_date.present? && work_version.embargo_date > Time.zone.today
+    end
 
     def regular_access
       {

--- a/spec/services/cocina_generator/access_generator_spec.rb
+++ b/spec/services/cocina_generator/access_generator_spec.rb
@@ -51,6 +51,17 @@ RSpec.describe CocinaGenerator::AccessGenerator do
     end
   end
 
+  context 'when expired embargoed' do
+    let(:work_version) { build(:work_version, :expired_embargo, access: 'world') }
+
+    it 'generates the model' do
+      expect(model).to eq(view: 'world',
+                          download: 'world',
+                          license: license_uri,
+                          useAndReproductionStatement: Settings.access.use_and_reproduction_statement)
+    end
+  end
+
   context 'when embargoed for stanford release' do
     let(:work_version) { build(:work_version, :embargoed, access: 'stanford') }
 


### PR DESCRIPTION
closes #3741

# Why was this change made? 🤔
Expired embargoes shouldn't be in the cocina. This will cause problems for migration roundtripping.


# How was this change tested? 🤨
Unit

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



