### PR TITLE
Set correct file access when embargo is expired.

### DIFF
--- a/app/models/work_version.rb
+++ b/app/models/work_version.rb
@@ -219,6 +219,10 @@ class WorkVersion < ApplicationRecord
     user_version != previous_version&.user_version
   end
 
+  def embargoed?
+    embargo_date.present? && embargo_date > Time.zone.today
+  end
+
   private
 
   def locally_cached_file_for(blob)

--- a/app/services/cocina_generator/access_generator.rb
+++ b/app/services/cocina_generator/access_generator.rb
@@ -12,7 +12,7 @@ module CocinaGenerator
     end
 
     def generate
-      access = embargo? ? embargoed_access : regular_access
+      access = work_version.embargoed? ? embargoed_access : regular_access
 
       base_access.merge(access)
     end
@@ -20,10 +20,6 @@ module CocinaGenerator
     private
 
     attr_reader :work_version
-
-    def embargo?
-      work_version.embargo_date.present? && work_version.embargo_date > Time.zone.today
-    end
 
     def regular_access
       {

--- a/app/services/cocina_generator/structural/file_generator.rb
+++ b/app/services/cocina_generator/structural/file_generator.rb
@@ -91,12 +91,8 @@ module CocinaGenerator
         attached_file.hide?
       end
 
-      def embargoed?
-        work_version.embargo_date
-      end
-
       def access
-        if embargoed?
+        if work_version.embargoed?
           { view: 'dark', download: 'none' }
         else
           { view: work_version.access, download: work_version.access }

--- a/spec/services/cocina_generator/structural/file_generator_spec.rb
+++ b/spec/services/cocina_generator/structural/file_generator_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe CocinaGenerator::Structural::FileGenerator do
 
       it { is_expected.to eq Cocina::Models::FileAccess.new(view: 'dark', download: 'none') }
     end
+
+    context 'when embargo is expired' do
+      let(:work_version) { build(:work_version, :expired_embargo) }
+      let(:attached_file) { create(:attached_file, :with_file, work_version:, hide: true) }
+
+      it { is_expected.to eq Cocina::Models::FileAccess.new(view: 'world', download: 'world') }
+    end
   end
 
   describe '#initialize' do


### PR DESCRIPTION
refs #3741

# Why was this change made? 🤔
I missed that file access should also be correctly set when an embargo is expired.


# How was this change tested? 🤨
Unit

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



