### PR TITLE
Ignore error when disallowing Globus writes.

### DIFF
--- a/app/jobs/deposit_job.rb
+++ b/app/jobs/deposit_job.rb
@@ -42,6 +42,8 @@ class DepositJob < BaseDepositJob
 
     # user_id nil because unneeded for permission update operations
     GlobusClient.disallow_writes(path: work_version.globus_endpoint, user_id: nil)
+  rescue GlobusClient::Errors::AccessRuleNotFound
+    true
   end
 
   def update_dro_with_file_identifiers(request_dro, work_version)

--- a/spec/jobs/deposit_job_spec.rb
+++ b/spec/jobs/deposit_job_spec.rb
@@ -354,6 +354,16 @@ RSpec.describe DepositJob do
       described_class.perform_now(first_work_version)
       expect(GlobusClient).to have_received(:disallow_writes).with(path: 'userid/workid/version1', user_id: nil)
     end
+
+    context 'when access rule is not found' do
+      before do
+        allow(GlobusClient).to receive(:disallow_writes).and_raise(GlobusClient::Errors::AccessRuleNotFound)
+      end
+
+      it 'ignores the error' do
+        expect { described_class.perform_now(first_work_version) }.not_to raise_error
+      end
+    end
   end
 
   context 'when the deposit request is not successful' do


### PR DESCRIPTION
closes #3769

# Why was this change made? 🤔
To allow re-depositing without errors.


# How was this change tested? 🤨
Unit

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration test create_object_h2_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



