### PR TITLE
Do not add citation status note when feature enabled.

### DIFF
--- a/app/services/cocina_generator/description/contributors_generator.rb
+++ b/app/services/cocina_generator/description/contributors_generator.rb
@@ -103,7 +103,7 @@ module CocinaGenerator
 
       def notes(contributor)
         notes = []
-        if contributor.type == 'Contributor'
+        if contributor.type == 'Contributor' && !Settings.no_citation_status_note
           notes << Cocina::Models::DescriptiveValue.new(type: 'citation status',
                                                         value: 'false')
         end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -55,6 +55,7 @@ allow_sdr_content_changes: true
 user_versions_ui_enabled: false
 merge_stanford_and_organization: false
 document_type: false
+no_citation_status_note: false
 
 authorization_group_header: HTTP_X_GROUPS
 first_name_header: HTTP_X_PERSON_NAME

--- a/spec/services/cocina_generator/description/contributors_generator_spec.rb
+++ b/spec/services/cocina_generator/description/contributors_generator_spec.rb
@@ -1222,4 +1222,30 @@ RSpec.describe CocinaGenerator::Description::ContributorsGenerator do
       end
     end
   end
+
+  context 'when no_citation_status_note is enabled' do
+    let(:contributor) { build(:org_contributor, role: 'Conference') }
+    let(:work_version) { build(:work_version, contributors: [contributor]) }
+
+    before do
+      allow(Settings).to receive(:no_citation_status_note).and_return(true)
+    end
+
+    it 'creates Cocina::Models::Contributor without citation status note' do
+      expect(cocina_props).to eq(
+        [
+          Cocina::Models::Contributor.new({
+                                            name: [{ value: contributor.full_name }],
+                                            type: 'conference',
+                                            status: 'primary',
+                                            role: [
+                                              {
+                                                value: 'conference'
+                                              }
+                                            ]
+                                          }).to_h
+        ]
+      )
+    end
+  end
 end


### PR DESCRIPTION
closes #3752

# Why was this change made? 🤔
Citation status note is being deprecated.


# How was this change tested? 🤨
Unit

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



