### PR TITLE
Map uncited publisher to contributor.

### DIFF
--- a/app/services/cocina_generator/description/contributors_generator.rb
+++ b/app/services/cocina_generator/description/contributors_generator.rb
@@ -32,7 +32,7 @@ module CocinaGenerator
       attr_reader :work_version, :merge_stanford_and_organization
 
       def work_form_contributors
-        contributors = (work_version.authors + work_version.contributors.reject { |c| c.role == 'Publisher' })
+        contributors = (work_version.authors + work_version.contributors)
         return contributors unless merge_stanford_and_organization
 
         # If there are any departments, then remove Stanford degree granting institution contributors

--- a/spec/services/cocina_generator/description/contributors_generator_spec.rb
+++ b/spec/services/cocina_generator/description/contributors_generator_spec.rb
@@ -888,7 +888,33 @@ RSpec.describe CocinaGenerator::Description::ContributorsGenerator do
                                                     }
                                                   }
                                                 ]
+                                              }).to_h,
+              Cocina::Models::Contributor.new({
+                                                name: [
+                                                  {
+                                                    value: 'Stanford University Press'
+
+                                                  }
+                                                ],
+                                                type: 'organization', role: [
+                                                                        {
+                                                                          value: 'publisher',
+                                                                          code: 'pbl',
+                                                                          uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                                                                          source: {
+                                                                            code: 'marcrelator',
+                                                                            uri: 'http://id.loc.gov/vocabulary/relators/'
+                                                                          }
+                                                                        }
+                                                                      ],
+                                                note: [
+                                                  {
+                                                    value: 'false',
+                                                    type: 'citation status'
+                                                  }
+                                                ]
                                               }).to_h
+
             ]
           }
         )

--- a/spec/services/cocina_generator/description/generator_spec.rb
+++ b/spec/services/cocina_generator/description/generator_spec.rb
@@ -287,21 +287,6 @@ RSpec.describe CocinaGenerator::Description::Generator do
     end
   end
 
-  # see https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_contributor.txt
-  #   example 13
-  #   Note:  no top level contributor -- publisher is under event
-  context 'when publisher entered by user, no publication date' do
-    let(:contributor) { build(:org_contributor, role: 'Publisher') }
-    let(:work_version) do
-      build(:work_version, :with_work, :with_contact_emails,
-            contributors: [contributor], title: 'Test title')
-    end
-
-    it 'creates no top level contributor' do
-      expect(model[:contributor]).to be_empty
-    end
-  end
-
   context 'with blank abstract and citation' do
     let(:work_version) do
       build(:work_version, :with_work, abstract: '', citation: '')


### PR DESCRIPTION
# Why was this change made? 🤔
In recent changes to the mapping of publisher, uncited publishers were dropped from the mapping. This puts them back.


# How was this change tested? 🤨
Unit
⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



